### PR TITLE
chore: ignore logs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ bin/
 obj/
 
 # logs and temp
+logs/
 *.log
 *.tmp
 *.bak


### PR DESCRIPTION
Update `.gitignore` to ignore `logs` folder.