### PR TITLE
refactor: rebase issue branches onto base instead of merging

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ The dev/review/decompose roles are picked independently via `DEV_AGENT` / `REVIE
 
 New unlabeled issues route through a `decomposing` stage that asks the decomposer agent for a structured manifest: `decision=single` flips the issue to `ready` and the implementer takes over; `decision=split` creates child issues, persists the dep graph, and parks the parent on `blocked` (or `umbrella` when the manifest's `umbrella` flag is true — a parent with no implementation of its own that `_handle_umbrella` closes to `done` once every child resolves) until the matching handler walks the children. Decomposition can be disabled with `DECOMPOSE=off`, which reverts to the legacy direct-to-`implementing` pickup.
 
-Once the reviewer approves and the PR is mergeable with green CI, the orchestrator can merge it itself (gated by `AUTO_MERGE`, default off) and close the issue with `done`; an approved-but-unmergeable PR detours through a `resolving_conflict` stage that auto-merges `origin/<base>` (capped by `MAX_CONFLICT_ROUNDS`) before bouncing back to `validating`; PRs closed without merge land on `rejected`.
+Once the reviewer approves and the PR is mergeable with green CI, the orchestrator can merge it itself (gated by `AUTO_MERGE`, default off) and close the issue with `done`; an approved-but-unmergeable PR detours through a `resolving_conflict` stage that rebases onto `origin/<base>` (capped by `MAX_CONFLICT_ROUNDS`) before bouncing back to `validating`; PRs closed without merge land on `rejected`.
 
 ## Design constraints
 
@@ -102,7 +102,7 @@ deliberately avoid them.
 
 An issue should have at most one workflow label at a time. Non-workflow labels such as `bug` or `enhancement` are preserved; orchestrator label writes only swap labels from its own workflow set. Label names are part of the public contract because live GitHub issues carry them, so renaming or repurposing one is a migration.
 
-The orchestrator also creates the non-workflow control label `hold_base_sync`; while present on an issue, it pauses per-tick base sync, `in_review` auto-merge/unmergeable handling, and `resolving_conflict` base merges until the label is removed.
+The orchestrator also creates the non-workflow control label `hold_base_sync`; while present on an issue, it pauses per-tick base sync, `in_review` auto-merge/unmergeable handling, and `resolving_conflict` base rebases until the label is removed.
 
 A second control label `backlog` is created for postponed work. While present on an issue, every per-tick handler skips it before the workflow label is even read, so the orchestrator does not pick up, decompose, or otherwise advance the issue. Removing the label hands control back to the state machine on the next tick — typically applied at issue creation to queue work that should sit until a human is ready.
 
@@ -116,7 +116,7 @@ A second control label `backlog` is created for postponed work. While present on
 | `implementing` | The dev agent is producing commits in a per-issue worktree. |
 | `validating` | The reviewer agent is checking the diff and may bounce fixes back to the dev agent. |
 | `in_review` | A PR is open and ready for human review or auto-merge gates. |
-| `resolving_conflict` | The orchestrator is trying to merge `origin/<base>` into an approved but unmergeable PR branch. |
+| `resolving_conflict` | The orchestrator is trying to rebase an approved but unmergeable PR branch onto `origin/<base>`. |
 | `done` | Terminal success; the PR merged, or an umbrella parent resolved after all children reached `done`. |
 | `rejected` | Terminal rejection; the PR or issue was closed without merge. |
 
@@ -152,22 +152,22 @@ Inside `workflow.tick(gh, spec)`, before any issue is dispatched the tick runs `
 
 Two paths depending on whether a PR already exists for the issue:
 
-- **Pre-PR worktrees** (no `pr_number` in pinned state) get a clean-tree `git merge --no-edit origin/<base>` directly — there is no remote to push to, so a local-only merge commit is the right outcome.
-- **PR-having worktrees** in `validating` / `in_review` are detoured to `resolving_conflict` instead (via `_route_pr_worktree_to_resolving_conflict`: post a PR notice, seed `conflict_round` only when absent, flip the label) so the existing `_handle_resolving_conflict` handler does merge + push + relabel-to-validating in one consistent flow.
+- **Pre-PR worktrees** (no `pr_number` in pinned state) get a clean-tree `git rebase origin/<base>` directly — there is no remote to push to, so the local branch can be kept linear without publishing a rewrite.
+- **PR-having worktrees** in `validating` / `in_review` are detoured to `resolving_conflict` instead (via `_route_pr_worktree_to_resolving_conflict`: post a PR notice, seed `conflict_round` only when absent, flip the label) so the existing `_handle_resolving_conflict` handler does rebase + force-with-lease push + relabel-to-validating in one consistent flow.
 
 Applying `hold_base_sync` to an issue skips both paths for that issue; removing the label lets the next tick perform the accumulated base sync once.
 
-A local-only merge commit on a pushed branch would otherwise diverge local HEAD from `pr.head.sha` and break the validating reviewer (it reads local HEAD, so it would snapshot `agent_approved_sha` to a SHA that isn't on the PR), `_squash_and_force_push`'s `--force-with-lease=<original_head>` (the lease compares against the un-merged remote tip), and AUTO_MERGE's `agent_approved_sha == pr.head.sha` gate. The detour works under `AUTO_MERGE=off` too — `_handle_resolving_conflict` never reads AUTO_MERGE, it just does merge + push + relabel.
+A local-only rebase on a pushed branch would otherwise diverge local HEAD from `pr.head.sha` and break the validating reviewer (it reads local HEAD, so it would snapshot `agent_approved_sha` to a SHA that isn't on the PR), `_squash_and_force_push`'s `--force-with-lease=<original_head>` (the lease compares against the un-rebased remote tip), and AUTO_MERGE's `agent_approved_sha == pr.head.sha` gate. The detour works under `AUTO_MERGE=off` too — `_handle_resolving_conflict` never reads AUTO_MERGE, it just does rebase + push + relabel.
 
 The detour deliberately does NOT call `_bump_in_review_watermarks` (the `_handle_in_review` analog runs that AFTER scanning new comments — running it here, before any handler scans, would silently mark unread human "do not merge" / fix-request comments as consumed and AUTO_MERGE could land the PR over them). The orchestrator's own PR notice is filtered out via `orchestrator_comment_ids` on the next in_review scan, so leaving the watermark alone is safe.
 
-The detour also skips when `awaiting_human=True` because `_handle_resolving_conflict`'s awaiting-human branch returns early without merging unless a new human comment arrived; relabeling here would just hide the existing park behind a `resolving_conflict` label without progress, including the documented `AUTO_MERGE=off` unmergeable-park case.
+The detour also skips when `awaiting_human=True` because `_handle_resolving_conflict`'s awaiting-human branch returns early without rebasing unless a new human comment arrived; relabeling here would just hide the existing park behind a `resolving_conflict` label without progress, including the documented `AUTO_MERGE=off` unmergeable-park case.
 
 Before relabeling, the detour fetches `gh.get_pr(pr_number)` and skips when `pr_state != "open"`: a just-merged PR advances `origin/<base>`, so the still-validating / still-in_review worktree pointed at the now-stale branch is naturally behind base; without this gate the refresh would post an "auto-resolution" notice and relabel to `resolving_conflict` on a PR the next handler call would finalize to `done` (or `rejected` for a closed-without-merge PR).
 
 A `gh.get_pr` failure is treated as "leave alone" so the handler retries from a stable label rather than racing a half-known PR state. Issues already labeled `resolving_conflict` are also skipped (the handler runs this tick anyway).
 
-Merge over rebase across both paths matches `_handle_resolving_conflict`'s standing contract: rebase rewrites every commit's SHA, which would invalidate `agent_approved_sha` and force the reviewer to re-approve even when only the base content changed. Dirty worktrees (in-flight agent edits, crash-recovered trees) are skipped, and on a pre-PR content conflict the merge is aborted so the worktree stays on its pre-merge SHA. Failures are logged and swallowed; keeping every issue moving matters more than perfect base sync.
+Rebase is used across both paths to keep issue branches linear after sibling PRs land. Dirty worktrees (in-flight agent edits, crash-recovered trees) are skipped, and on a pre-PR content conflict the rebase is aborted so the worktree stays on its pre-rebase SHA. For PR branches, every pushed rebase resets `review_round`, so the reviewer must approve the rewritten head before auto-merge can proceed. Failures are logged and swallowed; keeping every issue moving matters more than perfect base sync.
 
 Then `gh.list_pollable_issues()` yields all open non-PR issues plus closed non-PR issues still labeled `in_review` or `resolving_conflict`. The closed-`in_review`/`resolving_conflict` sweep is what makes the manual-merge path land cleanly: a human-merged PR with a `Resolves #N` footer auto-closes issue N before the orchestrator can flip the label, and without the sweep `_handle_in_review` / `_handle_resolving_conflict` would never run on it.
 
@@ -437,7 +437,7 @@ The hash is re-persisted on every reaction so a single edit triggers exactly one
      - **Approval check** — either `agent_approved_sha == pr.head.sha` (snapshotted by validating when the reviewer agent emitted `VERDICT: APPROVED`), OR `gh.pr_is_approved(pr, head_sha=pr.head.sha)` — only counts human/bot reviews submitted on the *current* head SHA, so a stale APPROVED from before a later push does not unlock auto-merge.
      - **`pr_is_mergeable`** — `None` means GitHub still computing, try next tick.
 
-       `False` with `AUTO_MERGE=on` does NOT park anymore — it routes the issue to the new `resolving_conflict` stage (post a notice on the PR, seed `conflict_round=0` only when absent so a re-entry preserves the cap counter, flip the label, return), where `_handle_resolving_conflict` attempts the auto-merge of `origin/<base>` on the next tick. Under `AUTO_MERGE=off` the legacy unmergeable park still fires here.
+       `False` with `AUTO_MERGE=on` does NOT park anymore — it routes the issue to the new `resolving_conflict` stage (post a notice on the PR, seed `conflict_round=0` only when absent so a re-entry preserves the cap counter, flip the label, return), where `_handle_resolving_conflict` attempts the base rebase on the next tick. Under `AUTO_MERGE=off` the legacy unmergeable park still fires here.
      - **`pr_combined_check_state`** — `success` proceeds; `pending` waits; `failure`/`none` parks awaiting human — `none` means no checks at all, ambiguous.
 
      Under `AUTO_MERGE=off` the gate sequence above is skipped entirely. Instead, once the PR is mergeable the handler posts a one-shot `:bell:` ping mentioning every `HITL_HANDLE` so the human knows the PR is ready for review/merge. The ping is de-duplicated by `ready_ping_sha` (the head SHA we pinged for) — a long-lived ready PR doesn't spam handles on every poll, but a new commit shifts `pr.head.sha` and triggers a fresh ping. The ping is NOT a park: `awaiting_human` stays false so subsequent ticks still react to new PR comments, an external merge, or a later unmergeable transition.
@@ -472,7 +472,7 @@ The "back to validating on a new PR comment" arc is intentional: validating is t
   3. If the issue itself was closed manually while the PR is still open, treat as a hard human stop: flip to `rejected` rather than continuing to spawn the dev agent. Deliberately do NOT clean up the branch here — the PR is still open and may be useful for inspection or salvage.
 
      Same caveat as the in_review counterpart: once the label flips to `rejected` the closed-issue sweep no longer surfaces this issue, so a subsequent PR close is not observed and the operator must clean up the worktree, local branch, and remote branch by hand. Cleanup fires automatically only when the PR is closed *before* the orchestrator flips the label to `rejected`.
-  4. **Awaiting-human resume path**: when parked from a previous round and a new human comment has arrived since `last_action_comment_id`, resume the dev session on the in-progress merge worktree with the human's text (mirrors `_handle_implementing`'s awaiting-human branch — the park messages explicitly invite that flow). The post-agent step uses the same `_post_conflict_resolution_result` helper as the fresh-merge path.
+  4. **Awaiting-human resume path**: when parked from a previous round and a new human comment has arrived since `last_action_comment_id`, resume the dev session on the in-progress rebase worktree with the human's text (mirrors `_handle_implementing`'s awaiting-human branch — the park messages explicitly invite that flow). The post-agent step uses the same `_post_conflict_resolution_result` helper as the fresh-rebase path.
   5. **Cap check**: if `conflict_round >= MAX_CONFLICT_ROUNDS`, park awaiting human with the round count and the cap quoted. To escape the park the human must either:
      - (a) relabel the issue back to `validating` (or any other workflow label) so the dispatcher leaves `_handle_resolving_conflict` entirely; or
      - (b) post a new issue comment, which the awaiting-human resume branch (item 4) picks up to drive another dev-agent round.
@@ -484,24 +484,27 @@ The "back to validating on a new PR comment" arc is intentional: validating is t
      - `behind > 0` (worktree diverged) → park: force-pushing local state would clobber the real PR head.
      - `ahead > 0` (recovered unpushed commits from a previous tick that crashed before `_push_branch` returned) → run the same dirty-tree check `_on_dirty_worktree` uses, then push the recovered work and flip to `validating` with `review_round=0`, `conflict_round += 1`.
      - `(0, 0)` (in sync) → fall through.
-  9. Refresh `origin/<base>` over the same hardened path, then run `git merge --no-edit origin/<base>` in the worktree under `_git_hardened` (drops global/system git config and disables hooks/fsmonitor/credential helpers — the agent owns the worktree and could otherwise plant a hook to execute attacker code mid-merge).
-  10. **Clean merge succeeded**: dirty-tree check first (a leftover edit from a crashed prior tick must not silently survive into validating).
+  9. Refresh `origin/<base>` over the same hardened path, then run `git rebase origin/<base>` in the worktree under `_git_hardened` (drops global/system git config, disables hooks/fsmonitor/credential helpers/commit signing, and disables rebase autostash — the agent owns the worktree and could otherwise plant a hook to execute attacker code mid-rebase).
+  10. **Clean rebase succeeded**: dirty-tree check first (a leftover edit from a crashed prior tick must not silently survive into validating).
 
-      If the HEAD SHA did not move (already up-to-date — `git merge` returned success without applying anything), skip the push and flip to `validating` with `review_round=0`, `conflict_round += 1`; counting the no-op against the cap surfaces a perpetually-unmergeable-due-to-branch-protection PR within `MAX_CONFLICT_ROUNDS` ticks instead of letting it ping-pong between handlers forever.
+      If the HEAD SHA did not move (already up-to-date — `git rebase` returned success without applying anything), skip the push and flip to `validating` with `review_round=0`, `conflict_round += 1`; counting the no-op against the cap surfaces a perpetually-unmergeable-due-to-branch-protection PR within `MAX_CONFLICT_ROUNDS` ticks instead of letting it ping-pong between handlers forever.
 
-      If HEAD moved (whether by fast-forward or by a real merge commit), push and flip to `validating` (same state writes).
-  11. **Conflicted merge**: build a conflict-resolution prompt via `_build_conflict_resolution_prompt` (lists up to 20 conflicted paths, instructs the agent to commit the merge and not push), resume the dev session on the locked spec (backend + args) with that prompt, then run `_post_conflict_resolution_result`.
+      If HEAD moved, force-with-lease push the rebased branch, clear any stale `agent_approved_sha`, and flip to `validating` (same state writes).
+  11. **Conflicted rebase**: build a conflict-resolution prompt via `_build_conflict_resolution_prompt` (lists up to 20 conflicted paths, instructs the agent to resolve and continue the rebase, and not push), resume the dev session on the locked spec (backend + args) with that prompt, then run `_post_conflict_resolution_result`.
   12. `_post_conflict_resolution_result` is the shared post-agent funnel:
       - timeout → park (HITL);
+      - unfinished rebase → park;
       - no new commit → `_on_question` park;
       - dirty tree → `_on_dirty_worktree` park;
       - push fail → park;
-      - success → push, set `last_conflict_resolved_at`, increment `conflict_round`, reset `review_round=0`, flip back to `validating`.
+      - success → force-with-lease push, clear any stale `agent_approved_sha`, set `last_conflict_resolved_at`, increment `conflict_round`, reset `review_round=0`, flip back to `validating`.
+
+      Fresh conflicted-rebase pushes pin the lease to the pre-rebase PR head captured after the branch/head equality gate. Awaiting-human resume pushes deliberately use `_push_branch`'s live `ls-remote` lease fallback, because the local `before_sha` may be an intermediate rebase or recovered commit SHA rather than the remote PR head.
 
       The counter increments only on the success path so a timeout/dirty/push-fail does not eat a slot from the cap.
 - **Output**: label moved to `validating` (clean push or up-to-date base) OR `done`/`rejected` (terminal arcs) OR a HITL park (cap exhausted, dirty worktree, push fail, agent timeout, agent silence, fetch fail, diverged worktree, missing pr_number).
 
-Merge over rebase by design: rebase rewrites every commit's SHA, which would invalidate the stored `agent_approved_sha` snapshot and force the reviewer agent to re-approve the entire branch even when only the base content changed. A merge commit costs one extra entry in `git log` and keeps approvals stable.
+The rebase path deliberately rewrites the PR branch to keep history linear after other issue PRs land. Every pushed rebase resets `review_round`, so the reviewer agent must re-approve the rewritten head before AUTO_MERGE can pass.
 
 ## Agent command specs
 
@@ -579,7 +582,7 @@ Extras whose value is `None` are dropped, so callers can pass optional context (
 | `pr_opened` | `_on_commits` after `gh.open_pr` succeeds | `pr_number`, `branch`, `sha`, `retry_count` |
 | `pr_merged` | `_handle_in_review` and `_handle_resolving_conflict` terminal arcs (external merge OR successful `gh.merge_pr` under AUTO_MERGE) | `pr_number`, `sha`, `merge_method` (`external` / `squash`), `check_state`, `review_round`, `conflict_round`, `retry_count` |
 | `pr_closed_without_merge` | `_handle_in_review` and `_handle_resolving_conflict` when the PR is closed without merge | `pr_number`, `sha`, `review_round`, `conflict_round`, `retry_count` |
-| `merge_attempt` | AUTO_MERGE `gh.merge_pr` call AND every `git merge origin/<base>` inside `_handle_resolving_conflict` | `method` (`squash` / `base_merge`), `result` (`success` / `failed` / `conflict`), `pr_number`, `sha`, `conflict_round`, `review_round`, `retry_count` |
+| `merge_attempt` | AUTO_MERGE `gh.merge_pr` call AND every `git rebase origin/<base>` inside `_handle_resolving_conflict` | `method` (`squash` / `base_rebase`), `result` (`success` / `failed` / `conflict`), `pr_number`, `sha`, `conflict_round`, `review_round`, `retry_count` |
 | `conflict_round` | `_route_pr_worktree_to_resolving_conflict` and the in_review unmergeable arc emit `action="entered"`; every increment site (`_emit_conflict_round_incremented`) emits `action="incremented"` with `outcome` | `pr_number`, `conflict_round`, `review_round`, `retry_count`, `outcome` (for increments), `sha` |
 
 **`agent_spawn` / `agent_exit` extras.** On top of the shared fields above:
@@ -604,14 +607,14 @@ If the two disagree — a write failed and was logged-and-swallowed, the file wa
 |---|---|---|---|
 | `main` polling loop | long-lived Python process | manual start (or wrapper) | every `POLL_INTERVAL`s |
 | `workflow.tick(gh, spec)` | function call | each loop iteration | once per tick **per configured `RepoSpec`**, fanned out across a `ThreadPoolExecutor` (one worker thread per repo) when N>1; single-repo legacy mode collapses to N=1 and stays in-thread |
-| `_refresh_base_and_worktrees(gh, spec)` | function call | start of each `workflow.tick` | once per tick per repo: one `git fetch <spec.remote_name> <spec.base_branch>` (remote defaults to `origin`, overridable per `REPOS` entry), then per-worktree dispatch (pre-PR worktrees merge directly; PR-having worktrees behind base detour to `resolving_conflict`). See [Per-tick flow](#per-tick-flow-workflowtick) for the full open-PR / `awaiting_human` / watermark / conflict / dirty-tree rules. |
+| `_refresh_base_and_worktrees(gh, spec)` | function call | start of each `workflow.tick` | once per tick per repo: one `git fetch <spec.remote_name> <spec.base_branch>` (remote defaults to `origin`, overridable per `REPOS` entry), then per-worktree dispatch (pre-PR worktrees rebase directly; PR-having worktrees behind base detour to `resolving_conflict`). See [Per-tick flow](#per-tick-flow-workflowtick) for the full open-PR / `awaiting_human` / watermark / conflict / dirty-tree rules. |
 | `_handle_*` per issue | function call | issue's workflow label | once per tick per open issue (within its repo's `tick`); concurrent up to `spec.parallel_limit` per repo and `MAX_PARALLEL_ISSUES_GLOBAL` across all repos (single shared `BoundedSemaphore`) |
 | decomposer agent (`DECOMPOSE_AGENT`) | subprocess (fresh or resumed, locked spec (backend + args)) | `_handle_decomposing` (retry budget OK) or HITL resume | one shot per tick when needed |
 | implementer agent (`DEV_AGENT`) | subprocess | `_handle_implementing` (no commits yet, retry budget OK) or HITL resume | one shot per tick when needed |
 | reviewer agent (`REVIEW_AGENT`) | subprocess (fresh session) | `_handle_validating`, round < max | one shot per tick |
 | dev-fix agent | subprocess (resumed dev session, locked spec (backend + args)) | reviewer says CHANGES_REQUESTED | one shot per tick |
-| `_handle_resolving_conflict` | function call | issue label `resolving_conflict` (set by `_handle_in_review` when an approved PR is unmergeable under `AUTO_MERGE=on`); also fires on closed-`resolving_conflict` issues from the polling sweep | once per tick per such issue (drives PR-state terminals → `done`/`rejected`, ahead-of-remote recovery push, `git merge origin/<base>` then clean-merge no-op flip / clean-merge push / dev-conflict resume / cap-park, plus all park branches) |
-| dev-conflict agent | subprocess (resumed dev session, locked spec (backend + args)) | `_handle_resolving_conflict` and `git merge origin/<base>` left conflicts | one shot per tick |
+| `_handle_resolving_conflict` | function call | issue label `resolving_conflict` (set by `_handle_in_review` when an approved PR is unmergeable under `AUTO_MERGE=on`); also fires on closed-`resolving_conflict` issues from the polling sweep | once per tick per such issue (drives PR-state terminals → `done`/`rejected`, ahead-of-remote recovery push, `git rebase origin/<base>` then clean-rebase no-op flip / clean-rebase push / dev-conflict resume / cap-park, plus all park branches) |
+| dev-conflict agent | subprocess (resumed dev session, locked spec (backend + args)) | `_handle_resolving_conflict` and `git rebase origin/<base>` left conflicts | one shot per tick |
 | `git push` | subprocess | after dev produces clean commits | per fix |
 | self-restart check | git fetch + diff | start of each tick | every tick |
 
@@ -747,12 +750,12 @@ If the two disagree — a write failed and was logged-and-swallowed, the file wa
    │                       ├─ recovered ahead-of-remote commits      │    │
    │                       │   ─► push, ++conflict_round,            │    │
    │                       │      label=validating                   │    │
-   │                       ├─ git merge origin/<base>:               │    │
+   │                       ├─ git rebase origin/<base>:              │    │
    │                       │     already up-to-date (HEAD unchanged) │    │
    │                       │       ─► flip to validating,            │    │
    │                       │         ++conflict_round (no push)      │    │
-   │                       │     HEAD moved (fast-forward or merge   │    │
-   │                       │       commit) ─► push,                  │    │
+   │                       │     HEAD moved (rebased commits)        │    │
+   │                       │       ─► push,                          │    │
    │                       │       label=validating, ++conflict_round│    │
    │                       │     conflicts ─► resume dev (locked) ───┘    │
    │                       │       push resolved commit,                  │
@@ -803,7 +806,7 @@ If the two disagree — a write failed and was logged-and-swallowed, the file wa
 | **stages/implementing.py** | `_handle_implementing` + developer-session lifecycle |
 | **stages/validating.py** | `_handle_validating` + reviewer-session lifecycle |
 | **stages/in_review.py** | `_handle_in_review` + PR-watermark / auto-merge primitives |
-| **stages/conflicts.py** | `_handle_resolving_conflict` + merge-loop primitives |
+| **stages/conflicts.py** | `_handle_resolving_conflict` + rebase-loop primitives |
 | **agents.py** | dispatch + spawn codex/claude subprocess, capture session id + last message |
 | **github.py** | issues, comments, labels, pinned state, PR open/comment |
 | **config.py** | env + token loading (token kept outside REPO_ROOT), backend validation |
@@ -831,7 +834,7 @@ If the two disagree — a write failed and was logged-and-swallowed, the file wa
                                                  │   unmergeable past approval  │
                                                  │   gates)─► resolving_conflict│
                                                  │  resolving_conflict --(clean │
-                                                 │   merge / pushed resolution) │
+                                                 │   rebase / pushed resolution)│
                                                  │   ─► validating              │
                                                  │  resolving_conflict --(round │
                                                  │   >= MAX_CONFLICT_ROUNDS)    │
@@ -871,8 +874,8 @@ If the two disagree — a write failed and was logged-and-swallowed, the file wa
                                                 done by hand)
 
    resolving_conflict (AUTO_MERGE only, capped by MAX_CONFLICT_ROUNDS):
-     git merge origin/<base> clean ─► label=validating (++conflict_round)
-     conflicts ─► dev resumes, commits merge, push ─► label=validating
+     git rebase origin/<base> clean ─► label=validating (++conflict_round)
+     conflicts ─► dev resumes, continues rebase, push ─► label=validating
      conflict_round >= MAX_CONFLICT_ROUNDS ─► park awaiting human
      pr merged/closed mid-stage ─► done / rejected (terminal)
 

--- a/orchestrator/stages/conflicts.py
+++ b/orchestrator/stages/conflicts.py
@@ -1,6 +1,6 @@
 # Copyright 2026 Geser Dugarov
 # SPDX-License-Identifier: Apache-2.0
-"""Resolving-conflict stage handler and its merge-loop primitives.
+"""Resolving-conflict stage handler and its rebase-loop primitives.
 
 Owns `_handle_resolving_conflict` plus the conflict-loop-private helpers:
 the shared post-agent disposition funnel (`_post_conflict_resolution_result`)
@@ -50,7 +50,7 @@ def _emit_conflict_round_incremented(
     """Record a `conflict_round` audit event when the counter ticks.
 
     Centralizes the bookkeeping so every increment site -- ahead-of-remote
-    push recovery, up-to-date no-op flip, clean base-merge push, agent-
+    push recovery, up-to-date no-op flip, clean base-rebase push, agent-
     resolved conflict push, drift-pushed bounce -- emits the same shape.
     `outcome` distinguishes the increment cause so a tail of the JSONL sink
     can attribute rounds without re-reading the surrounding code.
@@ -74,9 +74,9 @@ def _handle_resolving_conflict(
 ) -> None:
     """Drive an unmergeable PR back to mergeable.
 
-    Merge `origin/<base>` into the per-issue branch. On a clean merge,
+    Rebase the per-issue branch onto `origin/<base>`. On a clean rebase,
     push and flip back to `validating` so the reviewer agent re-runs on
-    the merged head; if the base hasn't moved (branch already
+    the rebased head; if the base hasn't moved (branch already
     up-to-date) skip the push and just flip the label. On real content
     conflicts, resume the dev session on the locked backend with a
     conflict-resolution prompt, then push the resolved commit. Cap loops
@@ -84,11 +84,9 @@ def _handle_resolving_conflict(
     agent timeout / dirty tree / push failure, park awaiting human and
     let the operator unstick.
 
-    Merge over rebase: simpler (one commit either way) and less
-    destructive. Rebase rewrites every commit's SHA, which would
-    invalidate any stored `agent_approved_sha` in surprising ways and
-    force the reviewer to re-approve the entire branch even when only
-    the base content changed.
+    Rebasing rewrites commit SHAs, so every pushed rebase resets
+    `review_round`; validation must re-approve the rebased branch before
+    any merge gate can pass.
     """
     from .. import workflow as _wf
 
@@ -189,7 +187,7 @@ def _handle_resolving_conflict(
 
     if issue_has_label(issue, BASE_SYNC_HOLD_LABEL):
         _wf.log.info(
-            "issue=#%d has %r; pausing resolving_conflict base merge",
+            "issue=#%d has %r; pausing resolving_conflict base rebase",
             issue.number, BASE_SYNC_HOLD_LABEL,
         )
         return
@@ -200,7 +198,7 @@ def _handle_resolving_conflict(
     # On a successful pushed fix we bounce to `validating` so the
     # reviewer re-runs on the updated branch; on an ack (no commit but a
     # reply) we stay in `resolving_conflict` without parking so a
-    # harmless clarification doesn't stall the merge.
+    # harmless clarification doesn't stall the rebase.
     new_hash = _wf._detect_user_content_change(gh, issue, state)
     if new_hash is not None:
         state.set("user_content_hash", new_hash)
@@ -244,7 +242,7 @@ def _handle_resolving_conflict(
     conflict_round = int(state.get("conflict_round") or 0)
 
     # Resume-on-human-reply: when parked awaiting human and a new
-    # comment arrived, resume the dev session on the in-progress merge
+    # comment arrived, resume the dev session on the in-progress rebase
     # worktree with the human's text. Mirrors `_handle_implementing`'s
     # awaiting-human path so a `_on_question` / `_on_dirty_worktree`
     # park can be unstuck by a comment (the park messages explicitly
@@ -268,6 +266,9 @@ def _handle_resolving_conflict(
         before_sha = _wf._head_sha(wt)
         wt, result = _wf._resume_dev_with_text(gh, spec, issue, state, followup)
         state.set("last_agent_action_at", _wf._now_iso())
+        # No explicit lease here: resume worktrees may be mid-rebase or
+        # ahead of the remote PR head, so `before_sha` is not necessarily
+        # the remote SHA. Let `_push_branch` lease against live ls-remote.
         _post_conflict_resolution_result(
             gh, spec, issue, state, wt, result, before_sha, conflict_round,
         )
@@ -320,19 +321,19 @@ def _handle_resolving_conflict(
 
     # Check the worktree against the freshly-fetched remote PR head.
     # Three outcomes:
-    #   * `(0, 0)`: in sync -- proceed to the base-merge below.
+    #   * `(0, 0)`: in sync -- proceed to the base rebase below.
     #   * `(>0, 0)`: HEAD has unpushed commits ahead of the remote PR
     #     head. This is the crash-recovery case: a previous tick committed
     #     a conflict resolution but crashed before `_push_branch` returned
     #     (or before the post-push state write landed). Without this
-    #     branch the next tick's `git merge` would be a no-op (HEAD
+    #     branch the next tick's `git rebase` would be a no-op (HEAD
     #     already contains origin/<base>) and we would flip to validating
     #     with the dev's resolution still unpushed -- letting the reviewer
     #     vote on a SHA that is not on the PR. Mirrors the implementing
     #     handler's `_has_new_commits` recovery shortcut.
     #   * Anything with `behind > 0`: stale or diverged worktree. Force-
     #     pushing the local state would clobber the real PR head, and
-    #     merging origin/<base> into a stale branch then force-pushing
+    #     rebasing a stale branch onto origin/<base> then force-pushing
     #     would silently revert anything that landed on `origin/<branch>`
     #     out-of-band. Refuse and park.
     ahead, behind = _wf._branch_ahead_behind(spec, wt, branch)
@@ -341,7 +342,7 @@ def _handle_resolving_conflict(
             gh, issue, state,
             f"{config.HITL_MENTIONS} worktree on `{branch}` is {ahead} "
             f"ahead and {behind} behind `{spec.remote_name}/{branch}` "
-            f"(PR head `{pr.head.sha[:8]}`); refusing to merge a stale "
+            f"(PR head `{pr.head.sha[:8]}`); refusing to rebase a stale "
             "or diverged branch -- force-pushing the local state would "
             "clobber the real PR head. Manual intervention needed.",
             reason="diverged_branch",
@@ -370,7 +371,7 @@ def _handle_resolving_conflict(
             return
         _wf.log.info(
             "issue=#%d resolving_conflict: pushing %d recovered commit(s) "
-            "ahead of %s/%s before attempting base merge",
+            "ahead of %s/%s before attempting base rebase",
             issue.number, ahead, spec.remote_name, branch,
         )
         if not _wf._push_branch(spec, wt, branch):
@@ -383,6 +384,7 @@ def _handle_resolving_conflict(
             gh.write_pinned_state(issue, state)
             return
         state.set("review_round", 0)
+        state.set("agent_approved_sha", None)
         state.set("conflict_round", conflict_round + 1)
         state.set("last_conflict_resolved_at", _wf._now_iso())
         _emit_conflict_round_incremented(
@@ -397,7 +399,7 @@ def _handle_resolving_conflict(
         return
 
     # In sync. Refresh `<remote>/<base>` so the upcoming
-    # `git merge <remote>/<base>` sees the current base tip.
+    # `git rebase <remote>/<base>` sees the current base tip.
     fetch_base = _wf._authed_fetch(
         spec,
         f"+refs/heads/{spec.base_branch}:"
@@ -420,14 +422,14 @@ def _handle_resolving_conflict(
         return
 
     before_sha = _wf._head_sha(wt)
-    succeeded, conflicted_files = _wf._merge_base_into_worktree(spec, wt)
+    succeeded, conflicted_files = _wf._rebase_base_into_worktree(spec, wt)
     gh.emit_event(
         "merge_attempt",
         issue_number=issue.number,
         stage="resolving_conflict",
         pr_number=int(pr_number),
         sha=before_sha or None,
-        method="base_merge",
+        method="base_rebase",
         result="success" if succeeded else (
             "conflict" if conflicted_files else "failed"
         ),
@@ -437,8 +439,8 @@ def _handle_resolving_conflict(
     )
 
     if succeeded:
-        # Dirty check before EITHER clean-merge exit (no-op flip OR
-        # merge-commit push): a pre-existing uncommitted edit (left by a
+        # Dirty check before EITHER clean-rebase exit (no-op flip OR
+        # rebased-head push): a pre-existing uncommitted edit (left by a
         # previous tick that crashed before its own dirty check ran)
         # would otherwise survive a no-op flip into validating, where
         # the reviewer agent reads the worktree directly. The reviewer
@@ -453,7 +455,7 @@ def _handle_resolving_conflict(
             _wf._park_awaiting_human(
                 gh, issue, state,
                 f"{config.HITL_MENTIONS} worktree has {len(dirty)} "
-                f"uncommitted change(s) after `git merge "
+                f"uncommitted change(s) after `git rebase "
                 f"{spec.remote_name}/{spec.base_branch}`; refusing to "
                 "push or hand back to validating with a dirty tree.",
                 reason="dirty_worktree",
@@ -468,7 +470,7 @@ def _handle_resolving_conflict(
             # Increment `conflict_round` even though no diff was applied:
             # if the PR is unmergeable purely due to branch protection /
             # required reviewers (PyGithub cannot distinguish those from a
-            # content conflict), the no-op merge would otherwise loop
+            # content conflict), the no-op rebase would otherwise loop
             # in_review <-> resolving_conflict forever with the cap never
             # firing. Counting the no-op against the cap surfaces the
             # situation to the operator within `MAX_CONFLICT_ROUNDS` ticks.
@@ -489,10 +491,13 @@ def _handle_resolving_conflict(
             gh.set_workflow_label(issue, "validating")
             gh.write_pinned_state(issue, state)
             return
-        if not _wf._push_branch(spec, wt, _wf._branch_name(issue.number)):
+        if not _wf._push_branch(
+            spec, wt, _wf._branch_name(issue.number),
+            force_with_lease=before_sha or None,
+        ):
             _wf._park_awaiting_human(
                 gh, issue, state,
-                f"{config.HITL_MENTIONS} git push failed after auto-merging "
+                f"{config.HITL_MENTIONS} git push failed after auto-rebasing "
                 f"`{spec.remote_name}/{spec.base_branch}`; "
                 "see orchestrator logs.",
                 reason="push_failed",
@@ -500,13 +505,14 @@ def _handle_resolving_conflict(
             gh.write_pinned_state(issue, state)
             return
         state.set("review_round", 0)
+        state.set("agent_approved_sha", None)
         state.set("conflict_round", conflict_round + 1)
         state.set("last_conflict_resolved_at", _wf._now_iso())
         _emit_conflict_round_incremented(
             gh, issue, state,
             pr_number=int(pr_number),
             new_round=conflict_round + 1,
-            outcome="base_merged_clean",
+            outcome="base_rebased_clean",
             sha=after_sha,
         )
         gh.set_workflow_label(issue, "validating")
@@ -517,10 +523,10 @@ def _handle_resolving_conflict(
         _wf._park_awaiting_human(
             gh, issue, state,
             f"{config.HITL_MENTIONS} "
-            f"`git merge {spec.remote_name}/{spec.base_branch}` "
+            f"`git rebase {spec.remote_name}/{spec.base_branch}` "
             "failed without listing conflicted files; manual intervention "
             "needed.",
-            reason="merge_failed_no_files",
+            reason="rebase_failed_no_files",
         )
         gh.write_pinned_state(issue, state)
         return
@@ -532,6 +538,7 @@ def _handle_resolving_conflict(
     state.set("last_agent_action_at", _wf._now_iso())
     _post_conflict_resolution_result(
         gh, spec, issue, state, wt, result, before_sha, conflict_round,
+        force_with_lease=before_sha or None,
     )
 
 
@@ -544,6 +551,8 @@ def _post_conflict_resolution_result(
     result: AgentResult,
     before_sha: str,
     conflict_round: int,
+    *,
+    force_with_lease: Optional[str] = None,
 ) -> None:
     """Common post-agent handling for both fresh conflict resolution
     and the awaiting-human resume path in `_handle_resolving_conflict`.
@@ -560,7 +569,7 @@ def _post_conflict_resolution_result(
     if result.timed_out:
         _wf._park_awaiting_human(
             gh, issue, state,
-            f"{config.HITL_MENTIONS} dev agent timed out resolving merge "
+            f"{config.HITL_MENTIONS} dev agent timed out resolving rebase "
             f"conflicts after {config.AGENT_TIMEOUT}s; manual intervention "
             "needed.",
             reason="agent_timeout",
@@ -568,9 +577,24 @@ def _post_conflict_resolution_result(
         gh.write_pinned_state(issue, state)
         return
 
+    if _wf._rebase_in_progress(wt):
+        raw = result.last_message.strip()
+        quoted = ""
+        if raw:
+            quoted = "\n\nAgent output:\n\n> " + raw.replace("\n", "\n> ")
+        _wf._park_awaiting_human(
+            gh, issue, state,
+            f"{config.HITL_MENTIONS} rebase is still in progress after the "
+            "dev agent returned; finish it manually or comment with "
+            f"guidance to resume.{quoted}",
+            reason="rebase_in_progress",
+        )
+        gh.write_pinned_state(issue, state)
+        return
+
     after_sha = _wf._head_sha(wt)
     if not after_sha or after_sha == before_sha:
-        # Agent did not produce a merge commit. Treat as a question /
+        # Agent did not finish the rebase. Treat as a question /
         # silence park, mirroring the implementing handler.
         _wf._on_question(gh, issue, state, result)
         gh.write_pinned_state(issue, state)
@@ -582,7 +606,12 @@ def _post_conflict_resolution_result(
         gh.write_pinned_state(issue, state)
         return
 
-    if not _wf._push_branch(spec, wt, _wf._branch_name(issue.number)):
+    branch = _wf._branch_name(issue.number)
+    pushed = _wf._push_branch(
+        spec, wt, branch,
+        force_with_lease=force_with_lease,
+    )
+    if not pushed:
         _wf._park_awaiting_human(
             gh, issue, state,
             f"{config.HITL_MENTIONS} git push failed after conflict "
@@ -593,6 +622,7 @@ def _post_conflict_resolution_result(
         return
 
     state.set("review_round", 0)
+    state.set("agent_approved_sha", None)
     state.set("conflict_round", conflict_round + 1)
     state.set("last_conflict_resolved_at", _wf._now_iso())
     pr_number = state.get("pr_number")

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -100,12 +100,16 @@ from .worktrees import _git_hardened as _git_hardened
 from .worktrees import _has_new_commits as _has_new_commits
 from .worktrees import _head_sha as _head_sha
 from .worktrees import _is_conventional_subject as _is_conventional_subject
+# TODO(remove after 2026-08-24): remove this compatibility re-export with
+# worktrees._merge_base_into_worktree.
 from .worktrees import _merge_base_into_worktree as _merge_base_into_worktree
+from .worktrees import _rebase_base_into_worktree as _rebase_base_into_worktree
 from .worktrees import (
     _pr_title_from_commit_or_issue as _pr_title_from_commit_or_issue,
 )
 from .worktrees import _push_branch as _push_branch
 from .worktrees import _refresh_base_and_worktrees as _refresh_base_and_worktrees
+from .worktrees import _rebase_in_progress as _rebase_in_progress
 from .worktrees import _sanitize_slug as _sanitize_slug
 from .worktrees import _squash_and_force_push as _squash_and_force_push
 from .worktrees import _sync_worktree_with_base as _sync_worktree_with_base

--- a/orchestrator/workflow_messages.py
+++ b/orchestrator/workflow_messages.py
@@ -588,18 +588,21 @@ def _build_conflict_resolution_prompt(
     if len(files) > len(shown):
         files_md += f"\n- ... ({len(files) - len(shown)} more)"
     return (
-        f"`git merge {base_ref}` left {len(files)} conflicted "
-        "file(s) in your worktree. Resolve each conflict and COMMIT the "
-        "merge in your current worktree. Do NOT push -- the orchestrator "
+        f"`git rebase {base_ref}` left {len(files)} conflicted "
+        "file(s) in your worktree. Resolve each conflict and complete the "
+        "rebase in your current worktree. Do NOT push -- the orchestrator "
         "pushes and re-runs the reviewer.\n\n"
         f"Conflicted paths:\n\n{files_md}\n\n"
         "Workflow: edit each file to a coherent resolution, `git add` it, "
-        "then commit (`git commit --no-edit` accepts the default merge "
-        "commit message). Use `git status` to inspect the in-progress "
-        "merge.\n\n"
+        "then run `git rebase --continue`. Repeat until the rebase completes. "
+        "If Git reports an empty commit because the change is already present, "
+        "use `git rebase --skip`; use `git commit --allow-empty` only when "
+        "an empty commit is intentional. Use `git rebase --abort` only as "
+        "the escape hatch when you cannot make progress. "
+        "Use `git status` to inspect the in-progress rebase.\n\n"
         "If you genuinely cannot resolve a conflict, end your final "
         "message with a question for the human and leave the worktree "
-        "mid-merge; the orchestrator will park the issue for human review."
+        "mid-rebase; the orchestrator will park the issue for human review."
     )
 
 

--- a/orchestrator/worktrees.py
+++ b/orchestrator/worktrees.py
@@ -318,7 +318,7 @@ def _branch_ahead_behind(
     calling so the comparison is against the current remote tip.
     Returns `(0, 0)` on git error so a transient failure does not
     silently re-route the workflow; the caller's subsequent steps
-    (the merge attempt, the push) surface the underlying problem.
+    (the rebase attempt, the push) surface the underlying problem.
     """
     r = _git_hardened(
         "rev-list", "--left-right", "--count",
@@ -880,28 +880,30 @@ def _squash_and_force_push(
 def _git_hardened(*args: str, cwd: Path) -> subprocess.CompletedProcess:
     """`_git` plus the agent-hostile-environment hardening from `_push_branch`.
 
-    Used for `git merge` inside a worktree the agent can write to: a
+    Used for local git operations inside a worktree the agent can write to: a
     planted `core.hooksPath`, `core.fsmonitor`, or url rewrite rule in
     the worktree's `.git/config` (or in `~/.gitconfig`) would otherwise
-    execute attacker code mid-merge or redirect a transient fetch to an
+    execute attacker code mid-operation or redirect a transient fetch to an
     attacker-controlled host. Drops global/system git config so url
     `insteadOf` rewrites and host-wide hooks cannot apply, and disables
-    repo-local hooks / fsmonitor / credential helpers via `-c` overrides.
-    No askpass is wired in -- this helper is for local-only operations
-    (merge); push remains the only call site that handles GIT_TOKEN.
+    repo-local hooks / fsmonitor / credential helpers / commit signing via
+    `-c` overrides. No askpass is wired in -- this helper is for local-only
+    operations (rebase, diff, rev-parse); push remains the only call site
+    that handles GIT_TOKEN.
 
     Injects `GIT_AUTHOR_*` / `GIT_COMMITTER_*` env vars (matching the
-    agent spawn's `_agent_env`) so a `git merge --no-edit` that needs
-    to create a merge commit doesn't fail with "Committer identity
-    unknown" -- stripping global config also strips any `user.name` /
-    `user.email` set there, and env vars take precedence over config
-    so the orchestrator's identity stamps the merge commit cleanly.
+    agent spawn's `_agent_env`) so a `git rebase` that needs to replay
+    commits doesn't fail with "Committer identity unknown" -- stripping
+    global config also strips any `user.name` / `user.email` set there,
+    and env vars take precedence over config.
     """
     git_prefix = [
         "git",
         "-c", "core.hooksPath=/dev/null",
         "-c", "credential.helper=",
         "-c", "core.fsmonitor=",
+        "-c", "commit.gpgsign=false",
+        "-c", "rebase.autoStash=false",
     ]
     env = {
         **os.environ,
@@ -923,16 +925,16 @@ def _git_hardened(*args: str, cwd: Path) -> subprocess.CompletedProcess:
     )
 
 
-def _merge_base_into_worktree(
+def _rebase_base_into_worktree(
     spec: RepoSpec, worktree: Path
 ) -> Tuple[bool, list[str]]:
-    """Run `git merge --no-edit origin/<base>` in the worktree.
+    """Run `git rebase origin/<base>` in the worktree.
 
     Returns `(succeeded, conflicted_files)`. On success, `conflicted_files`
-    is empty -- whether the merge fast-forwarded (no commit) or produced a
-    merge commit is the caller's job to detect via the HEAD-SHA delta.
-    On failure, the conflicted-file list is the unmerged paths from
-    `git diff --name-only --diff-filter=U`; an empty list means the merge
+    is empty -- whether the rebase was a no-op or replayed commits is the
+    caller's job to detect via the HEAD-SHA delta. On failure, the
+    conflicted-file list is the unmerged paths from
+    `git diff --name-only --diff-filter=U`; an empty list means the rebase
     failed for a non-conflict reason (hooks, permissions, etc.) and the
     caller should park rather than ask the agent to resolve nothing.
 
@@ -942,7 +944,7 @@ def _merge_base_into_worktree(
     code under the orchestrator's UID at diff time.
     """
     r = _git_hardened(
-        "merge", "--no-edit",
+        "rebase",
         f"{spec.remote_name}/{spec.base_branch}", cwd=worktree,
     )
     if r.returncode == 0:
@@ -955,6 +957,34 @@ def _merge_base_into_worktree(
         if line.strip()
     ]
     return False, files
+
+
+def _merge_base_into_worktree(
+    spec: RepoSpec, worktree: Path
+) -> Tuple[bool, list[str]]:
+    """Compatibility alias for older patches/imports.
+
+    TODO(remove after 2026-08-24): drop once out-of-repo patches have moved
+    to `_rebase_base_into_worktree`.
+    """
+    return _rebase_base_into_worktree(spec, worktree)
+
+
+def _rebase_in_progress(worktree: Path) -> bool:
+    """Return True when the worktree still has an unfinished rebase."""
+    for state_dir in ("rebase-merge", "rebase-apply"):
+        r = _git_hardened("rev-parse", "--git-path", state_dir, cwd=worktree)
+        if r.returncode != 0:
+            continue
+        path = (r.stdout or "").strip()
+        if not path:
+            continue
+        state_path = Path(path)
+        if not state_path.is_absolute():
+            state_path = worktree / state_path
+        if state_path.exists():
+            return True
+    return False
 
 
 def _authed_fetch(
@@ -1175,36 +1205,33 @@ def _refresh_base_and_worktrees(gh: GitHubClient, spec: RepoSpec) -> None:
 
     Two paths depending on whether a PR already exists for the issue:
 
-    * **Pre-PR worktrees** (no `pr_number` in pinned state): merge
-      `origin/<base>` directly into the local worktree -- no remote yet,
-      so a local-only merge commit is the right outcome and there is
-      nothing to push.
+    * **Pre-PR worktrees** (no `pr_number` in pinned state): rebase
+      the local worktree onto `origin/<base>` -- no remote yet, so there
+      is nothing to push.
 
-    * **PR-having worktrees** (validating / in_review): merging locally
+    * **PR-having worktrees** (validating / in_review): rebasing locally
       WITHOUT pushing would diverge local HEAD from `pr.head.sha` and
       break the validating reviewer (it reads local HEAD, so it would
       snapshot `agent_approved_sha` to a SHA that isn't on the PR),
       `_squash_and_force_push`'s `--force-with-lease=<original_head>`
-      (the lease compares against the un-merged remote tip), and
+      (the lease compares against the un-rebased remote tip), and
       AUTO_MERGE's `agent_approved_sha == pr.head.sha` gate. So instead
       we route the issue to `resolving_conflict`: the existing handler
-      does the merge, pushes, and flips back to `validating` so the
-      reviewer re-runs on the merged head. Applying the `hold_base_sync`
-      label to an issue pauses both the pre-PR local merge and the PR
+      does the rebase, pushes, and flips back to `validating` so the
+      reviewer re-runs on the rebased head. Applying the `hold_base_sync`
+      label to an issue pauses both the pre-PR local rebase and the PR
       detour until the label is removed. This works under
       `AUTO_MERGE=off` too -- `_handle_resolving_conflict` never reads
-      AUTO_MERGE, it just does the merge+push+relabel cycle. Issues
+      AUTO_MERGE, it just does the rebase+push+relabel cycle. Issues
       already labeled `resolving_conflict` are left alone (the handler
       runs this tick anyway); other labels are skipped (no PR worktree
       to refresh in those states).
 
-    Merge over rebase is the codebase's standing contract (see
-    `_handle_resolving_conflict`'s docstring): rebase rewrites every
-    commit's SHA, which would invalidate any stored `agent_approved_sha`
-    in surprising ways and force the reviewer to re-approve the entire
-    branch even when only the base content changed.
+    Rebase keeps the PR history linear after sibling PRs land. The handler
+    resets `review_round` on every pushed rebase, so the reviewer re-runs
+    against the rewritten SHA before any merge gate can pass.
 
-    Conflicts on the pre-PR path abort the merge so the worktree stays
+    Conflicts on the pre-PR path abort the rebase so the worktree stays
     on its original SHA -- conflict resolution still belongs to
     `_handle_resolving_conflict`. Dirty worktrees are skipped so a
     crash-recovered tree with uncommitted edits is never disturbed
@@ -1246,7 +1273,7 @@ def _refresh_base_and_worktrees(gh: GitHubClient, spec: RepoSpec) -> None:
 # in_review are the long-lived PR-stage labels: validating may run the
 # reviewer again, in_review is parked waiting for AUTO_MERGE / human merge.
 # `resolving_conflict` itself is excluded -- the handler runs this tick
-# regardless and will do the merge anyway. Other labels mean either no PR
+# regardless and will do the rebase anyway. Other labels mean either no PR
 # yet (pre-PR path applies instead) or terminal (done/rejected, nothing to
 # refresh).
 _PR_REFRESH_DETOUR_LABELS = frozenset({"validating", "in_review"})
@@ -1257,13 +1284,13 @@ def _sync_worktree_with_base(
 ) -> None:
     """Bring a single per-issue worktree up to date with `origin/<base>`.
 
-    Pre-PR: merge `origin/<base>` directly. PR-having + behind base +
+    Pre-PR: rebase onto `origin/<base>` directly. PR-having + behind base +
     label in {validating, in_review}: detour the issue to
-    `resolving_conflict` so the existing handler does merge + push +
+    `resolving_conflict` so the existing handler does rebase + push +
     relabel-to-validating in one consistent flow. Skips a dirty worktree
-    or a worktree already up to date (no pre-PR merge attempted, no PR
-    detour fired). On a pre-PR content conflict, aborts the merge so the
-    worktree stays on its pre-merge SHA -- conflict resolution lives in
+    or a worktree already up to date (no pre-PR rebase attempted, no PR
+    detour fired). On a pre-PR content conflict, aborts the rebase so the
+    worktree stays on its pre-rebase SHA -- conflict resolution lives in
     `_handle_resolving_conflict`, not here.
     """
     try:
@@ -1275,7 +1302,7 @@ def _sync_worktree_with_base(
         return
     if issue_has_label(issue, BACKLOG_LABEL):
         # Match the dispatcher's hard-skip: `backlog` means "the orchestrator
-        # should not touch this issue at all", so refresh must not merge
+        # should not touch this issue at all", so refresh must not rebase
         # base, post a PR comment, or detour the issue to
         # `resolving_conflict` before `_process_issue` would have skipped it.
         log.debug(
@@ -1322,29 +1349,29 @@ def _sync_worktree_with_base(
         )
         return
 
-    succeeded, conflicted = _merge_base_into_worktree(spec, worktree)
+    succeeded, conflicted = _rebase_base_into_worktree(spec, worktree)
     if succeeded:
         log.info(
-            "issue=#%d merged %s into worktree (was %d commit(s) behind)",
+            "issue=#%d rebased worktree onto %s (was %d commit(s) behind)",
             issue_number, base_ref, behind,
         )
         return
 
-    abort = _git_hardened("merge", "--abort", cwd=worktree)
+    abort = _git_hardened("rebase", "--abort", cwd=worktree)
     if abort.returncode != 0:
         log.warning(
-            "issue=#%d base merge failed and abort failed: %s",
+            "issue=#%d base rebase failed and abort failed: %s",
             issue_number, (abort.stderr or "").strip(),
         )
     if conflicted:
         log.info(
-            "issue=#%d base merge has %d conflict(s); aborted -- "
+            "issue=#%d base rebase has %d conflict(s); aborted -- "
             "resolving_conflict will handle it once a PR exists",
             issue_number, len(conflicted),
         )
     else:
         log.warning(
-            "issue=#%d base merge failed without conflicted files; aborted",
+            "issue=#%d base rebase failed without conflicted files; aborted",
             issue_number,
         )
 
@@ -1361,10 +1388,10 @@ def _route_pr_worktree_to_resolving_conflict(
 
     Mirrors `_handle_in_review`'s unmergeable detour, just driven by a
     base advance instead of a PyGithub `mergeable=False`. The handler
-    then runs `git merge origin/<base>` in the worktree, pushes, and
-    relabels to `validating` so the reviewer re-runs on the merged head
+    then runs `git rebase origin/<base>` in the worktree, pushes, and
+    relabels to `validating` so the reviewer re-runs on the rebased head
     -- the only safe pattern for PR-having worktrees, since a local-only
-    merge commit would diverge local HEAD from `pr.head.sha` and break
+    rebase would diverge local HEAD from `pr.head.sha` and break
     every downstream gate that compares the two. Works under both
     AUTO_MERGE on (replaces the unmergeable trigger) and AUTO_MERGE off
     (the only auto-rebase path under that mode -- `_handle_in_review`'s
@@ -1375,10 +1402,10 @@ def _route_pr_worktree_to_resolving_conflict(
     * The label is not one this refresh knows how to drive into
       `resolving_conflict` (only `validating` / `in_review`); the
       `resolving_conflict` label itself is also skipped because the
-      handler runs this tick anyway and will do the merge regardless.
+      handler runs this tick anyway and will do the rebase regardless.
 
     * `awaiting_human=True`. `_handle_resolving_conflict`'s awaiting-human
-      branch returns early without merging unless a new human comment
+      branch returns early without rebasing unless a new human comment
       arrived; relabeling here would just hide the existing park behind a
       `resolving_conflict` label without making any progress, including
       the documented `AUTO_MERGE=off` unmergeable park path. The park
@@ -1390,7 +1417,7 @@ def _route_pr_worktree_to_resolving_conflict(
       intervention after repeated failures.
 
     * The issue has `hold_base_sync`, which is an explicit operator hold for
-      series work where base should be merged once after prerequisite PRs
+      series work where base should be integrated once after prerequisite PRs
       land, not after every intermediate base advance.
 
     * The PR is no longer open. A merged PR advances `origin/<base>`, so
@@ -1464,7 +1491,7 @@ def _route_pr_worktree_to_resolving_conflict(
 
     log.info(
         "issue=#%d behind %s/%s by %d commit(s); routing %r -> "
-        "resolving_conflict so the handler can merge, push, and re-review",
+        "resolving_conflict so the handler can rebase, push, and re-review",
         issue.number, spec.remote_name, spec.base_branch, behind, label,
     )
 
@@ -1479,7 +1506,7 @@ def _route_pr_worktree_to_resolving_conflict(
             gh, pr_number, state,
             f":mag: PR is {behind} commit(s) behind "
             f"`{spec.remote_name}/{spec.base_branch}`; "
-            "orchestrator is attempting auto-resolution by merging it into "
+            "orchestrator is attempting auto-resolution by rebasing "
             "the branch (label: `resolving_conflict`).",
         )
     except Exception:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1670,15 +1670,15 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         self,
     ) -> None:
         # Regression for the validating/squash/AUTO_MERGE break: a local-only
-        # merge commit on a worktree whose branch has already been pushed
+        # base update on a worktree whose branch has already been pushed
         # diverges local HEAD from `pr.head.sha`. The reviewer would then
         # snapshot `agent_approved_sha` to a SHA that isn't on the PR (the
-        # local merge commit), `_squash_and_force_push`'s
+        # local updated HEAD), `_squash_and_force_push`'s
         # `--force-with-lease=<original_head>` would reject (the remote is
         # still at the un-merged tip), and AUTO_MERGE's
         # `agent_approved_sha == pr.head.sha` check would never pass.
         # The fix is to detour the issue to `resolving_conflict` so the
-        # existing handler does merge + push + relabel-to-validating in one
+        # existing handler does rebase + push + relabel-to-validating in one
         # consistent flow.
         from unittest.mock import MagicMock
         self.gh.add_issue(make_issue(7, label="in_review"))
@@ -1688,10 +1688,10 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         # Behind base by 3 commits.
         git_mock = MagicMock(return_value=self._git_result(stdout="3\n"))
         with patch.object(worktrees, "_worktree_dirty_files", return_value=[]), \
-             patch.object(worktrees, "_merge_base_into_worktree", merge), \
+             patch.object(worktrees, "_rebase_base_into_worktree", merge), \
              patch.object(worktrees, "_git", git_mock):
             workflow._sync_worktree_with_base(self.gh, self.spec, self.wt, 7)
-        # Local merge MUST NOT have happened on the PR worktree.
+        # Local base update MUST NOT have happened on the PR worktree.
         merge.assert_not_called()
         # Label flipped to resolving_conflict.
         self.assertIn((7, "resolving_conflict"), self.gh.label_history)
@@ -1727,7 +1727,7 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         merge = MagicMock()
         git_mock = MagicMock(return_value=self._git_result(stdout="3\n"))
         with patch.object(worktrees, "_worktree_dirty_files", return_value=[]), \
-             patch.object(worktrees, "_merge_base_into_worktree", merge), \
+             patch.object(worktrees, "_rebase_base_into_worktree", merge), \
              patch.object(worktrees, "_git", git_mock):
             workflow._sync_worktree_with_base(self.gh, self.spec, self.wt, 7)
 
@@ -1735,7 +1735,7 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         self.assertEqual(self.gh.label_history, [])
         self.assertEqual(self.gh.posted_pr_comments, [])
 
-    def test_hold_base_sync_label_skips_pre_pr_base_merge(self) -> None:
+    def test_hold_base_sync_label_skips_pre_pr_base_rebase(self) -> None:
         from unittest.mock import MagicMock
         issue = make_issue(7, label="implementing")
         issue.labels.append(FakeLabel(BASE_SYNC_HOLD_LABEL))
@@ -1743,7 +1743,7 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         merge = MagicMock()
         git_mock = MagicMock(return_value=self._git_result(stdout="3\n"))
         with patch.object(worktrees, "_worktree_dirty_files", return_value=[]), \
-             patch.object(worktrees, "_merge_base_into_worktree", merge), \
+             patch.object(worktrees, "_rebase_base_into_worktree", merge), \
              patch.object(worktrees, "_git", git_mock):
             workflow._sync_worktree_with_base(self.gh, self.spec, self.wt, 7)
 
@@ -1763,7 +1763,7 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         merge = MagicMock()
         git_mock = MagicMock(return_value=self._git_result(stdout="3\n"))
         with patch.object(worktrees, "_worktree_dirty_files", return_value=[]), \
-             patch.object(worktrees, "_merge_base_into_worktree", merge), \
+             patch.object(worktrees, "_rebase_base_into_worktree", merge), \
              patch.object(worktrees, "_git", git_mock):
             workflow._sync_worktree_with_base(self.gh, self.spec, self.wt, 7)
 
@@ -1771,7 +1771,7 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         self.assertEqual(self.gh.label_history, [])
         self.assertEqual(self.gh.posted_pr_comments, [])
 
-    def test_backlog_label_skips_pre_pr_base_merge(self) -> None:
+    def test_backlog_label_skips_pre_pr_base_rebase(self) -> None:
         from unittest.mock import MagicMock
         issue = make_issue(7, label="implementing")
         issue.labels.append(FakeLabel(BACKLOG_LABEL))
@@ -1779,7 +1779,7 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         merge = MagicMock()
         git_mock = MagicMock(return_value=self._git_result(stdout="3\n"))
         with patch.object(worktrees, "_worktree_dirty_files", return_value=[]), \
-             patch.object(worktrees, "_merge_base_into_worktree", merge), \
+             patch.object(worktrees, "_rebase_base_into_worktree", merge), \
              patch.object(worktrees, "_git", git_mock):
             workflow._sync_worktree_with_base(self.gh, self.spec, self.wt, 7)
 
@@ -1787,7 +1787,7 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         self.assertEqual(self.gh.label_history, [])
 
     def test_pr_having_resolving_conflict_label_does_not_re_route(self) -> None:
-        # The handler runs this tick anyway and will do the merge -- a
+        # The handler runs this tick anyway and will do the rebase -- a
         # second label flip is pointless and would re-post the PR notice.
         from unittest.mock import MagicMock
         self.gh.add_issue(make_issue(7, label="resolving_conflict"))
@@ -1946,7 +1946,7 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         merge = MagicMock()
         with patch.object(
             worktrees, "_worktree_dirty_files", return_value=["a.py"],
-        ), patch.object(worktrees, "_merge_base_into_worktree", merge):
+        ), patch.object(worktrees, "_rebase_base_into_worktree", merge):
             workflow._sync_worktree_with_base(self.gh, self.spec, self.wt, 7)
         merge.assert_not_called()
 
@@ -1957,7 +1957,7 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         with patch.object(
             worktrees, "_worktree_dirty_files", return_value=[],
         ), patch.object(worktrees, "_git", git_mock), \
-             patch.object(worktrees, "_merge_base_into_worktree", merge):
+             patch.object(worktrees, "_rebase_base_into_worktree", merge):
             workflow._sync_worktree_with_base(self.gh, self.spec, self.wt, 7)
         merge.assert_not_called()
 
@@ -1968,11 +1968,11 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         with patch.object(
             worktrees, "_worktree_dirty_files", return_value=[],
         ), patch.object(worktrees, "_git", git_mock), \
-             patch.object(worktrees, "_merge_base_into_worktree", merge):
+             patch.object(worktrees, "_rebase_base_into_worktree", merge):
             workflow._sync_worktree_with_base(self.gh, self.spec, self.wt, 7)
         merge.assert_not_called()
 
-    def test_clean_merge_when_behind(self) -> None:
+    def test_clean_rebase_when_behind(self) -> None:
         from unittest.mock import MagicMock
         merge = MagicMock(return_value=(True, []))
         git_mock = MagicMock(return_value=self._git_result(stdout="3\n"))
@@ -1980,13 +1980,13 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         with patch.object(
             worktrees, "_worktree_dirty_files", return_value=[],
         ), patch.object(worktrees, "_git", git_mock), \
-             patch.object(worktrees, "_merge_base_into_worktree", merge), \
+             patch.object(worktrees, "_rebase_base_into_worktree", merge), \
              patch.object(worktrees, "_git_hardened", hardened):
             workflow._sync_worktree_with_base(self.gh, self.spec, self.wt, 7)
         merge.assert_called_once()
         # No abort issued on success.
         self.assertFalse(
-            any(c.args[:1] == ("merge",) for c in hardened.call_args_list)
+            any(c.args[:1] == ("rebase",) for c in hardened.call_args_list)
         )
 
     def test_conflict_aborts_and_swallows(self) -> None:
@@ -1997,13 +1997,13 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         with patch.object(
             worktrees, "_worktree_dirty_files", return_value=[],
         ), patch.object(worktrees, "_git", git_mock), \
-             patch.object(worktrees, "_merge_base_into_worktree", merge), \
+             patch.object(worktrees, "_rebase_base_into_worktree", merge), \
              patch.object(worktrees, "_git_hardened", hardened):
             workflow._sync_worktree_with_base(self.gh, self.spec, self.wt, 7)
         # Abort issued exactly once.
         abort_calls = [
             c for c in hardened.call_args_list
-            if c.args[:2] == ("merge", "--abort")
+            if c.args[:2] == ("rebase", "--abort")
         ]
         self.assertEqual(len(abort_calls), 1)
 
@@ -2012,7 +2012,7 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         # must not crash the refresh -- skip silently.
         from unittest.mock import MagicMock
         merge = MagicMock()
-        with patch.object(worktrees, "_merge_base_into_worktree", merge):
+        with patch.object(worktrees, "_rebase_base_into_worktree", merge):
             workflow._sync_worktree_with_base(self.gh, self.spec, self.wt, 9999)
         merge.assert_not_called()
 
@@ -2883,8 +2883,8 @@ class TickPerRepoParallelLimitTest(unittest.TestCase):
 class RefreshBaseAndWorktreesRealGitTest(unittest.TestCase):
     """Integration coverage for `_refresh_base_and_worktrees` against a real
     bare remote + per-issue worktree. Mirrors `SquashHelperRealGitTest`'s
-    setup so the helper's interaction with `git fetch` / `git merge` /
-    `git merge --abort` is exercised end-to-end.
+    setup so the helper's interaction with `git fetch` / `git rebase` /
+    `git rebase --abort` is exercised end-to-end.
     """
 
     def _git(self, *args: str, cwd: Path, env_extra: dict | None = None) -> str:
@@ -2942,7 +2942,7 @@ class RefreshBaseAndWorktreesRealGitTest(unittest.TestCase):
             base_branch="main",
         )
         # Default: per-issue worktree #7 is in `implementing` (no PR yet),
-        # so the refresh is allowed to merge base into it. Tests that want
+        # so the refresh is allowed to rebase it onto base. Tests that want
         # the PR-skip path call `_seed_pr_state(7)`.
         self.gh = FakeGitHubClient()
         self.gh.add_issue(make_issue(7, label="implementing"))
@@ -2984,7 +2984,7 @@ class RefreshBaseAndWorktreesRealGitTest(unittest.TestCase):
 
     def _advance_base(self, *, conflicting: bool) -> None:
         """Push a new commit to origin/main. When `conflicting=True`, the
-        commit edits `feature.py` so a base-merge into the per-issue branch
+        commit edits `feature.py` so a base rebase of the per-issue branch
         will conflict with the local feature commit.
         """
         self._git("checkout", "main", cwd=self.work)
@@ -3003,7 +3003,7 @@ class RefreshBaseAndWorktreesRealGitTest(unittest.TestCase):
     def _is_clean(self) -> bool:
         return self._git("status", "--porcelain", cwd=self.wt).strip() == ""
 
-    def test_clean_advance_merges_into_worktree(self) -> None:
+    def test_clean_advance_rebases_worktree(self) -> None:
         self._advance_base(conflicting=False)
         head_before = self._wt_head()
         with patch.object(
@@ -3014,6 +3014,10 @@ class RefreshBaseAndWorktreesRealGitTest(unittest.TestCase):
         self.assertNotEqual(head_before, head_after)
         # The base file landed in the worktree's tree.
         self.assertTrue((self.wt / "extra.txt").exists())
+        self.assertEqual(
+            self._git("log", "-1", "--format=%s", cwd=self.wt).strip(),
+            "feat: add feature",
+        )
         self.assertTrue(self._is_clean())
 
     def test_no_op_when_already_up_to_date(self) -> None:
@@ -3032,7 +3036,7 @@ class RefreshBaseAndWorktreesRealGitTest(unittest.TestCase):
             workflow.config, "WORKTREES_DIR", self.tmpdir / "worktrees",
         ):
             workflow._refresh_base_and_worktrees(self.gh, self.spec)
-        # HEAD did NOT move (merge aborted) and worktree is clean again --
+        # HEAD did NOT move (rebase aborted) and worktree is clean again --
         # the conflict surfaces later via the resolving_conflict stage.
         self.assertEqual(head_before, self._wt_head())
         self.assertTrue(self._is_clean())
@@ -3040,7 +3044,7 @@ class RefreshBaseAndWorktreesRealGitTest(unittest.TestCase):
     def test_dirty_worktree_skipped_without_disturbing_changes(self) -> None:
         self._advance_base(conflicting=False)
         # Plant an uncommitted edit in the worktree -- mirrors a mid-flight
-        # agent edit. The base merge must NOT run.
+        # agent edit. The base rebase must NOT run.
         (self.wt / "scratch.py").write_text("scratch\n")
         head_before = self._wt_head()
         with patch.object(
@@ -3054,13 +3058,13 @@ class RefreshBaseAndWorktreesRealGitTest(unittest.TestCase):
 
     def test_pr_open_worktree_is_not_merged_locally(self) -> None:
         # Regression: once a PR exists, the per-issue branch has been pushed
-        # and `pr.head.sha` equals local HEAD. A local-only base-merge would
+        # and `pr.head.sha` equals local HEAD. A local-only base rebase would
         # diverge them and break the validating reviewer (it reads local
         # HEAD), `_squash_and_force_push`'s lease check (it expects the
         # remote to equal `original_head` = local HEAD), and AUTO_MERGE's
         # `agent_approved_sha == pr.head.sha` gate. The refresh must NOT
-        # do a local merge here; instead it routes the issue to
-        # `resolving_conflict` so the existing handler does merge + push +
+        # do a local rebase here; instead it routes the issue to
+        # `resolving_conflict` so the existing handler does rebase + push +
         # relabel-to-validating in one consistent flow.
         # Replace the default `implementing` issue with one in `in_review`
         # plus the PR-having pinned state.
@@ -3073,7 +3077,7 @@ class RefreshBaseAndWorktreesRealGitTest(unittest.TestCase):
             workflow.config, "WORKTREES_DIR", self.tmpdir / "worktrees",
         ):
             workflow._refresh_base_and_worktrees(self.gh, self.spec)
-        # HEAD did NOT move: no local-only merge commit was created.
+        # HEAD did NOT move: no local-only rebase was performed.
         self.assertEqual(head_before, self._wt_head())
         # The base file did NOT land in the worktree (not yet -- it will
         # after `_handle_resolving_conflict` runs and pushes).

--- a/tests/test_workflow_conflicts.py
+++ b/tests/test_workflow_conflicts.py
@@ -33,7 +33,7 @@ class ResolvingConflictEventEmissionTest(
     unittest.TestCase, _PatchedWorkflowMixin
 ):
     """`_handle_resolving_conflict` emits `merge_attempt` for each base-
-    merge attempt, `conflict_round` whenever the counter ticks, and the
+    rebase attempt, `conflict_round` whenever the counter ticks, and the
     same `pr_merged` / `pr_closed_without_merge` terminals as in_review.
     """
 
@@ -80,7 +80,7 @@ class ResolvingConflictEventEmissionTest(
             return_value=(merge_succeeded, list(conflicted_files))
         )
         ok = MagicMock(returncode=0, stdout="", stderr="")
-        with patch.object(workflow, "_merge_base_into_worktree", merge_mock), \
+        with patch.object(workflow, "_rebase_base_into_worktree", merge_mock), \
              patch.object(workflow, "_git", MagicMock(return_value=ok)), \
              patch.object(workflow, "_git_hardened", MagicMock(return_value=ok)):
             return self._run(
@@ -92,7 +92,7 @@ class ResolvingConflictEventEmissionTest(
                 head_shas=head_shas,
             )
 
-    def test_merge_attempt_success_on_clean_base_merge(self) -> None:
+    def test_merge_attempt_success_on_clean_base_rebase(self) -> None:
         gh, issue, pr = self._seed()
         self._run_with_merge(
             gh, issue, merge_succeeded=True,
@@ -103,11 +103,11 @@ class ResolvingConflictEventEmissionTest(
         ev = attempts[0]
         self.assertEqual(ev["stage"], "resolving_conflict")
         self.assertEqual(ev["pr_number"], self.PR_NUMBER)
-        self.assertEqual(ev["method"], "base_merge")
+        self.assertEqual(ev["method"], "base_rebase")
         self.assertEqual(ev["result"], "success")
         self.assertEqual(ev["conflict_round"], 0)
 
-    def test_merge_attempt_conflict_when_base_merge_leaves_unmerged_paths(self) -> None:
+    def test_merge_attempt_conflict_when_base_rebase_leaves_unmerged_paths(self) -> None:
         gh, issue, pr = self._seed()
         self._run_with_merge(
             gh, issue, merge_succeeded=False,
@@ -118,7 +118,7 @@ class ResolvingConflictEventEmissionTest(
         self.assertEqual(len(attempts), 1)
         self.assertEqual(attempts[0]["result"], "conflict")
 
-    def test_conflict_round_incremented_on_clean_base_merge_push(self) -> None:
+    def test_conflict_round_incremented_on_clean_base_rebase_push(self) -> None:
         gh, issue, pr = self._seed()
         self._run_with_merge(
             gh, issue, merge_succeeded=True,
@@ -130,8 +130,8 @@ class ResolvingConflictEventEmissionTest(
         ]
         self.assertEqual(len(rounds), 1)
         self.assertEqual(rounds[0]["conflict_round"], 1)
-        self.assertEqual(rounds[0]["outcome"], "base_merged_clean")
-        # SHA is the after-merge HEAD captured before the push.
+        self.assertEqual(rounds[0]["outcome"], "base_rebased_clean")
+        # SHA is the after-rebase HEAD captured before the push.
         self.assertEqual(rounds[0]["sha"], "merged")
 
     def test_conflict_round_incremented_on_base_up_to_date_no_op(self) -> None:
@@ -169,7 +169,7 @@ class ResolvingConflictEventEmissionTest(
         self.assertEqual(len(merged), 1)
         self.assertEqual(merged[0]["stage"], "resolving_conflict")
         self.assertEqual(merged[0]["pr_number"], self.PR_NUMBER)
-        # No base-merge attempted on the terminal path.
+        # No base rebase attempted on the terminal path.
         self.assertEqual(self._events_of(gh, "merge_attempt"), [])
 
     def test_pr_closed_without_merge_event_on_resolving_conflict_closed(self) -> None:
@@ -379,7 +379,7 @@ class HandleResolvingConflictUsesAuthedFetchTest(
         # mocks dict rather than installing our own outer patch (which
         # `_run`'s inner `with` would override).
         with patch.object(
-            workflow, "_merge_base_into_worktree", merge_mock,
+            workflow, "_rebase_base_into_worktree", merge_mock,
         ):
             mocks = self._run(
                 lambda: workflow._handle_resolving_conflict(
@@ -394,7 +394,7 @@ class HandleResolvingConflictUsesAuthedFetchTest(
         # Two fetches per fresh resolving_conflict round: first for the
         # PR branch (so the SHA-alignment / unpushed-recovery check sees
         # current `origin/<branch>`), then for the base branch (so the
-        # upcoming `git merge` sees current `origin/<base>`).
+        # upcoming `git rebase` sees current `origin/<base>`).
         self.assertEqual(authed_fetch_mock.call_count, 2)
         refspecs = [call.args[1] for call in authed_fetch_mock.call_args_list]
         cwds = [call.kwargs["cwd"] for call in authed_fetch_mock.call_args_list]
@@ -424,9 +424,9 @@ class HandleResolvingConflictUsesAuthedFetchTest(
 class GitHardenedInjectsIdentityTest(unittest.TestCase):
     """`_git_hardened` strips global/system git config (where `user.name`
     / `user.email` typically live), so without explicit `GIT_AUTHOR_*` /
-    `GIT_COMMITTER_*` env vars a `git merge --no-edit` that needs to
-    create a merge commit fails with "Committer identity unknown" and
-    parks the issue as a non-conflict failure rather than resolving.
+    `GIT_COMMITTER_*` env vars a `git rebase` that needs to replay commits
+    can fail with "Committer identity unknown" and park the issue as a
+    non-conflict failure rather than resolving.
     """
 
     def test_env_includes_committer_and_author_identity(self) -> None:
@@ -440,7 +440,7 @@ class GitHardenedInjectsIdentityTest(unittest.TestCase):
             return MagicMock(returncode=0, stdout="", stderr="")
 
         with mock_patch("subprocess.run", side_effect=fake_run):
-            workflow._git_hardened("merge", "--no-edit", "x", cwd=Path("/tmp"))
+            workflow._git_hardened("rebase", "x", cwd=Path("/tmp"))
 
         env = captured["env"]
         self.assertEqual(env.get("GIT_AUTHOR_NAME"), config.AGENT_GIT_NAME)
@@ -906,8 +906,8 @@ class HandleResolvingConflictDispatchTest(unittest.TestCase):
 class HandleResolvingConflictTest(
     unittest.TestCase, _PatchedWorkflowMixin
 ):
-    """Drive `_handle_resolving_conflict` through the merge / push / cap /
-    PR-state branches with `_git`, `_merge_base_into_worktree`, and the
+    """Drive `_handle_resolving_conflict` through the rebase / push / cap /
+    PR-state branches with `_git`, `_rebase_base_into_worktree`, and the
     push helper mocked so no shell-out happens.
     """
 
@@ -959,6 +959,7 @@ class HandleResolvingConflictTest(
         run_agent_result=None,
         fetch_returncode: int = 0,
         dirty_files=(),
+        rebase_in_progress: bool = False,
     ):
         from unittest.mock import MagicMock
 
@@ -976,7 +977,7 @@ class HandleResolvingConflictTest(
         git_mock = MagicMock(return_value=fetch_result)
         git_hardened_mock = MagicMock(return_value=fetch_result)
         with patch.object(
-            workflow, "_merge_base_into_worktree", merge_mock
+            workflow, "_rebase_base_into_worktree", merge_mock
         ), patch.object(workflow, "_git", git_mock), patch.object(
             workflow, "_git_hardened", git_hardened_mock,
         ):
@@ -988,25 +989,34 @@ class HandleResolvingConflictTest(
                 push_branch=push_branch,
                 head_shas=head_shas,
                 dirty_files=dirty_files,
+                rebase_in_progress=rebase_in_progress,
             )
         return mocks, merge_mock, git_mock
 
-    def test_clean_merge_pushes_and_flips_to_validating(self) -> None:
-        gh, issue, pr = self._seed()
+    def test_clean_rebase_pushes_and_flips_to_validating(self) -> None:
+        gh, issue, pr = self._seed(
+            extra_state={"agent_approved_sha": "stale-approval"},
+        )
         mocks, merge_mock, git_mock = self._run_with_merge(
             gh, issue,
             merge_succeeded=True,
             head_shas=["beforehead", "merged"],
             push_branch=True,
         )
-        # Agent must NOT be spawned -- a clean base-merge does not need
+        # Agent must NOT be spawned -- a clean base rebase does not need
         # the dev to do anything.
         mocks["run_agent"].assert_not_called()
         merge_mock.assert_called_once()
-        mocks["_push_branch"].assert_called_once()
+        mocks["_push_branch"].assert_called_once_with(
+            _TEST_SPEC,
+            _FAKE_WT,
+            self.BRANCH,
+            force_with_lease="beforehead",
+        )
         self.assertIn((200, "validating"), gh.label_history)
         data = gh.pinned_data(200)
         self.assertEqual(data.get("review_round"), 0)
+        self.assertIsNone(data.get("agent_approved_sha"))
         self.assertEqual(data.get("conflict_round"), 1)
         self.assertIn("last_conflict_resolved_at", data)
 
@@ -1028,11 +1038,11 @@ class HandleResolvingConflictTest(
         self.assertEqual(data.get("conflict_round"), 0)
         self.assertFalse(data.get("awaiting_human"))
 
-    def test_clean_merge_already_up_to_date_skips_push_and_ticks_round(
+    def test_clean_rebase_already_up_to_date_skips_push_and_ticks_round(
         self,
     ) -> None:
         # When the base hasn't moved (e.g. unmergeability is purely due to
-        # branch protection), the merge is a no-op and there is nothing to
+        # branch protection), the rebase is a no-op and there is nothing to
         # push. The handler must still increment `conflict_round` so the
         # cap eventually fires -- otherwise the in_review <-> resolving
         # cycle would loop forever.
@@ -1051,9 +1061,9 @@ class HandleResolvingConflictTest(
         self.assertEqual(data.get("review_round"), 0)
         self.assertEqual(data.get("conflict_round"), 1)
 
-    def test_no_op_merge_loops_until_cap_fires(self) -> None:
+    def test_no_op_rebase_loops_until_cap_fires(self) -> None:
         # A PR stuck unmergeable purely due to branch protection would
-        # bounce between in_review and resolving_conflict with the merge
+        # bounce between in_review and resolving_conflict with the rebase
         # always a no-op. The cap must fire after MAX_CONFLICT_ROUNDS
         # such no-op rounds.
         gh, issue, pr = self._seed(extra_state={"conflict_round": 2})
@@ -1080,7 +1090,9 @@ class HandleResolvingConflictTest(
     def test_conflict_resolved_by_agent_pushes_and_flips_to_validating(
         self,
     ) -> None:
-        gh, issue, pr = self._seed()
+        gh, issue, pr = self._seed(
+            extra_state={"agent_approved_sha": "stale-approval"},
+        )
         mocks, merge_mock, git_mock = self._run_with_merge(
             gh, issue,
             merge_succeeded=False,
@@ -1093,11 +1105,20 @@ class HandleResolvingConflictTest(
         prompt = mocks["run_agent"].call_args.args[1]
         self.assertIn("a.py", prompt)
         self.assertIn("b.py", prompt)
-        self.assertIn("merge", prompt.lower())
-        mocks["_push_branch"].assert_called_once()
+        self.assertIn("rebase", prompt.lower())
+        self.assertIn("git rebase --skip", prompt)
+        self.assertIn("git commit --allow-empty", prompt)
+        self.assertIn("git rebase --abort", prompt)
+        mocks["_push_branch"].assert_called_once_with(
+            _TEST_SPEC,
+            _FAKE_WT,
+            self.BRANCH,
+            force_with_lease="beforehead",
+        )
         self.assertIn((200, "validating"), gh.label_history)
         data = gh.pinned_data(200)
         self.assertEqual(data.get("review_round"), 0)
+        self.assertIsNone(data.get("agent_approved_sha"))
         self.assertEqual(data.get("conflict_round"), 1)
         self.assertIn("last_conflict_resolved_at", data)
 
@@ -1214,7 +1235,7 @@ class HandleResolvingConflictTest(
         # so wire dirty_files through the kwarg rather than a separate
         # outer patch (which `_run`'s patch would override).
         with patch.object(
-            workflow, "_merge_base_into_worktree", merge_mock
+            workflow, "_rebase_base_into_worktree", merge_mock
         ), patch.object(workflow, "_git", git_mock), patch.object(
             workflow, "_git_hardened", git_mock,
         ):
@@ -1235,6 +1256,29 @@ class HandleResolvingConflictTest(
         self.assertTrue(data.get("awaiting_human"))
         self.assertNotIn((200, "validating"), gh.label_history)
 
+    def test_agent_left_rebase_in_progress_parks_without_push(self) -> None:
+        gh, issue, pr = self._seed()
+        mocks, merge_mock, git_mock = self._run_with_merge(
+            gh, issue,
+            merge_succeeded=False,
+            conflicted_files=["a.py"],
+            head_shas=["beforehead", "after"],
+            push_branch=True,
+            run_agent_result=_agent(
+                session_id="dev-sess",
+                last_message="I resolved one stop but another remains",
+            ),
+            rebase_in_progress=True,
+        )
+
+        mocks["_push_branch"].assert_not_called()
+        data = gh.pinned_data(200)
+        self.assertTrue(data.get("awaiting_human"))
+        self.assertNotIn((200, "validating"), gh.label_history)
+        last_comment = gh.posted_comments[-1][1]
+        self.assertIn("rebase is still in progress", last_comment)
+        self.assertIn("I resolved one stop", last_comment)
+
     def test_push_failure_parks_awaiting_human(self) -> None:
         gh, issue, pr = self._seed()
         mocks, merge_mock, git_mock = self._run_with_merge(
@@ -1254,7 +1298,7 @@ class HandleResolvingConflictTest(
 
     def test_awaiting_human_no_new_comments_is_quiet(self) -> None:
         # Once parked, ticks without a new human reply must not retry --
-        # otherwise the cap is meaningless and a poisoned merge would
+        # otherwise the cap is meaningless and a poisoned rebase would
         # burn tokens. The parked state stays put.
         gh, issue, pr = self._seed(
             extra_state={
@@ -1270,7 +1314,7 @@ class HandleResolvingConflictTest(
             return_value=MagicMock(returncode=0, stdout="", stderr="")
         )
         with patch.object(
-            workflow, "_merge_base_into_worktree", merge_mock
+            workflow, "_rebase_base_into_worktree", merge_mock
         ), patch.object(workflow, "_git", git_mock), patch.object(
             workflow, "_git_hardened", git_mock,
         ):
@@ -1289,13 +1333,14 @@ class HandleResolvingConflictTest(
         # `_on_question` / `_on_dirty_worktree` parks tell the human
         # "reply with guidance and the orchestrator will resume the
         # session". Honor that contract: a fresh comment past the
-        # watermark must resume the dev on the in-progress merge
+        # watermark must resume the dev on the in-progress rebase
         # worktree, NOT keep the issue stuck until a manual relabel.
         gh, issue, pr = self._seed(
             extra_state={
                 "awaiting_human": True,
                 "conflict_round": 1,
                 "last_action_comment_id": 1000,
+                "agent_approved_sha": "stale-approval",
             },
         )
         # Fresh comment above the watermark.
@@ -1313,16 +1358,22 @@ class HandleResolvingConflictTest(
             push_branch=True,
         )
 
-        # Resume runs the agent with the human's text; merge is NOT
-        # re-attempted (the worktree is mid-merge already).
+        # Resume runs the agent with the human's text; rebase is NOT
+        # re-attempted (the worktree is mid-rebase already).
         mocks["run_agent"].assert_called_once()
         prompt = mocks["run_agent"].call_args.args[1]
         self.assertIn("try harder", prompt)
         merge_mock.assert_not_called()
         # Successful resume pushes the branch and flips to validating.
-        mocks["_push_branch"].assert_called_once()
+        mocks["_push_branch"].assert_called_once_with(
+            _TEST_SPEC,
+            _FAKE_WT,
+            self.BRANCH,
+            force_with_lease=None,
+        )
         data = gh.pinned_data(200)
         self.assertEqual(data.get("review_round"), 0)
+        self.assertIsNone(data.get("agent_approved_sha"))
         self.assertEqual(data.get("conflict_round"), 2)
         self.assertIn((200, "validating"), gh.label_history)
         # Watermark advanced past the consumed comment.
@@ -1338,7 +1389,7 @@ class HandleResolvingConflictTest(
         # (still below the threshold), and the human would have to comment
         # twice more before recovery. With the fix, `_resume_dev_with_text`
         # transparently retries with a fresh spawn in the same worktree;
-        # the merge commit produced by the retry pushes and the issue
+        # the rebase commit produced by the retry pushes and the issue
         # flips back to validating in a single tick.
         gh, issue, pr = self._seed(
             extra_state={
@@ -1373,7 +1424,7 @@ class HandleResolvingConflictTest(
             return_value=MagicMock(returncode=0, stdout="", stderr="")
         )
         with patch.object(
-            workflow, "_merge_base_into_worktree", merge_mock,
+            workflow, "_rebase_base_into_worktree", merge_mock,
         ), patch.object(workflow, "_git", git_mock), patch.object(
             workflow, "_git_hardened", git_mock,
         ):
@@ -1454,7 +1505,7 @@ class HandleResolvingConflictTest(
             return_value=MagicMock(returncode=0, stdout="", stderr="")
         )
         with patch.object(
-            workflow, "_merge_base_into_worktree", merge_mock,
+            workflow, "_rebase_base_into_worktree", merge_mock,
         ), patch.object(workflow, "_git", git_mock), patch.object(
             workflow, "_git_hardened", git_mock,
         ):
@@ -1480,7 +1531,7 @@ class HandleResolvingConflictTest(
         from unittest.mock import MagicMock
         merge_mock = MagicMock(return_value=(True, []))
 
-        with patch.object(workflow, "_merge_base_into_worktree", merge_mock):
+        with patch.object(workflow, "_rebase_base_into_worktree", merge_mock):
             mocks = self._run(
                 lambda: workflow._handle_resolving_conflict(
                     gh, _TEST_SPEC, issue,
@@ -1491,7 +1542,7 @@ class HandleResolvingConflictTest(
                 # unpushed resolution); not behind.
                 branch_ahead_behind=(1, 0),
             )
-        # Recovered work pushed; merge NOT attempted (we already have a
+        # Recovered work pushed; rebase NOT attempted (we already have a
         # resolution waiting to ship).
         mocks["_push_branch"].assert_called_once()
         merge_mock.assert_not_called()
@@ -1515,7 +1566,7 @@ class HandleResolvingConflictTest(
         from unittest.mock import MagicMock
         merge_mock = MagicMock(return_value=(True, []))
 
-        with patch.object(workflow, "_merge_base_into_worktree", merge_mock):
+        with patch.object(workflow, "_rebase_base_into_worktree", merge_mock):
             mocks = self._run(
                 lambda: workflow._handle_resolving_conflict(
                     gh, _TEST_SPEC, issue,
@@ -1541,7 +1592,7 @@ class HandleResolvingConflictTest(
         from unittest.mock import MagicMock
         merge_mock = MagicMock(return_value=(True, []))
 
-        with patch.object(workflow, "_merge_base_into_worktree", merge_mock):
+        with patch.object(workflow, "_rebase_base_into_worktree", merge_mock):
             mocks = self._run(
                 lambda: workflow._handle_resolving_conflict(
                     gh, _TEST_SPEC, issue,
@@ -1565,7 +1616,7 @@ class HandleResolvingConflictTest(
         from unittest.mock import MagicMock
         merge_mock = MagicMock(return_value=(True, []))
 
-        with patch.object(workflow, "_merge_base_into_worktree", merge_mock):
+        with patch.object(workflow, "_rebase_base_into_worktree", merge_mock):
             mocks = self._run(
                 lambda: workflow._handle_resolving_conflict(
                     gh, _TEST_SPEC, issue,
@@ -1592,7 +1643,7 @@ class HandleResolvingConflictTest(
         from unittest.mock import MagicMock
         merge_mock = MagicMock(return_value=(True, []))
 
-        with patch.object(workflow, "_merge_base_into_worktree", merge_mock):
+        with patch.object(workflow, "_rebase_base_into_worktree", merge_mock):
             mocks = self._run(
                 lambda: workflow._handle_resolving_conflict(
                     gh, _TEST_SPEC, issue,
@@ -1611,10 +1662,10 @@ class HandleResolvingConflictTest(
         last_comment = gh.posted_comments[-1][1]
         self.assertIn("uncommitted", last_comment)
 
-    def test_dirty_clean_merge_with_new_commit_parks_without_push(self) -> None:
-        # Clean merge produced a merge commit (HEAD changed) but the
+    def test_dirty_clean_rebase_with_new_commit_parks_without_push(self) -> None:
+        # Clean rebase produced a new HEAD but the
         # worktree carries pre-existing dirty files. Pushing the merge
-        # commit without those edits would publish an incomplete branch.
+        # rebased branch without those edits would publish an incomplete branch.
         gh, issue, pr = self._seed()
         mocks, merge_mock, _ = self._run_with_merge(
             gh, issue,
@@ -1628,8 +1679,8 @@ class HandleResolvingConflictTest(
         data = gh.pinned_data(200)
         self.assertTrue(data.get("awaiting_human"))
 
-    def test_dirty_clean_merge_no_op_parks_without_flip(self) -> None:
-        # Clean no-op merge (HEAD didn't change because base hadn't
+    def test_dirty_clean_rebase_no_op_parks_without_flip(self) -> None:
+        # Clean no-op rebase (HEAD didn't change because base hadn't
         # moved) but the worktree carries dirty files. The reviewer
         # at validating reads the worktree directly, so flipping with a
         # dirty tree would let the agent vote on something that does NOT

--- a/tests/workflow_helpers.py
+++ b/tests/workflow_helpers.py
@@ -85,6 +85,7 @@ class _PatchedWorkflowMixin:
         first_commit_subject="",
         squash_result=(True, None, 0, None),
         branch_ahead_behind=(0, 0),
+        rebase_in_progress=False,
     ):
         rc_mock = _as_mock(run_agent)
         hnc_seq = has_new_commits if isinstance(has_new_commits, (list, tuple)) else None
@@ -128,6 +129,7 @@ class _PatchedWorkflowMixin:
         # against `_FAKE_WT`. Default: success-no-op, so tests not exercising
         # the squash path see no agent_approved_sha override.
         squash_mock = MagicMock(return_value=tuple(squash_result))
+        rebase_in_progress_mock = MagicMock(return_value=bool(rebase_in_progress))
 
         with patch.object(workflow, "run_agent", rc_mock), \
              patch.object(workflow, "_ensure_worktree", wt_mock), \
@@ -143,7 +145,8 @@ class _PatchedWorkflowMixin:
              patch.object(workflow, "_first_commit_subject", first_subject_mock), \
              patch.object(workflow, "_squash_and_force_push", squash_mock), \
              patch.object(workflow, "_authed_fetch", authed_fetch_ok), \
-             patch.object(workflow, "_branch_ahead_behind", ahead_behind_mock):
+             patch.object(workflow, "_branch_ahead_behind", ahead_behind_mock), \
+             patch.object(workflow, "_rebase_in_progress", rebase_in_progress_mock):
             callable_()
 
         return {
@@ -162,4 +165,5 @@ class _PatchedWorkflowMixin:
             "_squash_and_force_push": squash_mock,
             "_authed_fetch": authed_fetch_ok,
             "_branch_ahead_behind": ahead_behind_mock,
+            "_rebase_in_progress": rebase_in_progress_mock,
         }


### PR DESCRIPTION
If some PR was merged, then another PR should update the base branch.
This leads to "Merge ..." commits, which will be declined by commit formatting hygiene.
This PR replaces merge by rebase.