### PR TITLE
docs: move CI details to configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ State lives entirely in the issue itself — one workflow label plus one pinned 
 
 It is meant for solo or small-team setups that already have a `codex` or `claude` login and want autonomy without standing up a separate planner, queue, or database.
 
-For design and stage definitions, see [`docs/architecture.md`](docs/architecture.md). For agent roles and command specs, see [`docs/workflow.md`](docs/workflow.md). For env vars and run modes, see [`docs/configuration.md`](docs/configuration.md). The implementation roadmap is in [`plans/roadmap.md`](plans/roadmap.md).
+For design and stage definitions, see [`docs/architecture.md`](docs/architecture.md). For agent roles and command specs, see [`docs/workflow.md`](docs/workflow.md). For env vars, run modes, and project CI, see [`docs/configuration.md`](docs/configuration.md). The implementation roadmap is in [`plans/roadmap.md`](plans/roadmap.md).
 
 ## Requirements
 
@@ -84,10 +84,6 @@ For design and stage definitions, see [`docs/architecture.md`](docs/architecture
 ## Asking the orchestrator a question
 
 Apply the `question` label to any open issue to get a read-only answer instead of an implementation. The orchestrator spawns the configured `DECOMPOSE_AGENT` in the issue's worktree with a read-only prompt and posts the answer as an issue comment that pings `HITL_HANDLE`; subsequent human replies resume the same locked session, and closing the issue is the terminal signal. See [`docs/workflow.md#question-stage--read-only-qa-on-the-question-label`](docs/workflow.md#question-stage--read-only-qa-on-the-question-label) for the full lifecycle and the read-only-violation park reasons.
-
-## Continuous integration
-
-[`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs `ruff check` and `pytest` on Python 3.12 for every push to `main` and every pull request. Lint rules are configured in [`pyproject.toml`](pyproject.toml) under `[tool.ruff.lint]`.
 
 ## Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,6 +155,10 @@ Non-positive or non-integer values for either cap (or for a per-entry `parallel_
 | `ANALYTICS_LOG_PATH`       | `LOG_DIR/analytics.jsonl`        | project-local analytics sink for raw metric records (`{ts, repo, issue, event, optional stage, ...}`). Records today: `stage_enter` (label transitions), `stage_evaluation` (per-dispatch timing with `duration_s` and `result=ok\|error`), and `agent_exit` (token / model / cost details). The raw JSONL is intended for later ingestion into a structured database; one record per line keeps that path streaming. Filesystem only — no PostgreSQL, Streamlit, or external services in-process. Set to `` (empty) or to `off` / `disabled` / `none` to disable writes entirely. See the [analytics sink section in `architecture.md`](architecture.md#analytics-sink-analytics_log_path) for the per-event schema and prune semantics. |
 | `ANALYTICS_RETENTION_DAYS` | `90`                             | retention window for `ANALYTICS_LOG_PATH`. The polling loop calls `analytics.prune_old_records(...)` once per tick to remove records whose `ts` is older than this window without touching pinned GitHub state. Set to `0` (or any non-positive value) to keep raw data indefinitely — the prune helper becomes a no-op. |
 
+## Continuous integration
+
+[`../.github/workflows/ci.yml`](../.github/workflows/ci.yml) runs `ruff check` and `pytest` on Python 3.12 for every push to `main` and every pull request. Lint rules are configured in [`../pyproject.toml`](../pyproject.toml) under `[tool.ruff.lint]`.
+
 ## Run modes
 
 - `./run.sh` — production. Continuous polling. `run.sh` does `git pull --ff-only origin "$ORCHESTRATOR_BASE_BRANCH"` (read from `.env`, default `main`) and re-launches the orchestrator after each clean exit, so a self-modifying merge picks up the new code automatically.


### PR DESCRIPTION
Move CI details from `README` to configuration docs.