### PR TITLE
feat: log held children under decomposed parents

### DIFF
--- a/orchestrator/stages/decomposition.py
+++ b/orchestrator/stages/decomposition.py
@@ -822,6 +822,7 @@ def _handle_blocked(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
     # left as `blocked` (network blip, label-flip failure, etc.).
     dep_graph = state.get("dep_graph") or {}
     relabeled = False
+    held: list[tuple[int, list[int]]] = []
     for idx, child_number in enumerate(children):
         cn = int(child_number)
         if child_labels.get(cn) != "blocked":
@@ -830,11 +831,32 @@ def _handle_blocked(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
         dep_numbers = [
             int(children[int(d)]) for d in deps if int(d) < len(children)
         ]
-        if all(child_labels.get(dn) == "done" for dn in dep_numbers):
+        pending = [dn for dn in dep_numbers if child_labels.get(dn) != "done"]
+        if not pending:
             gh.set_workflow_label(child_issues[cn], "ready")
             relabeled = True
+        else:
+            held.append((cn, pending))
     if relabeled:
         gh.write_pinned_state(issue, state)
+
+    # Visibility: surface which children are still held under this blocked
+    # parent and the exact unfinished dependencies gating each, so an
+    # operator can see at a glance why a decomposed parent is not advancing.
+    # Children whose deps are satisfied are intentionally NOT held -- they
+    # run concurrently while the parent waits, which is what drives the tree
+    # to completion. Logged only when something is held to keep a healthy
+    # parent from spamming the tick log.
+    if held:
+        done_count = sum(1 for lbl in child_labels.values() if lbl == "done")
+        summary = "; ".join(
+            f"#{cn} waits on {', '.join(f'#{d}' for d in pending)}"
+            for cn, pending in held
+        )
+        _wf.log.info(
+            "issue=#%s blocked parent: %d/%d children done, %d held: %s",
+            issue.number, done_count, len(children), len(held), summary,
+        )
 
 
 def _handle_umbrella(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
@@ -971,6 +993,7 @@ def _handle_umbrella(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
     # rescued here.
     dep_graph = state.get("dep_graph") or {}
     relabeled = False
+    held: list[tuple[int, list[int]]] = []
     for idx, child_number in enumerate(children):
         cn = int(child_number)
         if child_labels.get(cn) != "blocked":
@@ -979,8 +1002,26 @@ def _handle_umbrella(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
         dep_numbers = [
             int(children[int(d)]) for d in deps if int(d) < len(children)
         ]
-        if all(child_labels.get(dn) == "done" for dn in dep_numbers):
+        pending = [dn for dn in dep_numbers if child_labels.get(dn) != "done"]
+        if not pending:
             gh.set_workflow_label(child_issues[cn], "ready")
             relabeled = True
+        else:
+            held.append((cn, pending))
     if relabeled:
         gh.write_pinned_state(issue, state)
+
+    # Visibility: surface which children are still held under this umbrella
+    # parent and the exact unfinished dependencies gating each, so an
+    # operator can see at a glance why the umbrella is not yet closing.
+    # Mirrors `_handle_blocked`; logged only when something is held.
+    if held:
+        done_count = sum(1 for lbl in child_labels.values() if lbl == "done")
+        summary = "; ".join(
+            f"#{cn} waits on {', '.join(f'#{d}' for d in pending)}"
+            for cn, pending in held
+        )
+        _wf.log.info(
+            "issue=#%s umbrella parent: %d/%d children done, %d held: %s",
+            issue.number, done_count, len(children), len(held), summary,
+        )

--- a/tests/test_workflow_decomposition_blocked.py
+++ b/tests/test_workflow_decomposition_blocked.py
@@ -222,6 +222,51 @@ class HandleBlockedTest(unittest.TestCase, _PatchedWorkflowMixin):
         self.assertEqual(flipped, ["ready"])
         self.assertNotIn((33, "ready"), gh.label_history)
 
+    def test_held_children_are_logged_with_pending_deps(self) -> None:
+        # Visibility feature: a child still `blocked` on an unfinished
+        # sibling is "held". `_handle_blocked` must surface it -- and the
+        # exact dependency gating it -- on the tick log so an operator can
+        # see why a decomposed parent is not advancing. children[0] is
+        # in-flight (not done), so children[1] (depends on [0]) stays held.
+        gh, parent, children = self._seed_parent_with_children(
+            parent_number=34,
+            child_labels=["implementing", "blocked"],
+            dep_graph={"1": [0]},
+        )
+
+        with self.assertLogs("orchestrator.workflow", level="INFO") as cm:
+            self._run(
+                lambda: workflow._handle_blocked(gh, _TEST_SPEC, parent),
+                run_agent=_agent(),
+            )
+
+        self.assertTrue(
+            any(
+                "blocked parent" in m
+                and "1 held" in m
+                and f"#{children[1].number} waits on #{children[0].number}" in m
+                for m in cm.output
+            ),
+            cm.output,
+        )
+        # Held means genuinely still gated -- no relabel to `ready`.
+        self.assertNotIn((children[1].number, "ready"), gh.label_history)
+
+    def test_no_held_children_emits_no_log(self) -> None:
+        # When every child is either done or already running (none still
+        # `blocked` on a sibling), nothing is held and the visibility log
+        # stays silent -- a healthy parent must not spam the tick log.
+        gh, parent, _children = self._seed_parent_with_children(
+            parent_number=35,
+            child_labels=["done", "implementing"],
+        )
+
+        with self.assertNoLogs("orchestrator.workflow", level="INFO"):
+            self._run(
+                lambda: workflow._handle_blocked(gh, _TEST_SPEC, parent),
+                run_agent=_agent(),
+            )
+
     def test_blocked_with_no_recorded_children_parks(self) -> None:
         gh = FakeGitHubClient()
         parent = make_issue(34, label="blocked")

--- a/tests/test_workflow_decomposition_umbrella.py
+++ b/tests/test_workflow_decomposition_umbrella.py
@@ -167,6 +167,52 @@ class HandleUmbrellaTest(unittest.TestCase, _PatchedWorkflowMixin):
         self.assertNotIn((65, "done"), gh.label_history)
         self.assertFalse(parent.closed)
 
+    def test_held_children_are_logged_with_pending_deps(self) -> None:
+        # Visibility feature mirrored from `_handle_blocked`: a child still
+        # `blocked` on an unfinished sibling is "held". `_handle_umbrella`
+        # must surface it -- and the exact dependency gating it -- on the
+        # tick log so an operator can see why the umbrella is not yet
+        # closing. children[0] is in-flight (not done), so children[1]
+        # (depends on [0]) stays held.
+        gh, parent, children = self._seed_umbrella_with_children(
+            parent_number=66,
+            child_labels=["implementing", "blocked"],
+            dep_graph={"1": [0]},
+        )
+
+        with self.assertLogs("orchestrator.workflow", level="INFO") as cm:
+            self._run(
+                lambda: workflow._handle_umbrella(gh, _TEST_SPEC, parent),
+                run_agent=_agent(),
+            )
+
+        self.assertTrue(
+            any(
+                "umbrella parent" in m
+                and "1 held" in m
+                and f"#{children[1].number} waits on #{children[0].number}" in m
+                for m in cm.output
+            ),
+            cm.output,
+        )
+        self.assertNotIn((children[1].number, "ready"), gh.label_history)
+        self.assertFalse(parent.closed)
+
+    def test_no_held_children_emits_no_log(self) -> None:
+        # When every child is either done or already running (none still
+        # `blocked` on a sibling), nothing is held and the visibility log
+        # stays silent -- a healthy umbrella must not spam the tick log.
+        gh, parent, _children = self._seed_umbrella_with_children(
+            parent_number=67,
+            child_labels=["done", "implementing"],
+        )
+
+        with self.assertNoLogs("orchestrator.workflow", level="INFO"):
+            self._run(
+                lambda: workflow._handle_umbrella(gh, _TEST_SPEC, parent),
+                run_agent=_agent(),
+            )
+
     def test_umbrella_with_no_recorded_children_parks(self) -> None:
         gh = FakeGitHubClient()
         parent = make_issue(66, label="umbrella")


### PR DESCRIPTION
## What

When `_handle_blocked` / `_handle_umbrella` poll a decomposed parent's children, each now emits one INFO line naming the children still **held** — i.e. still `blocked` on an unfinished sibling — and the exact dependencies gating each:

```
issue=#3 blocked parent: 5/7 children done, 2 held: #11 waits on #7; #12 waits on #7, #9
issue=#3 umbrella parent: 5/7 children done, 1 held: #12 waits on #9
```

This gives operators at-a-glance visibility into *why* a decomposed parent isn't advancing, without changing any flow.

## Why

A `blocked`/`umbrella` parent is waiting on its children. Children whose dependencies are satisfied run concurrently while the parent waits — that's what drives the tree to completion. But which children are still gated, and on what, was previously invisible in the tick log. This surfaces it.

## Scope (deliberately minimal)

- **No behavior change.** Eligible children still run; held children still wait. Only an added log line per handler.
- Logged **only when something is held**, so a healthy parent doesn't spam the tick log.
- The held/pending computation reuses the dep-graph walk already in each handler — no extra GitHub reads.
- Both family-aware parent handlers covered (`_handle_blocked`, `_handle_umbrella`); the line wording matches each (`blocked parent` / `umbrella parent`).

## Tests

`tests/test_workflow_decomposition_blocked.py` and `tests/test_workflow_decomposition_umbrella.py`:
- `test_held_children_are_logged_with_pending_deps` — a child blocked on an in-flight sibling is logged with its pending dep.
- `test_no_held_children_emits_no_log` — an all-running/done parent stays silent.

Full suite: 1294 passed, 27 skipped; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)