### PR TITLE
fix: keep backlog issues out of the cap-counted family bucket

### DIFF
--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -16,7 +16,7 @@ An issue should have at most one workflow label at a time. Non-workflow labels s
 Three non-workflow **control labels** modify behavior without occupying the workflow slot:
 
 - `hold_base_sync` pauses per-tick base sync, `in_review` HITL pings / unmergeable parks, and `resolving_conflict` rebases until removed.
-- `backlog` makes every per-tick handler skip the issue before the workflow label is read. Removing it hands control back to the state machine on the next tick.
+- `backlog` makes the orchestrator skip the issue: the per-tick dispatcher filters it out before the family/fanout split (so a parked, workflow-label-less issue cannot fold into the cap-counted family bucket and starve other work under `parallel_limit=1`), and each stage handler also skips it before the workflow label is read. Removing it hands control back to the state machine on the next tick.
 - `community_contribution` is applied by the per-tick open-PR sweep when `ALLOWED_ISSUE_AUTHORS` is configured: any open PR whose author is not in the allowlist is labeled and `HITL_HANDLE` is @-mentioned once per PR. The orchestrator does not otherwise drive these PRs. With `ALLOWED_ISSUE_AUTHORS` empty (the default), the sweep is a no-op.
 
 ### Typed states and the transition guard

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -590,11 +590,22 @@ def tick(
     family_numbers: list[int] = []
     fanout_numbers: list[int] = []
     for issue in gh.list_pollable_issues():
+        # `backlog` is a "not yet" hold -- filter it before the family /
+        # fanout split so a parked, workflow-label-less issue is never
+        # folded into the family bucket (see `_dispatch_via_scheduler` for
+        # why that starves fanout under `parallel_limit=1`).
+        # `_process_issue` skips backlog anyway.
         try:
+            if issue_has_label(issue, BACKLOG_LABEL):
+                log.info(
+                    "repo=%s issue=#%s has %r; skipping",
+                    spec.slug, issue.number, BACKLOG_LABEL,
+                )
+                continue
             label = gh.workflow_label(issue)
         except Exception:
             log.exception(
-                "repo=%s issue=#%s workflow_label read failed; routing to "
+                "repo=%s issue=#%s label read failed; routing to "
                 "family bucket so per-issue exception isolation can pick "
                 "up any sustained failure", spec.slug, issue.number,
             )
@@ -772,19 +783,37 @@ def _dispatch_via_scheduler(
     per-repo slot (under the default ``parallel_limit=1``) and deadlock
     the very children it waits on. A bucket containing ``decomposing``
     (spawns the decomposer agent) or an unlabeled-pickup ``None`` stays
-    cap-counted. The family mutex still applies, so a follow-up tick that
-    finds another family issue still serializes against this bucket.
+    cap-counted. ``backlog`` issues are filtered out before this split --
+    a parked issue carries no workflow label, so leaving it in would fold
+    it into the bucket and force ``cap_exempt=False``, starving fanout
+    behind a "not yet" hold under ``parallel_limit=1``. The family mutex
+    still applies, so a follow-up tick that finds another family issue
+    still serializes against this bucket.
     """
     per_repo_cap = max(1, int(getattr(spec, "parallel_limit", 1) or 1))
     family_numbers: list[int] = []
     family_labels: list[Optional[str]] = []
     fanout_numbers: list[int] = []
     for issue in gh.list_pollable_issues():
+        # `backlog` is an operator "not yet" hold: the issue sits outside
+        # the state machine until the label is removed. Drop it BEFORE the
+        # family/fanout split. A parked issue carries no workflow label, so
+        # it would otherwise land in the family bucket and -- being neither
+        # `blocked` nor `umbrella` -- flip the whole bucket to cap-counted,
+        # reserving the only per-repo slot under `parallel_limit=1` and
+        # starving every fanout issue behind it. `_process_issue` skips
+        # backlog anyway; filtering here keeps it from holding a slot.
         try:
+            if issue_has_label(issue, BACKLOG_LABEL):
+                log.info(
+                    "repo=%s issue=#%s has %r; skipping",
+                    spec.slug, issue.number, BACKLOG_LABEL,
+                )
+                continue
             label = gh.workflow_label(issue)
         except Exception:
             log.exception(
-                "repo=%s issue=#%s workflow_label read failed; routing to "
+                "repo=%s issue=#%s label read failed; routing to "
                 "family bucket so per-issue exception isolation can pick "
                 "up any sustained failure", spec.slug, issue.number,
             )

--- a/tests/test_workflow_scheduler_routing.py
+++ b/tests/test_workflow_scheduler_routing.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import base_sync, config, workflow
+from orchestrator.github import BACKLOG_LABEL
 
 from tests.fakes import FakeGitHubClient, FakeLabel, make_issue
 
@@ -1122,6 +1123,146 @@ class UmbrellaCapExemptionTest(unittest.TestCase):
             for ev in releases.values():
                 ev.set()
         self._wait_idle(sched, "acme/widget")
+
+
+class BacklogDispatchFilterTest(unittest.TestCase):
+    """A `backlog` issue carries no workflow label, so the per-tick
+    dispatcher would otherwise fold it into the family bucket. Because
+    `backlog` is neither `blocked` nor `umbrella`, that flips the whole
+    bucket to cap-counted -- and under `parallel_limit=1` the bucket then
+    reserves the only per-repo slot every tick, starving all fanout work
+    behind a parked "not yet" issue. The dispatcher must drop `backlog`
+    issues BEFORE the family/fanout split so they never reserve or block a
+    scheduler slot (`_process_issue` skips them anyway).
+    """
+
+    def _spec(self, parallel_limit: int = 5) -> config.RepoSpec:
+        return config.RepoSpec(
+            slug="acme/widget",
+            target_root=Path("/tmp/orchestrator-test-target-root"),
+            base_branch="main",
+            parallel_limit=parallel_limit,
+        )
+
+    def _wait_idle(self, sched, repo_slug: str, deadline_s: float = 5.0) -> None:
+        import threading as _threading
+        deadline = _threading.Event()
+        timer = _threading.Timer(deadline_s, deadline.set)
+        timer.daemon = True
+        timer.start()
+        try:
+            while sched.active_count(repo_slug) > 0 and not deadline.is_set():
+                pass
+        finally:
+            timer.cancel()
+        self.assertEqual(sched.active_count(repo_slug), 0)
+
+    def _backlog_issue(self, number: int):
+        issue = make_issue(number)
+        issue.labels.append(FakeLabel(BACKLOG_LABEL))
+        return issue
+
+    def test_backlog_only_does_not_starve_fanout(self) -> None:
+        # Per-repo cap 1: a parked `backlog` issue (no workflow label) and a
+        # real `implementing` fanout issue. Before the fix the backlog issue
+        # formed a cap-counted family bucket that grabbed the only slot, so
+        # the implementer was `per_repo_cap`-skipped every tick. After the
+        # fix the backlog issue is filtered out and the fanout runs.
+        import threading
+        from orchestrator.scheduler import IssueScheduler
+        sched = IssueScheduler(global_cap=8, per_repo_cap=1)
+        self.addCleanup(sched.shutdown)
+        gh = FakeGitHubClient()
+        gh.add_issue(make_issue(1, label="implementing"))
+        gh.add_issue(self._backlog_issue(2))
+
+        start = threading.Event()
+        release = threading.Event()
+        processed: list[int] = []
+        lock = threading.Lock()
+
+        def fake_process(_gh, _spec, issue) -> None:
+            with lock:
+                processed.append(issue.number)
+            if issue.number == 1:
+                start.set()
+                release.wait(timeout=5.0)
+
+        try:
+            with patch.object(workflow, "_refresh_base_and_worktrees"), \
+                 patch.object(workflow, "_process_issue", side_effect=fake_process):
+                workflow.tick(gh, self._spec(parallel_limit=1), scheduler=sched)
+                self.assertTrue(
+                    start.wait(timeout=2.0),
+                    "implementing #1 was starved -- the backlog issue must "
+                    "not occupy the only per-repo slot",
+                )
+        finally:
+            release.set()
+        self._wait_idle(sched, "acme/widget")
+        with lock:
+            self.assertNotIn(
+                2, processed,
+                "backlog #2 must be filtered at dispatch, never processed",
+            )
+
+    def test_backlog_does_not_make_blocked_bucket_cap_counted(self) -> None:
+        # The production regression: a `blocked` parent and a parked
+        # `backlog` issue share the family bucket. The backlog issue (label
+        # None) used to force `cap_exempt=False`, so the bucket reserved the
+        # only slot and the `implementing` fanout never ran. With the backlog
+        # issue filtered out, the bucket is `blocked`-only -> cap-exempt, so
+        # BOTH the blocked parent and the fanout implementer run this tick.
+        import threading
+        from orchestrator.scheduler import IssueScheduler
+        sched = IssueScheduler(global_cap=8, per_repo_cap=1)
+        self.addCleanup(sched.shutdown)
+        gh = FakeGitHubClient()
+        gh.add_issue(make_issue(1, label="implementing"))
+        gh.add_issue(make_issue(2, label="blocked"))
+        gh.add_issue(self._backlog_issue(3))
+
+        starts: dict[int, threading.Event] = {
+            1: threading.Event(),
+            2: threading.Event(),
+        }
+        releases: dict[int, threading.Event] = {
+            1: threading.Event(),
+            2: threading.Event(),
+        }
+        processed: list[int] = []
+        lock = threading.Lock()
+
+        def fake_process(_gh, _spec, issue) -> None:
+            with lock:
+                processed.append(issue.number)
+            ev = starts.get(issue.number)
+            if ev is not None:
+                ev.set()
+                releases[issue.number].wait(timeout=5.0)
+
+        try:
+            with patch.object(workflow, "_refresh_base_and_worktrees"), \
+                 patch.object(workflow, "_process_issue", side_effect=fake_process):
+                workflow.tick(gh, self._spec(parallel_limit=1), scheduler=sched)
+                self.assertTrue(
+                    starts[1].wait(timeout=2.0),
+                    "implementing fanout #1 did not start",
+                )
+                self.assertTrue(
+                    starts[2].wait(timeout=2.0),
+                    "blocked #2 did not start -- the bucket must stay "
+                    "cap-exempt once the backlog issue is filtered out",
+                )
+        finally:
+            for ev in releases.values():
+                ev.set()
+        self._wait_idle(sched, "acme/widget")
+        with lock:
+            self.assertNotIn(
+                3, processed,
+                "backlog #3 must be filtered at dispatch, never processed",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Under `parallel_limit=1` (the default), a `backlog`-parked issue silently froze **all** other work on the repo.

`backlog` is a control label with no workflow label, so `workflow_label()` returns `None`. The per-tick dispatcher routes `None`-labelled issues into the **family bucket**, and a family bucket is only cap-*exempt* when every member is `blocked`/`umbrella`. The `None` member (the backlog issue) flips the whole bucket to **cap-counted**, so every tick it reserves the single per-repo slot before the fanout issues are submitted — and `implementing` / `documenting` / `fixing` / `question` issues get `per_repo_cap`-skipped indefinitely.

Observed in production: after one issue was parked to `backlog`, four others stopped advancing across dozens of ticks (`active=1`, no agent, no spawn — only the `blocked` + `backlog` worker lines).

## Fix

Filter `backlog` issues out **before** the family/fanout split, in both dispatch paths (`_dispatch_via_scheduler` and the legacy local-executor path). A parked issue should have zero scheduling effect; `_process_issue` skips it anyway, so dropping it at dispatch keeps it from reserving or blocking a slot. The check sits inside the existing label-read `try`, so a lazy-load failure still routes conservatively to the family bucket.

## Tests

Two new tests in `tests/test_workflow_scheduler_routing.py` reproduce the starvation under `parallel_limit=1` (they fail on the pre-fix code):
- `test_backlog_only_does_not_starve_fanout`
- `test_backlog_does_not_make_blocked_bucket_cap_counted`

Full suite: 1398 passed, 29 skipped, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
