### PR TITLE
fix: tell dev agents to run verification in foreground

### DIFF
--- a/orchestrator/stages/conflicts.py
+++ b/orchestrator/stages/conflicts.py
@@ -271,6 +271,7 @@ def _handle_resolving_conflict(
             f"@{c.user.login if c.user else 'user'}: {c.body}"
             for c in new_comments if c.body
         )
+        followup = f"{followup}\n\n{_wf._FOREGROUND_ONLY_NOTE}"
         wt = _wf._worktree_path(spec, issue.number)
         if not wt.exists():
             wt = _wf._ensure_pr_worktree(

--- a/orchestrator/stages/implementing.py
+++ b/orchestrator/stages/implementing.py
@@ -352,10 +352,13 @@ def _resume_developer_on_human_reply(
         return None
     consumed_max = max(c.id for c in new_comments)
     state.set("last_action_comment_id", consumed_max)
+    from .. import workflow as _wf
+
     followup = "\n\n".join(
         f"@{c.user.login if c.user else 'user'}: {c.body}"
         for c in new_comments if c.body
     )
+    followup = f"{followup}\n\n{_wf._FOREGROUND_ONLY_NOTE}"
     return _resume_dev_with_text(gh, spec, issue, state, followup)
 
 

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -84,6 +84,7 @@ from .workflow_drift import (
 from .workflow_drift import _route_drift_to_decomposing as _route_drift_to_decomposing
 from .workflow_messages import _orchestrator_ids, _post_issue_comment
 from .workflow_messages import _MANIFEST_RE as _MANIFEST_RE
+from .workflow_messages import _FOREGROUND_ONLY_NOTE as _FOREGROUND_ONLY_NOTE
 from .workflow_messages import _ORCH_COMMENT_MARKER as _ORCH_COMMENT_MARKER
 from .workflow_messages import _STDERR_TAIL_BUDGET as _STDERR_TAIL_BUDGET
 from .workflow_messages import (

--- a/orchestrator/workflow_drift.py
+++ b/orchestrator/workflow_drift.py
@@ -37,6 +37,7 @@ from github.Issue import Issue
 from .state_machine import WorkflowLabel
 from .github import PINNED_STATE_MARKER, GitHubClient, PinnedState
 from .workflow_messages import (
+    _FOREGROUND_ONLY_NOTE,
     _ORCH_COMMENT_MARKER,
     _orchestrator_ids,
     _post_issue_comment,
@@ -158,7 +159,8 @@ def _build_user_content_change_prompt(
         "and stays on the current label without parking. If you have a "
         "clarification question or are unsure, do NOT use `ACK:`; reply "
         "with the question and the orchestrator will park awaiting a human "
-        "reply (same as a regular agent question)."
+        "reply (same as a regular agent question).\n\n"
+        f"{_FOREGROUND_ONLY_NOTE}"
     )
 
 

--- a/orchestrator/workflow_messages.py
+++ b/orchestrator/workflow_messages.py
@@ -54,6 +54,22 @@ _ORCH_COMMENT_ID_CAP = 500
 # orchestrator-comment filter are independent identifiers.
 _ORCH_COMMENT_MARKER = "<!--orchestrator-comment-->"
 
+# Appended to every prompt that can lead to a commit. Agent sessions are
+# one-shot headless processes: the CLI exits the moment the model ends its
+# turn, so a backgrounded build/test (a long suite, `cargo miri`, a dev
+# server) dies with the session and its result is never observed -- the
+# issue just parks on "waiting for X to finish" forever. Models default to
+# the interactive habit of backgrounding slow jobs and "checking later",
+# so the execution model has to be spelled out.
+_FOREGROUND_ONLY_NOTE = (
+    "IMPORTANT: your session terminates the moment you finish responding -- "
+    "nothing keeps running between turns, and a later resume starts a fresh "
+    "process. NEVER start a background job (build, test run, Miri, server) "
+    "and end your turn intending to check it later: the job dies with your "
+    "session and its result will never be seen. Run all builds and tests in "
+    "the foreground and wait for them to complete before you commit or reply."
+)
+
 
 def _orchestrator_ids(state: PinnedState) -> set[int]:
     """Set of comment ids the orchestrator itself posted on this issue/PR.
@@ -532,6 +548,7 @@ def _build_implement_prompt(issue: Issue, comments_text: str) -> str:
         "The commit message MUST be the subject line only -- no extended description / "
         "body and no `Co-Authored-By:` (or other) trailer. Use `git commit -m \"<type>: "
         "<subject>\"` with a single `-m`.\n\n"
+        f"{_FOREGROUND_ONLY_NOTE}\n\n"
         "If you cannot proceed because of missing information, leave the working tree "
         "uncommitted (no commits) and end your response with a clear question for the human."
     )
@@ -616,7 +633,8 @@ def _build_documentation_prompt(
         "If you genuinely cannot decide because of missing information, "
         "leave the worktree uncommitted, omit the marker, and end your "
         "final message with a question for the human; the orchestrator "
-        "will park the issue for human review."
+        "will park the issue for human review.\n\n"
+        f"{_FOREGROUND_ONLY_NOTE}"
     )
 
 
@@ -635,6 +653,7 @@ def _build_fix_prompt(review_feedback: str) -> str:
         "The commit message MUST be the subject line only -- no extended description / "
         "body and no `Co-Authored-By:` (or other) trailer. Use `git commit -m \"<type>: "
         "<subject>\"` with a single `-m`.\n\n"
+        f"{_FOREGROUND_ONLY_NOTE}\n\n"
         "If you genuinely disagree with a point, end your final message with a question for "
         "the human and leave that item un-fixed; the orchestrator will park the issue for "
         "human review. Otherwise, fix all items (a single commit is fine)."
@@ -713,7 +732,8 @@ def _build_conflict_resolution_prompt(
         "Use `git status` to inspect the in-progress rebase.\n\n"
         "If you genuinely cannot resolve a conflict, end your final "
         "message with a question for the human and leave the worktree "
-        "mid-rebase; the orchestrator will park the issue for human review."
+        "mid-rebase; the orchestrator will park the issue for human review.\n\n"
+        f"{_FOREGROUND_ONLY_NOTE}"
     )
 
 
@@ -804,5 +824,6 @@ def _build_pr_comment_followup(comments: list) -> str:
         "and the branch already satisfies them, make NO commit and end your "
         "final message with a single line `ACK: <brief reason>`. The "
         "orchestrator will then return the PR to review-ready instead of "
-        "parking it for a fix that is not warranted."
+        "parking it for a fix that is not warranted.\n\n"
+        f"{_FOREGROUND_ONLY_NOTE}"
     )

--- a/tests/test_workflow_conflicts.py
+++ b/tests/test_workflow_conflicts.py
@@ -1373,6 +1373,11 @@ class HandleResolvingConflictTest(
         mocks["run_agent"].assert_called_once()
         prompt = mocks["run_agent"].call_args.args[1]
         self.assertIn("try harder", prompt)
+        # The bare human-reply followup must carry the foreground-only
+        # execution-model note -- a resumed dev that backgrounds a slow
+        # test run and ends its turn "to check later" strands the issue
+        # (the job dies with the session).
+        self.assertIn("NEVER start a background job", prompt)
         merge_mock.assert_not_called()
         # Successful resume pushes the branch and hands straight back
         # to `validating`. Docs do not run here -- the single docs pass

--- a/tests/test_workflow_implementing_fresh.py
+++ b/tests/test_workflow_implementing_fresh.py
@@ -252,6 +252,11 @@ class HandleImplementingAwaitingHumanTest(unittest.TestCase, _PatchedWorkflowMix
         self.assertEqual(call.kwargs.get("resume_session_id"), "sess-old")
         followup_arg = call.args[1]
         self.assertIn("please use sqlite", followup_arg)
+        # The bare human-reply followup must still carry the
+        # foreground-only execution-model note -- a resumed dev that
+        # backgrounds a slow test run and ends its turn "to check later"
+        # strands the issue (the job dies with the session).
+        self.assertIn("NEVER start a background job", followup_arg)
         # Ran through to PR open.
         self.assertEqual(len(gh.opened_prs), 1)
         self.assertFalse(gh.pinned_data(2).get("awaiting_human"))

--- a/tests/test_workflow_implementing_pr_reuse.py
+++ b/tests/test_workflow_implementing_pr_reuse.py
@@ -186,6 +186,36 @@ class ConventionalCommitPromptTest(unittest.TestCase):
         self.assertIn("Co-Authored-By", prompt)
 
 
+class ForegroundOnlyPromptTest(unittest.TestCase):
+    """Every prompt that can lead to a commit must spell out the one-shot
+    execution model: the session dies when the model ends its turn, so a
+    backgrounded build/test ("Miri is running, I'll continue when it
+    completes") is never observed and the issue parks forever."""
+
+    MARKER = "NEVER start a background job"
+
+    def test_dev_facing_prompts_carry_foreground_only_note(self) -> None:
+        issue = make_issue(7, title="add a thing", body="please add a thing")
+        comments = [FakeComment(id=42, body="please rename foo to bar",
+                                user=FakeUser("alice"))]
+        prompts = {
+            "implement": workflow._build_implement_prompt(
+                issue, comments_text=""),
+            "fix": workflow._build_fix_prompt("please fix the typo"),
+            "pr_comment_followup": workflow._build_pr_comment_followup(
+                comments),
+            "documentation": workflow._build_documentation_prompt(
+                _TEST_SPEC, issue, comments_text=""),
+            "conflict": workflow._build_conflict_resolution_prompt(
+                "origin/main", ["a.rs"]),
+            "user_content_change": workflow._build_user_content_change_prompt(
+                issue, comments_text=""),
+        }
+        for name, prompt in prompts.items():
+            with self.subTest(prompt=name):
+                self.assertIn(self.MARKER, prompt)
+
+
 class ConventionalPrTitleTest(unittest.TestCase, _PatchedWorkflowMixin):
     """`_on_commits` derives the PR title from the agent's first commit
     subject when it already follows the Conventional-Commits convention,


### PR DESCRIPTION
## Problem

Observed live: a dev agent implementing a Rust issue launched `cargo miri test` in the background and ended its turn with "Miri is running in the background. I'll continue when it completes." The orchestrator parked the issue `awaiting_human`. But agent sessions are one-shot headless processes — the CLI exits the moment the model ends its turn, so the backgrounded Miri run died with its parent and its result can never be observed. Every subsequent human nudge resumed the dev, which parked again with the same "waiting for Miri" reply: an unbounded park loop with work sitting uncommitted in the worktree.

The model isn't misbehaving — backgrounding a slow job and "checking later" is the correct habit in interactive sessions, where the harness persists across turns. Nothing in the orchestrator's prompts told it the execution model is one-shot.

## Fix

New `_FOREGROUND_ONLY_NOTE` constant in `workflow_messages.py`, appended to every prompt that can lead to a commit:

- `_build_implement_prompt`, `_build_fix_prompt`, `_build_documentation_prompt`, `_build_conflict_resolution_prompt`, `_build_pr_comment_followup` (workflow_messages.py)
- `_build_user_content_change_prompt` (workflow_drift.py, direct constant import)
- the bare human-reply followup in `_resume_developer_on_human_reply` (implementing.py, via the `workflow` facade re-export)

The note states: the session terminates when the response ends, nothing runs between turns, never background builds/tests and end the turn intending to check later — run them in the foreground before committing or replying.

Read-only prompts (question stage, reviewer) are deliberately left unchanged — they don't gate a commit on long verification runs.

## Tests

- `ForegroundOnlyPromptTest` asserts the note is present in all six builder outputs (subtests per prompt).
- Extended the existing human-reply resume test to assert the followup carries the note.

Full suite passes; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)