### PR TITLE
fix: reduce closed-issue sweep API usage

### DIFF
--- a/.env.example.advanced
+++ b/.env.example.advanced
@@ -46,6 +46,17 @@
 # Polling interval for the main loop, seconds.
 # POLL_INTERVAL=60
 
+# How many ticks apart the closed-issue recovery sweep runs. That sweep
+# issues one closed-issue query per non-terminal workflow label PER REPO
+# every tick; across many repos at a short POLL_INTERVAL it dominates
+# request volume and exhausts GitHub's 5000 req/hour primary rate limit
+# (symptom: repeated "403: Forbidden" + long "Setting next backoff to …s"
+# stalls in orchestrator.log). 1 (default) runs it every tick; raise it
+# (e.g. 4-5) on multi-repo hosts. Cost: an externally-merged/closed issue
+# may take up to N-1 extra ticks to finalize to `done`. See
+# docs/configuration.md#github-rate-limits.
+# CLOSED_ISSUE_SWEEP_EVERY_N_TICKS=1
+
 # Wall-clock cap per agent invocation, seconds.
 # AGENT_TIMEOUT=1800
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,6 +78,7 @@ The first token of each role spec selects the backend (`codex` / `claude`); any 
 | Variable                   | Default     | Purpose                                                                                          |
 | -------------------------- | ----------- | ------------------------------------------------------------------------------------------------ |
 | `POLL_INTERVAL`            | `60`        | seconds between polling ticks                                                                    |
+| `CLOSED_ISSUE_SWEEP_EVERY_N_TICKS` | `1` | how many ticks apart the closed-issue recovery sweep runs (see [GitHub rate limits](#github-rate-limits) below). The sweep issues one `GET …/issues?state=closed&labels=<L>` per non-terminal workflow label **per repo**; across many repos at a short `POLL_INTERVAL` that fixed cost dominates request volume and is the main driver of GitHub *primary* rate-limit (5000 req/hour/PAT) exhaustion. `1` runs it every tick (unchanged behavior). Raise it (e.g. `4`–`5`) on multi-repo deployments; the only cost is that an externally-merged/closed issue may take up to `N-1` extra ticks to finalize to `done`. The latency-sensitive open-issue poll always runs every tick. |
 | `AGENT_TIMEOUT`            | `1800`      | wall-clock cap per agent invocation, seconds                                                     |
 | `REVIEW_TIMEOUT`           | (= `AGENT_TIMEOUT`) | wall-clock cap per reviewer invocation, seconds                                          |
 | `SHUTDOWN_GRACE_SECONDS`   | `30`        | seconds after SIGTERM/SIGINT before the loop force-terminates in-flight agent subprocesses and hard-exits (`128 + signum`). Keep below the systemd unit's `TimeoutStopSec` (90s) so `systemctl restart` sees a clean stop instead of escalating to SIGKILL — without it the drain waits on in-flight workers bounded only by `AGENT_TIMEOUT` (1800s) or a blocking GitHub retry/backoff, which overruns the stop deadline. |
@@ -88,6 +89,23 @@ The first token of each role spec selects the backend (`codex` / `claude`); any 
 | `ORCHESTRATOR_BASE_BRANCH` | `main`      | base branch of the orchestrator's own repo, used by the self-update path                          |
 | `SQUASH_ON_APPROVAL`       | `on`        | after the reviewer emits `VERDICT: APPROVED`, squash the dev's commits on the PR branch into a single subject-only commit and force-push with lease. The subject reuses the dev's first commit subject when it carries a reusable `<prefix>:` form (Conventional **or** repo-local such as `event:`/`career:`); otherwise it is synthesized with a prefix inferred from recent base-branch history. `off` leaves the per-step commit history intact (useful when downstream tooling depends on it). Parsed as a boolean: `1` / `true` / `on` / `yes` enable, anything else disables. |
 | `EXPOSE_TRACKED_REPOS`     | `on`        | tell working agents about the *other* repos this orchestrator tracks (slug, local `target_root`, base branch) for cross-repo reference. Inert for single-repo hosts — the awareness block is emitted only when more than one repo is configured, so a default deployment sees zero added prompt tokens. The disclosed data is operator-configured and non-secret (no tokens, no remote URLs), and write-containment is unchanged. `off` forces the disclosure off globally. Parsed as a boolean: `1` / `true` / `on` / `yes` enable, anything else disables. |
+
+### GitHub rate limits
+
+A single fine-grained PAT gets **5000 REST requests/hour** (the GitHub *primary* rate limit). Each tick spends a roughly fixed number of `GET /repos/…` requests **per repo**, independent of how much real work the repo has:
+
+- the open-issue poll (`list_pollable_issues`): 1+ requests,
+- the closed-issue recovery sweep: one `GET …/issues?state=closed&labels=<L>` per non-terminal workflow label (7 today), and
+- the community-contribution PR sweep: 1 `GET …/pulls` request.
+
+With `R` repos at `POLL_INTERVAL` seconds, the floor is roughly `R × (9 + sweep) × 3600 / POLL_INTERVAL` requests/hour even when every repo is idle. Past ~5–6 repos at the 60s default this exceeds 5000/hour: the budget is spent partway into each hour, GitHub starts returning `403: Forbidden` with an `X-RateLimit-Reset` in the future, and PyGithub's `GithubRetry` sleeps (uninterruptibly) until the reset — typically a ~15–18 minute stall **every hour**, on the hour. The signature in `orchestrator.log` is repeated `github.GithubRetry: … failed with 403: Forbidden` followed by `Setting next backoff to <hundreds-to-1000+>s`.
+
+Two built-in mitigations reduce the floor without touching `POLL_INTERVAL`:
+
+- **Workflow-label objects are cached** per repo client. They are immutable after `ensure_workflow_labels`, so the closed sweep no longer re-fetches them every tick — eliminating 7 `GET …/labels/<name>` requests per repo per tick automatically.
+- **`CLOSED_ISSUE_SWEEP_EVERY_N_TICKS`** batches the closed-issue recovery sweep to once every N ticks (see the table above). At `N=4`–`5` the seven closed-label queries are amortized down by the same factor while the open-issue poll stays every tick.
+
+If you still approach the cap, the remaining levers are operator-side: raise `POLL_INTERVAL`, split repos across more than one PAT (one token file per slug under `~/.config/<owner>/<repo>/token`), or reduce the number of tracked repos. Check current consumption with `curl -H "Authorization: Bearer $TOKEN" https://api.github.com/rate_limit`.
 
 ## Local verification gate
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -85,6 +85,8 @@ Before rebasing, the flow fetches `gh.get_pr(pr_number)` and skips when `pr_stat
 
 Pre-PR labels (`decomposing` / `blocked` / `umbrella` / `ready`) are not swept closed — a closed issue at those stages is a hard human stop until an operator relabels.
 
+The closed-issue sweep issues one closed-issue query per sweep label per repo, every tick — a fixed request cost that drives GitHub primary-rate-limit exhaustion on multi-repo hosts. `CLOSED_ISSUE_SWEEP_EVERY_N_TICKS` (default `1`) batches it to once every N ticks; the open-issue poll is unaffected, so the only effect of `N>1` is that an externally-merged/closed issue can take up to `N-1` extra ticks to finalize. See [configuration.md#github-rate-limits](configuration.md#github-rate-limits).
+
 `done` and `rejected` are terminal no-ops. Every handler receives the active `RepoSpec`, so `git worktree add`, `git fetch <spec.remote_name> <spec.base_branch>`, push-token resolution, and PR-base selection all flow from the spec.
 
 ### Pinned state

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -125,6 +125,25 @@ GITHUB_TOKEN: str = _resolve_github_token(REPO)
 POLL_INTERVAL: int = int(os.environ.get("POLL_INTERVAL", "60"))
 AGENT_TIMEOUT: int = int(os.environ.get("AGENT_TIMEOUT", "1800"))
 
+# How many polling ticks apart the closed-issue recovery sweep in
+# `GitHubClient.list_pollable_issues` runs. That sweep issues one
+# `GET /repos/.../issues?state=closed&labels=<L>` per non-terminal workflow
+# label, PER REPO, every tick -- a fixed request cost that is independent of
+# how much real work the repo has. Across many configured repos at a short
+# `POLL_INTERVAL` it dominates per-tick request volume and is the principal
+# driver of GitHub *primary* rate-limit (5000 req/hour/PAT) exhaustion: once
+# the hourly budget is spent PyGithub's GithubRetry sleeps until the reset
+# (~uninterruptible 1000s+ stalls observed). The latency-sensitive open-issue
+# poll still runs every tick; only the closed recovery sweep is batched to
+# once per N ticks. `1` (default) preserves the legacy every-tick behavior.
+# Raise it (e.g. 4-5) on multi-repo deployments to stay under the hourly cap;
+# the only cost is that an externally-merged/closed issue may take up to N-1
+# extra ticks to finalize to `done` -- pinned GitHub state stays authoritative
+# in the meantime, so nothing is lost, only briefly deferred.
+CLOSED_ISSUE_SWEEP_EVERY_N_TICKS: int = max(
+    1, int(os.environ.get("CLOSED_ISSUE_SWEEP_EVERY_N_TICKS", "1"))
+)
+
 # Hard ceiling, in seconds, on how long the polling loop may take to exit
 # after a SIGTERM/SIGINT before it force-terminates in-flight agent
 # subprocesses and hard-exits. Must stay comfortably below the systemd

--- a/orchestrator/github.py
+++ b/orchestrator/github.py
@@ -18,6 +18,7 @@ from typing import Any, Iterable, Optional
 from github import Auth, Github, GithubException
 from github.Issue import Issue
 from github.IssueComment import IssueComment
+from github.Label import Label
 from github.PullRequest import PullRequest
 from github.Repository import Repository
 
@@ -199,6 +200,16 @@ class GitHubClient:
         # FakeGitHubClient mirrors this attribute so workflow tests can read
         # captured events without touching disk.
         self.recorded_events: list[dict] = []
+        # Per-name cache of resolved workflow Label objects (see
+        # `_cached_label`). Workflow labels are immutable after
+        # `ensure_workflow_labels`, so the closed-issue sweep can stop
+        # re-fetching them every tick.
+        self._label_cache: dict[str, Label] = {}
+        # Count of `list_pollable_issues` calls on this client. Because that
+        # method is invoked exactly once per repo per tick, this doubles as a
+        # tick counter and drives the closed-issue-sweep cadence throttle
+        # (`config.CLOSED_ISSUE_SWEEP_EVERY_N_TICKS`).
+        self._pollable_calls = 0
 
     def _for_worker_thread(self) -> "GitHubClient":
         """Build a fresh GitHubClient for a single worker thread.
@@ -222,6 +233,41 @@ class GitHubClient:
         carries event ordering across threads.
         """
         return GitHubClient(token=self._token, repo_slug=self._repo_slug)
+
+    def _cached_label(self, name: str) -> Optional[Label]:
+        """Resolve a workflow Label object, caching successes for this client.
+
+        The closed-issue sweep in `list_pollable_issues` needs Label OBJECTS
+        because PyGithub's `get_issues(labels=...)` reads `label.name`.
+        Workflow labels are created once by `ensure_workflow_labels` and are
+        never mutated by the orchestrator, so re-fetching each one every tick
+        is pure waste -- on a multi-repo deployment those
+        `GET /repos/.../labels/<name>` calls are a large fraction of the
+        per-tick request volume that exhausts the GitHub primary rate limit.
+        Cache the resolved object so each label is fetched at most once per
+        repo client.
+
+        Failures are NOT cached: a missing label (under-scoped PAT, or one not
+        yet created) keeps being retried every tick exactly as before, so
+        fixing the PAT or creating the label takes effect without a restart.
+        Returns None on a lookup failure so the caller can skip that label's
+        sweep instead of raising out of the generator.
+        """
+        cached = self._label_cache.get(name)
+        if cached is not None:
+            return cached
+        try:
+            label_obj = self.repo.get_label(name)
+        except GithubException as e:
+            log.warning(
+                "could not look up %r label for closed-issue sweep "
+                "(HTTP %s); skipping. Externally-merged %s issues will "
+                "not finalize to `done` until the label exists.",
+                name, e.status, name,
+            )
+            return None
+        self._label_cache[name] = label_obj
+        return label_obj
 
     def list_pollable_issues(self, since: Optional[datetime] = None) -> Iterable[Issue]:
         """Open issues plus closed issues still labeled with any non-terminal
@@ -258,6 +304,7 @@ class GitHubClient:
         worktree on disk indefinitely.
         """
         seen: set[int] = set()
+        self._pollable_calls += 1
 
         kwargs: dict[str, Any] = {
             "state": "open",
@@ -271,32 +318,36 @@ class GitHubClient:
                 seen.add(issue.number)
                 yield issue
 
+        # The closed-issue recovery sweep below issues one GET per non-terminal
+        # label, per repo. That fixed cost -- paid every tick regardless of how
+        # much real work exists -- dominates request volume on multi-repo
+        # deployments and exhausts GitHub's primary rate limit (see
+        # `config.CLOSED_ISSUE_SWEEP_EVERY_N_TICKS`). Run it on the first call
+        # (so startup recovery is never delayed) and then once every N ticks;
+        # the open-issue poll above always runs. `<= 1` keeps it every tick.
+        every = config.CLOSED_ISSUE_SWEEP_EVERY_N_TICKS
+        if every > 1 and (self._pollable_calls - 1) % every != 0:
+            return
+
         # PyGithub's Repository.get_issues(labels=...) expects Label OBJECTS
         # and reads `label.name`; passing a raw string list raises a
         # TypeError before the sweep yields anything. Because that exception
         # propagates out of this generator on the second `for` -- past the
         # per-issue try/except in `tick()` -- it would silently break every
         # tick after open issues processed and leave externally-merged
-        # in_review issues stuck closed-but-labeled forever. Look up
-        # each Label once per call; treat a missing label as "nothing to
-        # sweep" and skip rather than raising. Multi-label-OR is achieved
-        # by issuing one query per label (the GitHub Issues API treats
-        # `labels` as AND, not OR).
+        # in_review issues stuck closed-but-labeled forever. Resolve each
+        # Label via the per-client cache (`_cached_label`); treat a missing
+        # label as "nothing to sweep" and skip rather than raising.
+        # Multi-label-OR is achieved by issuing one query per label (the
+        # GitHub Issues API treats `labels` as AND, not OR).
         for label_name in (
             WorkflowLabel.IMPLEMENTING, WorkflowLabel.DOCUMENTING,
             WorkflowLabel.VALIDATING, WorkflowLabel.IN_REVIEW,
             WorkflowLabel.FIXING, WorkflowLabel.RESOLVING_CONFLICT,
             WorkflowLabel.QUESTION,
         ):
-            try:
-                label_obj = self.repo.get_label(label_name)
-            except GithubException as e:
-                log.warning(
-                    "could not look up %r label for closed-issue sweep "
-                    "(HTTP %s); skipping. Externally-merged %s issues will "
-                    "not finalize to `done` until the label exists.",
-                    label_name, e.status, label_name,
-                )
+            label_obj = self._cached_label(label_name)
+            if label_obj is None:
                 continue
             closed_kwargs: dict[str, Any] = {
                 "state": "closed",

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -184,6 +184,11 @@ class FakeGitHubClient:
         # writes to disk via the same helper the real client uses, so a
         # single test can cover both surfaces.
         self.recorded_events: list[dict] = []
+        # Mirrors GitHubClient._pollable_calls: drives the closed-issue-sweep
+        # cadence throttle (`config.CLOSED_ISSUE_SWEEP_EVERY_N_TICKS`) so the
+        # public "closed issues may be omitted on N-1 of every N calls"
+        # contract is exercisable through the fake.
+        self._pollable_calls = 0
         self._issues: dict[int, FakeIssue] = {i.number: i for i in issues}
         self._pinned: dict[int, PinnedState] = {}
         self._comment_id = count(start=1000)
@@ -252,11 +257,19 @@ class FakeGitHubClient:
         """
         out: list[FakeIssue] = []
         seen: set[int] = set()
+        self._pollable_calls += 1
         for issue in self._issues.values():
             if issue.closed:
                 continue
             seen.add(issue.number)
             out.append(issue)
+        # Throttle the closed-issue recovery sweep to once every N calls,
+        # always running it on the first call. Mirrors the real client so
+        # `config.CLOSED_ISSUE_SWEEP_EVERY_N_TICKS` is testable through the
+        # fake; `<= 1` (default) keeps every call sweeping.
+        every = config.CLOSED_ISSUE_SWEEP_EVERY_N_TICKS
+        if every > 1 and (self._pollable_calls - 1) % every != 0:
+            return out
         for issue in self._issues.values():
             if not issue.closed or issue.number in seen:
                 continue

--- a/tests/test_workflow_in_review_checks.py
+++ b/tests/test_workflow_in_review_checks.py
@@ -28,6 +28,10 @@ class GitHubClientClosedIssueSweepLabelTest(unittest.TestCase):
         # Bypass __init__: it would require a real PAT and Github client.
         client = GitHubClient.__new__(GitHubClient)
         client.repo = MagicMock()
+        # __init__ normally seeds these; the closed sweep and label cache
+        # both read them.
+        client._pollable_calls = 0
+        client._label_cache = {}
         # All get_issues calls (open sweep + per-label closed sweeps)
         # return nothing -- we only care about the call arguments.
         client.repo.get_issues.return_value = iter([])
@@ -92,6 +96,8 @@ class GitHubClientClosedIssueSweepLabelTest(unittest.TestCase):
 
         client = GitHubClient.__new__(GitHubClient)
         client.repo = MagicMock()
+        client._pollable_calls = 0
+        client._label_cache = {}
         client.repo.get_issues.return_value = iter([])
         client.repo.get_label.side_effect = GithubException(
             404, {"message": "Not Found"}, None

--- a/tests/test_workflow_list_pollable.py
+++ b/tests/test_workflow_list_pollable.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 import os
 import unittest
+from unittest import mock
 
 os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
+from github import GithubException
+
+from orchestrator import config
+from orchestrator.github import GitHubClient
 from tests.fakes import FakeGitHubClient, make_issue
 
 
@@ -81,6 +86,99 @@ class ListPollableIssuesClosedSweepTest(unittest.TestCase):
         gh.add_issue(closed)
         yielded = [i.number for i in gh.list_pollable_issues()]
         self.assertIn(303, yielded)
+
+
+class ClosedSweepCadenceTest(unittest.TestCase):
+    """`CLOSED_ISSUE_SWEEP_EVERY_N_TICKS` batches the per-label closed-issue
+    recovery sweep so its fixed request cost is not paid every tick. The
+    open-issue poll must stay every tick; only the closed sweep is throttled.
+    """
+
+    def test_default_runs_closed_sweep_every_tick(self) -> None:
+        gh = FakeGitHubClient()
+        gh.add_issue(make_issue(1, label="implementing"))
+        closed = make_issue(7, label="in_review")
+        closed.closed = True
+        gh.add_issue(closed)
+        # Default knob (1): the closed issue surfaces on every call.
+        for _ in range(3):
+            out = {i.number for i in gh.list_pollable_issues()}
+            self.assertEqual(out, {1, 7})
+
+    def test_throttled_sweep_runs_on_first_then_every_nth_call(self) -> None:
+        gh = FakeGitHubClient()
+        gh.add_issue(make_issue(1, label="implementing"))
+        closed = make_issue(7, label="in_review")
+        closed.closed = True
+        gh.add_issue(closed)
+        with mock.patch.object(config, "CLOSED_ISSUE_SWEEP_EVERY_N_TICKS", 3):
+            # Call 1 (first): sweep runs -> closed issue present.
+            self.assertEqual({i.number for i in gh.list_pollable_issues()}, {1, 7})
+            # Calls 2 and 3: sweep skipped -> open issue only.
+            self.assertEqual({i.number for i in gh.list_pollable_issues()}, {1})
+            self.assertEqual({i.number for i in gh.list_pollable_issues()}, {1})
+            # Call 4 (== first + N): sweep runs again.
+            self.assertEqual({i.number for i in gh.list_pollable_issues()}, {1, 7})
+
+    def test_throttle_never_drops_open_issues(self) -> None:
+        gh = FakeGitHubClient()
+        gh.add_issue(make_issue(1, label="implementing"))
+        gh.add_issue(make_issue(2, label="validating"))
+        with mock.patch.object(config, "CLOSED_ISSUE_SWEEP_EVERY_N_TICKS", 5):
+            for _ in range(5):
+                out = {i.number for i in gh.list_pollable_issues()}
+                self.assertEqual(out, {1, 2})
+
+
+class _StubLabel:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _CountingRepo:
+    """Minimal stand-in for PyGithub's Repository that records how many times
+    `get_label` is called, so the cache can be asserted without network."""
+
+    def __init__(self, *, missing: set[str] | None = None) -> None:
+        self.get_label_calls: list[str] = []
+        self._missing = missing or set()
+
+    def get_label(self, name: str):
+        self.get_label_calls.append(name)
+        if name in self._missing:
+            raise GithubException(403, {"message": "Forbidden"}, None)
+        return _StubLabel(name)
+
+
+class CachedLabelTest(unittest.TestCase):
+    """`_cached_label` must fetch each workflow label at most once per client
+    (labels are immutable after `ensure_workflow_labels`), while still
+    retrying a failed lookup every call so a fixed PAT / created label is
+    picked up without a restart.
+    """
+
+    def _bare_client(self, repo: _CountingRepo) -> GitHubClient:
+        # Bypass the networked __init__; wire only what _cached_label touches.
+        gh = GitHubClient.__new__(GitHubClient)
+        gh.repo = repo
+        gh._label_cache = {}
+        return gh
+
+    def test_resolved_label_is_fetched_once(self) -> None:
+        repo = _CountingRepo()
+        gh = self._bare_client(repo)
+        for _ in range(5):
+            label = gh._cached_label("implementing")
+            self.assertEqual(label.name, "implementing")
+        self.assertEqual(repo.get_label_calls, ["implementing"])
+
+    def test_failed_lookup_is_not_cached_and_retries(self) -> None:
+        repo = _CountingRepo(missing={"implementing"})
+        gh = self._bare_client(repo)
+        self.assertIsNone(gh._cached_label("implementing"))
+        self.assertIsNone(gh._cached_label("implementing"))
+        # Both calls hit GitHub: a transient 403 must not poison the cache.
+        self.assertEqual(repo.get_label_calls, ["implementing", "implementing"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `CLOSED_ISSUE_SWEEP_EVERY_N_TICKS` to batch closed-issue recovery sweeps while keeping open-issue
polling every tick.
- Cache workflow label objects per GitHub client to avoid repeated label lookups during sweeps.
- Document the GitHub rate-limit behavior and add fake/client tests for sweep cadence and label caching.

## Tests

- `uv run pytest tests/test_workflow_list_pollable.py tests/test_workflow_in_review_checks.py`