### PR TITLE
docs: add comment hygiene, and new test economy and assertion quality into `develop` and `review` skillsf

### DIFF
--- a/.agents/skills/develop/SKILL.md
+++ b/.agents/skills/develop/SKILL.md
@@ -37,6 +37,22 @@ The facade pattern in `orchestrator/workflow.py` is load-bearing for tests. Get 
 - When you move a helper to a new module, either update the test's patch target to the new module boundary, or keep the compatibility alias on `workflow.py` and patch through the facade. Pick one approach per PR and be consistent.
 - Stage-handler tests live in `tests/test_workflow_<stage>.py` (`_conflicts`); the validating stage is split into focused `tests/test_workflow_validating_*.py` files (review loops + retry caps, handoff, squash, watermarks, drift, verify, terminal), the in_review stage into focused `tests/test_workflow_in_review_*.py` files (routing, watermarks, filtering, parked, migration, checks, drift, fresh-feedback fixing route), the implementing stage into focused `tests/test_workflow_implementing_*.py` files (fresh runs, PR reuse + conventional-commit helpers, retry / backend behavior, user-content drift, full-spec persistence, terminal merges / closed issues), and the decomposition stage into focused `tests/test_workflow_decomposition_*.py` files (manifest parsing, decomposing/ready/blocked/umbrella stage handlers, child issue creation, hash drift, stale manifest cleanup, child merged-PR finalize). Per-label dispatcher / routing tests live in `tests/test_workflow_<label>_routing.py` (backlog, question, documenting, fixing) and the remaining facade-level helpers (worktree serialization, drain-terminals, finalize-if-pr-merged, stage analytics) live in their own focused modules. Shared fixtures go in `tests/workflow_helpers.py`.
 - Prefer extending the in-memory fakes in `tests/fakes.py` over mocking PyGithub directly. New behavior should land with tests in the matching stage file.
+- Before finalizing tests, do a redundancy pass:
+  - List each added/modified test and the distinct behavior it protects.
+  - Merge tests that differ only by input shape or branch case into `pytest.mark.parametrize` cases or a small named loop, unless separate setup materially improves clarity.
+  - Prefer one focused helper/unit test that covers sibling branches over multiple tests with repeated setup.
+  - Keep end-to-end tests only when they exercise an integration boundary that helper tests cannot cover.
+  - Ensure assertions observe the behavior being fixed. For resource-usage bugs (over-fetching, redundant API calls, retained state), add a direct assertion at the helper/producer level when final-result checks could pass for the wrong reason.
+  - Remove incidental low-level assertions when existing tests already cover that behavior.
+
+## Comments
+
+Write every comment against the current state of the code, as if it had always been this way:
+
+- Prefer stating why the code below exists — the invariant it protects, the non-local consumer it serves, the failure it prevents — over describing what it does. If a comment paraphrases an already-readable line (`# cap the page size at what we still need` above `min(remaining, page_size)`) or the assert below it, delete it or replace it with the reason.
+- Exception: a plain-language summary of genuinely dense code (tricky offset math, a multi-step comprehension or iterator chain, subtle ordering constraints) is fine even though it "restates" the code. The test is whether the comment is faster to understand than the code below it, not whether it repeats it.
+- No diff-relative wording: "previously", "the old X", "instead of a `set`", "no longer", "now sized to". Those sentences address the reviewer and go stale the moment the PR merges — put the before/after story in the commit message or PR description instead.
+- Same rule for test docstrings: describe the behavior the test pins down, not the bug or implementation it replaced.
 
 ## Documentation drift
 

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -33,6 +33,13 @@ The compatibility surface on `orchestrator/workflow.py` is load-bearing. Confirm
 - Stage modules access cross-module helpers via `from .. import workflow as _wf` **at call time**, not via top-level `from ..workflow import _foo` and not via direct imports from `workflow_drift` / `workflow_messages` / `worktrees`. The late-binding pattern preserves `patch.object(workflow, ...)` semantics in tests.
 - Test patches target the new module boundary after a move (or the facade alias, consistently). Flag tests that still patch the old location.
 
+## Test economy and assertion quality
+
+- Identify newly added tests that duplicate existing tests or each other; request merging into `pytest.mark.parametrize` cases or a small named loop when the only difference is fixture values or branch selection.
+- Verify each added test fails against the old behavior or directly protects a changed contract.
+- For resource-usage fixes (over-fetching, redundant API calls, retained state), reject tests that only assert the final result; require at least one assertion at the helper/producer level.
+- Prefer fewer tests with clear distinct coverage over many narrowly overlapping regression tests.
+
 ## Documentation drift
 
 After any handler or helper move, grep the PR for stale pointers and request fixes in:
@@ -44,6 +51,11 @@ After any handler or helper move, grep the PR for stale pointers and request fix
 - module docstrings at the top of `workflow.py`, `workflow_drift.py`, `workflow_messages.py`, `worktrees.py`, `orchestrator/stages/*.py`
 
 Treat blanket statements like "every helper is re-exported" with suspicion — verify literally against the code.
+
+## Comment hygiene
+
+- Flag diff-relative comments — "previously", "the old retry cap", "instead of a dict", "now uses" — in code and test docstrings alike. A comment must read correctly to someone who never saw the change; the before/after story belongs in the commit message or PR description.
+- Flag comments that paraphrase an already-readable line or the assert below them instead of stating a why (invariant, non-local consumer, prevented failure). Ask for the reason or for deletion. Do not flag plain-language summaries above genuinely dense code (tricky offset math, multi-step comprehension chains) — a comment that is faster to understand than the code it heads earns its place.
 
 ## Commit hygiene
 


### PR DESCRIPTION
.agents/skills/develop/SKILL.md
- Tests section gained the "redundancy pass" checklist: list what each test protects, merge near-duplicates, prefer focused helper tests, keep end-to-end tests only for integration boundaries, assert at the level where the bug lives, and drop assertions that duplicate existing coverage.
- New Comments section: state the why (invariant, non-local consumer, prevented failure) rather than paraphrasing readable code, allow plain-language summaries above genuinely dense code, ban diff-relative wording ("previously",
"no longer"), and apply the same rule to test docstrings.

.agents/skills/review/SKILL.md
- New Test economy and assertion quality section: flag duplicated tests and request parametrize/loop merging, verify each new test would fail against the old behavior, reject final-result-only assertions for resource-usage fixes, prefer fewer distinct tests.
- New Comment hygiene section: flag diff-relative and paraphrasing comments, but not summaries of dense code.
