### PR TITLE
test: normalize verbose test names

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -799,7 +799,7 @@ class InterruptedClassificationTest(unittest.TestCase):
         self.assertFalse(timed_out)
         self.assertFalse(interrupted)
 
-    def test_run_subprocess_own_timeout_is_timed_out_not_interrupted(self) -> None:
+    def test_own_timeout_is_timed_out(self) -> None:
         # A child that outlives our own `timeout` drives the timeout branch:
         # `_terminate_process_group` reaps the group and the run is classified
         # `timed_out=True`, `interrupted=False`, exit_code=-1 -- distinct from

--- a/tests/test_analytics_sync.py
+++ b/tests/test_analytics_sync.py
@@ -966,7 +966,7 @@ class AnalyticsSyncBatchTest(unittest.TestCase):
                 "ON CONFLICT (content_hash) DO NOTHING", sql,
             )
 
-    def test_race_backstop_rowcount_distinguishes_inserted_and_duplicate(self) -> None:
+    def test_rowcount_distinguishes_inserted_and_duplicate(self) -> None:
         # Race-safe backstop: model a concurrent writer that landed
         # rows AFTER the startup pre-check completed but BEFORE the
         # batched flush, by holding the pre-check view empty while
@@ -989,12 +989,12 @@ class AnalyticsSyncBatchTest(unittest.TestCase):
             for record in records[:2]:
                 fake.seen_hashes.add(analytics_sync._content_hash(record))
             with patch.object(analytics_sync, "_BATCH_SIZE", 4):
-                result = analytics_sync.sync_jsonl_to_postgres(
+                sync_result = analytics_sync.sync_jsonl_to_postgres(
                     connect=lambda url: fake,
                     json_adapter=lambda v: v,
                 )
-            self.assertEqual(result.inserted, 2)
-            self.assertEqual(result.skipped_duplicate, 2)
+            self.assertEqual(sync_result.inserted, 2)
+            self.assertEqual(sync_result.skipped_duplicate, 2)
             self.assertEqual(len(fake.batches), 1)
             self.assertEqual(len(fake.batches[0][1]), 4)
 

--- a/tests/test_comment_trust.py
+++ b/tests/test_comment_trust.py
@@ -84,7 +84,7 @@ class FilterTrustedTest(unittest.TestCase):
         ]
         self.assertEqual(filter_trusted(comments, allowed=()), comments)
 
-    def test_populated_allowlist_drops_untrusted_and_preserves_order(self) -> None:
+    def test_allowlist_drops_untrusted_preserves_order(self) -> None:
         allowed = ("alice",)
         comments = [
             FakeComment(1, "ok", FakeUser("Alice")),

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -2023,7 +2023,7 @@ class MainRenderDispatchTest(_MainSourceTest):
         # earlier, so anchor on the last occurrence.
         self.assertLess(idxs[-1], src.rindex("_render_drilldown("))
 
-    def test_skill_card_stays_inline_between_heatmap_and_recent_runs(
+    def test_skill_card_stays_between_heatmap_and_runs(
         self,
     ) -> None:
         src = self._main_source()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -462,7 +462,7 @@ class SchedulerWiringTest(unittest.TestCase):
             self.assertEqual(rc, 128 + signal.SIGINT)
             self.assertEqual(submit_results, [True, False])
 
-    def test_signal_during_active_tick_closes_submit_path_multi_repo(
+    def test_active_tick_signal_closes_multi_repo_submit(
         self,
     ) -> None:
         # Same invariant as above but where both repos are already

--- a/tests/test_workflow_agent_analytics.py
+++ b/tests/test_workflow_agent_analytics.py
@@ -242,7 +242,7 @@ class AgentAnalyticsTest(unittest.TestCase, _PatchedWorkflowMixin):
             ):
                 self.assertNotIn(forbidden, records[0])
 
-    def test_reviewer_record_carries_review_round_and_resume_context(
+    def test_reviewer_record_carries_round_and_resume(
         self,
     ) -> None:
         # Reviewer spawn carries `agent_spec=REVIEW_AGENT_SPEC` and the
@@ -291,16 +291,16 @@ class AgentAnalyticsTest(unittest.TestCase, _PatchedWorkflowMixin):
                 if record.get("agent_role") == "reviewer"
             ]
             self.assertEqual(len(reviewer), 1)
-            rec = reviewer[0]
-            self.assertEqual(rec["stage"], "validating")
-            self.assertEqual(rec["backend"], config.REVIEW_AGENT)
-            self.assertEqual(rec["agent_spec"], config.REVIEW_AGENT_SPEC)
-            self.assertEqual(rec["review_round"], 2)
-            self.assertEqual(rec["retry_count"], 3)
-            self.assertEqual(rec["session_id"], "sess-review")
+            reviewer_record = reviewer[0]
+            self.assertEqual(reviewer_record["stage"], "validating")
+            self.assertEqual(reviewer_record["backend"], config.REVIEW_AGENT)
+            self.assertEqual(reviewer_record["agent_spec"], config.REVIEW_AGENT_SPEC)
+            self.assertEqual(reviewer_record["review_round"], 2)
+            self.assertEqual(reviewer_record["retry_count"], 3)
+            self.assertEqual(reviewer_record["session_id"], "sess-review")
             # Reviewer always spawns fresh; the wrapper drops None-valued
             # extras so `resume_session_id` is absent (not stored as null).
-            self.assertNotIn("resume_session_id", rec)
+            self.assertNotIn("resume_session_id", reviewer_record)
 
     def test_timeout_records_exit_metadata_and_no_cost(self) -> None:
         # A timed-out agent has empty stdout; the parser yields the
@@ -624,7 +624,7 @@ class RunUsageSurfacedTest(unittest.TestCase):
                 "agent_exit", {event["event"] for event in gh.recorded_events},
             )
 
-    def test_analytics_and_skill_events_unchanged_with_usage_surfaced(
+    def test_analytics_and_skill_events_unchanged(
         self,
     ) -> None:
         # Surfacing usage must not perturb the analytics record or the
@@ -634,23 +634,23 @@ class RunUsageSurfacedTest(unittest.TestCase):
         # carries the same metrics.
         with tempfile.TemporaryDirectory(prefix="usage-unchanged-") as td:
             path = Path(td) / "analytics.jsonl"
-            gh, result = self._run(
+            gh, agent_result = self._run(
                 stdout=_claude_stdout_with_skills(skills=("develop", "review")),
                 track=True,
                 analytics_path=path,
             )
             records = self._records(path)
             self.assertEqual(len(records), 1)
-            rec = records[0]
-            self.assertEqual(rec["event"], "agent_exit")
-            self.assertEqual(rec["input_tokens"], 1000)
-            self.assertEqual(rec["output_tokens"], 500)
+            exit_record = records[0]
+            self.assertEqual(exit_record["event"], "agent_exit")
+            self.assertEqual(exit_record["input_tokens"], 1000)
+            self.assertEqual(exit_record["output_tokens"], 500)
             # The record shape is unchanged -- the surfaced field name must
             # not leak into the JSONL record.
-            self.assertNotIn("usage", rec)
+            self.assertNotIn("usage", exit_record)
             # The same numbers are visible on the surfaced metrics object.
-            self.assertEqual(result.usage.input_tokens, 1000)
-            self.assertEqual(result.usage.output_tokens, 500)
+            self.assertEqual(agent_result.usage.input_tokens, 1000)
+            self.assertEqual(agent_result.usage.output_tokens, 500)
             # Skill-trigger audit events are unaffected.
             skill_events = [
                 event for event in gh.recorded_events

--- a/tests/test_workflow_base_sync_real_git.py
+++ b/tests/test_workflow_base_sync_real_git.py
@@ -321,7 +321,7 @@ class RefreshBaseAndWorktreesRealGitTest(unittest.TestCase):
         state = self.gh.pinned_data(7)
         self.assertIsNone(state.get("review_round"))
 
-    def test_pr_open_conflicting_base_advance_relabels_resolving_conflict(
+    def test_open_pr_conflicting_base_relabels_resolving_conflict(
         self,
     ) -> None:
         # When the rebase actually leaves conflicted files, the refresh

--- a/tests/test_workflow_base_sync_unit.py
+++ b/tests/test_workflow_base_sync_unit.py
@@ -728,14 +728,14 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         # CRITICAL: park survives on disk, watermark NOT advanced.
         # The operator's "retry" comment is still ahead of the
         # watermark so the next refresh tick rediscovers it.
-        state = self.gh.pinned_data(ISSUE)
-        self.assertTrue(state.get(KEY_AWAITING_HUMAN))
+        pinned_state = self.gh.pinned_data(ISSUE)
+        self.assertTrue(pinned_state.get(KEY_AWAITING_HUMAN))
         self.assertEqual(
-            state.get(KEY_PARK_REASON), PARK_PUSH_FAILED,
+            pinned_state.get(KEY_PARK_REASON), PARK_PUSH_FAILED,
         )
-        self.assertEqual(state.get(KEY_LAST_ACTION_COMMENT_ID), 99)
+        self.assertEqual(pinned_state.get(KEY_LAST_ACTION_COMMENT_ID), 99)
 
-    def test_pr_auto_rebase_park_survives_early_exit_when_pr_fetch_fails(
+    def test_auto_rebase_park_survives_pr_fetch_failure(
         self,
     ) -> None:
         # Same regression for the `gh.get_pr()` failure gate: a
@@ -1010,7 +1010,7 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
             rebased[0].get("method"), "crash_recovery_relabel_only",
         )
 
-    def test_pr_crash_recovery_clears_stale_flag_when_head_unchanged(
+    def test_crash_recovery_clears_stale_flag_on_same_head(
         self,
     ) -> None:
         # Scenario 3: a prior tick set the anchor, then died before
@@ -1044,13 +1044,16 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
         merge.assert_called_once()
         push.assert_called_once()
         # Anchor cleared and label flipped to `validating`.
-        state = self.gh.pinned_data(ISSUE)
-        self.assertIsNone(state.get(KEY_PENDING_PUSH_SHA))
+        pinned_state = self.gh.pinned_data(ISSUE)
+        self.assertIsNone(pinned_state.get(KEY_PENDING_PUSH_SHA))
         self.assertIn((ISSUE, LABEL_VALIDATING), self.gh.label_history)
         # Normal-flow rebase event, NOT a crash-recovery one.
-        rebased = [e for e in self.gh.recorded_events if e.get("event") == EVENT_BASE_REBASED]
-        self.assertEqual(len(rebased), 1)
-        self.assertEqual(rebased[0].get("method"), "auto_clean_rebase")
+        base_rebased_events = [
+            event for event in self.gh.recorded_events
+            if event.get("event") == EVENT_BASE_REBASED
+        ]
+        self.assertEqual(len(base_rebased_events), 1)
+        self.assertEqual(base_rebased_events[0].get("method"), "auto_clean_rebase")
 
     def _run_unverifiable_recovery(
         self,
@@ -1189,7 +1192,7 @@ class SyncWorktreeWithBaseUnitTest(unittest.TestCase):
             hardened_mock, push_mock, merge_mock,
         )
 
-    def test_pr_crash_recovery_parks_on_sha_mismatch_zero_ahead_behind(
+    def test_crash_recovery_parks_on_zero_ahead_mismatch(
         self,
     ) -> None:
         # The fourth cannot-verify path: rev-parse returns a DIFFERENT

--- a/tests/test_workflow_conflicts_resume.py
+++ b/tests/test_workflow_conflicts_resume.py
@@ -341,7 +341,7 @@ class ResolvingConflictAwaitingHumanResumeTest(
         self.assertNotIn((200, "validating"), gh.label_history)
         self.assertTrue(state.get("awaiting_human"))
 
-    def test_agent_silent_bare_continue_retries_without_literal_command(
+    def test_silent_bare_continue_retries_without_literal(
         self,
     ) -> None:
         # `/orchestrator continue` on a session-failure rebase park is an

--- a/tests/test_workflow_decomposition_cleanup.py
+++ b/tests/test_workflow_decomposition_cleanup.py
@@ -83,7 +83,7 @@ class DecomposingDriftBeforeHalfFinishedRecoveryTest(
     manifest. The drift check must run FIRST so the manifest gets
     re-derived against the new body."""
 
-    def test_drift_with_children_clears_manifest_and_re_runs_decomposer(
+    def test_children_clear_manifest_and_rerun_decomposer(
         self,
     ) -> None:
         # Simulate the recovery shape: parent label is still

--- a/tests/test_workflow_decomposition_decomposing.py
+++ b/tests/test_workflow_decomposition_decomposing.py
@@ -608,7 +608,7 @@ class HandleDecomposingTest(unittest.TestCase, _PatchedWorkflowMixin):
         ))
         self.assertEqual(gh.created_child_issues, [])
 
-    def test_decompose_off_ratchets_last_action_past_decomposing_comments(
+    def test_decompose_off_ratchets_past_stage_comments(
         self,
     ) -> None:
         # When DECOMPOSE flips off mid-flight, decomposing-era human
@@ -1242,7 +1242,7 @@ class DecomposerRunUsageAccumulationTest(
         self.assertNotIn("issue_total_tokens", state)
         self.assertFalse(state.get("awaiting_human"))
 
-    def test_interrupted_but_dirty_run_parks_without_persisting_counters(
+    def test_dirty_interruption_parks_without_counters(
         self,
     ) -> None:
         # An interrupted decomposer that nonetheless left changes in the

--- a/tests/test_workflow_documenting.py
+++ b/tests/test_workflow_documenting.py
@@ -1016,18 +1016,18 @@ class HandleDocumentingInterruptedTest(
         self.assertEqual(mocks[RUN_AGENT].call_count, 1)
         self.assertEqual(gh.write_state_calls, before_writes)
         self.assertNotIn((202, IN_REVIEW), gh.label_history)
-        state = gh.pinned_data(202)
-        self.assertFalse(state.get(AWAITING_HUMAN))
-        self.assertNotIn(DOCS_VERDICT, state)
+        pinned_state = gh.pinned_data(202)
+        self.assertFalse(pinned_state.get(AWAITING_HUMAN))
+        self.assertNotIn(DOCS_VERDICT, pinned_state)
         # The pre-spawn `docs_checked_sha=before_sha` write was discarded.
-        self.assertNotIn(DOCS_CHECKED_SHA, state)
+        self.assertNotIn(DOCS_CHECKED_SHA, pinned_state)
         self.assertEqual(gh.posted_pr_comments, [])
         self.assertFalse(any(
             "agent needs your input" in body or "timed out" in body
             for _, body in gh.posted_comments
         ))
 
-    def test_awaiting_human_resume_interrupted_does_not_consume_reply(
+    def test_awaiting_human_resume_keeps_reply(
         self,
     ) -> None:
         gh = FakeGitHubClient()
@@ -1103,7 +1103,7 @@ class HandleDocumentingParkedSilenceTest(
         gh.seed_state(self.ISSUE, **defaults)
         return gh, issue
 
-    def test_parked_with_no_new_comments_short_circuits_before_fetch(
+    def test_no_new_comments_short_circuits_before_fetch(
         self,
     ) -> None:
         gh, issue = self._seeded(park_reason=PARK_AGENT_QUESTION)
@@ -1124,7 +1124,7 @@ class HandleDocumentingParkedSilenceTest(
         self.assertEqual(gh.posted_pr_comments, [])
         self.assertEqual(gh.write_state_calls, 0)
 
-    def test_parked_with_no_new_comments_does_not_repark_on_fetch_fail(
+    def test_no_new_comments_does_not_repark_on_fetch_fail(
         self,
     ) -> None:
         # If the fetch would have failed on this tick, the parked
@@ -1149,7 +1149,7 @@ class HandleDocumentingParkedSilenceTest(
             gh.pinned_data(self.ISSUE).get(PARK_REASON), PARK_AGENT_QUESTION,
         )
 
-    def test_parked_with_no_new_comments_does_not_repark_on_diverged(
+    def test_no_new_comments_does_not_repark_on_diverged(
         self,
     ) -> None:
         # Same shape for a behind-remote tick.
@@ -1258,9 +1258,9 @@ class HandleDocumentingDriftTest(
         mocks[RUN_AGENT].assert_not_called()
         mocks[PUSH_BRANCH].assert_not_called()
         # Hash updated; notice posted; relabel to validating.
-        state = gh.pinned_data(self.ISSUE)
+        pinned_state = gh.pinned_data(self.ISSUE)
         self.assertNotEqual(
-            state.get("user_content_hash"),
+            pinned_state.get("user_content_hash"),
             "stale-hash-from-original-body",
         )
         self.assertTrue(any(
@@ -1269,9 +1269,9 @@ class HandleDocumentingDriftTest(
         ))
         self.assertIn((self.ISSUE, VALIDATING), gh.label_history)
         self.assertNotIn((self.ISSUE, IN_REVIEW), gh.label_history)
-        self.assertEqual(state.get(REVIEW_ROUND), 0)
+        self.assertEqual(pinned_state.get(REVIEW_ROUND), 0)
 
-    def test_body_edit_with_recovered_commit_still_relabels_without_push(
+    def test_body_edit_recovered_commit_relabels_without_push(
         self,
     ) -> None:
         # A prior final-docs tick committed docs and parked before
@@ -1301,8 +1301,8 @@ class HandleDocumentingDriftTest(
             "issue body changed" in body
             for _, body in gh.posted_comments
         ))
-        state = gh.pinned_data(self.ISSUE)
-        self.assertEqual(state.get(REVIEW_ROUND), 0)
+        pinned_state = gh.pinned_data(self.ISSUE)
+        self.assertEqual(pinned_state.get(REVIEW_ROUND), 0)
 
     def test_body_edit_resets_unpushed_local_docs_commit(self) -> None:
         # Regression: drift mid-final-docs-hop must discard any
@@ -1368,8 +1368,8 @@ class HandleDocumentingDriftTest(
         # Drift fetch was attempted before the probe + reset.
         mocks["_authed_fetch"].assert_called()
 
-        state = gh.pinned_data(self.ISSUE)
-        self.assertEqual(state.get(REVIEW_ROUND), 0)
+        pinned_state = gh.pinned_data(self.ISSUE)
+        self.assertEqual(pinned_state.get(REVIEW_ROUND), 0)
 
     def test_body_edit_resets_dirty_worktree_with_no_local_commits(
         self,
@@ -2001,7 +2001,7 @@ class HandleDocumentingFinalDocsHandoffTest(
         mocks[PUSH_BRANCH].assert_called_once()
         self.assertIn((self.ISSUE, IN_REVIEW), gh.label_history)
 
-    def test_user_content_drift_relabels_to_validating_without_spawn(
+    def test_drift_relabels_to_validating_without_spawn(
         self,
     ) -> None:
         # A human body edit during the final-docs hop must reset
@@ -2033,7 +2033,7 @@ class HandleDocumentingFinalDocsHandoffTest(
         state = gh.pinned_data(self.ISSUE)
         self.assertEqual(state.get(REVIEW_ROUND), 0)
 
-    def test_resume_consumed_reply_does_not_replay_as_in_review_feedback(
+    def test_consumed_reply_not_replayed_as_feedback(
         self,
     ) -> None:
         # Lifecycle: validating approves at SHA `approvedSha` and seeds
@@ -2102,10 +2102,10 @@ class HandleDocumentingFinalDocsHandoffTest(
         )
 
         self.assertIn((709, IN_REVIEW), gh.label_history)
-        state = gh.pinned_data(709)
-        self.assertEqual(state.get(LAST_ACTION_COMMENT_ID), 1100)
+        pinned_state = gh.pinned_data(709)
+        self.assertEqual(pinned_state.get(LAST_ACTION_COMMENT_ID), 1100)
         self.assertGreaterEqual(
-            state.get("pr_last_comment_id"), 1100,
+            pinned_state.get("pr_last_comment_id"), 1100,
             "pr_last_comment_id must ratchet past the consumed human "
             "issue-thread reply on the final-docs handoff so the next "
             "in_review tick does not replay it as fresh PR feedback",

--- a/tests/test_workflow_documenting_routing.py
+++ b/tests/test_workflow_documenting_routing.py
@@ -42,7 +42,7 @@ class DocumentingLabelRoutingTest(unittest.TestCase):
         names = [name for name, _, _ in WORKFLOW_LABEL_SPECS]
         self.assertIn("documenting", names)
 
-    def test_documenting_label_sits_between_validating_and_in_review(
+    def test_label_sits_between_validating_and_in_review(
         self,
     ) -> None:
         # The happy-path lifecycle is implementing -> validating ->
@@ -120,7 +120,7 @@ class DocumentingLabelRoutingTest(unittest.TestCase):
         # leaves the operator in control of the next move.
         self.assertEqual(gh.label_history, [])
 
-    def test_documenting_missing_pr_number_is_idempotent_when_parked(
+    def test_missing_pr_number_is_idempotent_when_parked(
         self,
     ) -> None:
         # A second tick on an already-parked documenting issue (still

--- a/tests/test_workflow_drift.py
+++ b/tests/test_workflow_drift.py
@@ -77,7 +77,7 @@ class ComputeUserContentHashTest(unittest.TestCase):
             workflow._compute_user_content_hash(issue_with_pinned, set()),
         )
 
-    def test_bare_orchestrator_continue_excluded_but_guidance_counts(
+    def test_bare_continue_excluded_but_guidance_counts(
         self,
     ) -> None:
         # A bare `/orchestrator continue` is an operator command, not
@@ -217,7 +217,7 @@ class DetectUserContentChangeTest(unittest.TestCase):
         self.assertEqual(gh.write_state_calls, before)
         self.assertEqual(state.get("user_content_hash"), prior)
 
-    def test_legacy_baseline_with_bare_continue_absorbs_without_drift(
+    def test_legacy_bare_continue_baseline_absorbs(
         self,
     ) -> None:
         # A baseline written by the pre-#729 algorithm counted a bare
@@ -558,7 +558,7 @@ class DriftMarksCommentsConsumedTest(
             int(state.get("last_action_comment_id")), 5000,
         )
 
-    def test_in_review_fresh_human_comment_routes_to_fixing_not_drift(
+    def test_in_review_human_comment_routes_to_fixing(
         self,
     ) -> None:
         # Regression for the reviewer's bug: a fresh issue-thread human
@@ -616,7 +616,7 @@ class DriftMarksCommentsConsumedTest(
         # consumed feedback has been fed to the dev.
         self.assertEqual(state.get("pr_last_comment_id"), 0)
 
-    def test_implementing_drift_bumps_last_action_past_human_comment(
+    def test_implementing_bumps_last_action_past_comment(
         self,
     ) -> None:
         gh = FakeGitHubClient()
@@ -708,7 +708,7 @@ class OrchCommentMarkerSurvivesIdCapTest(unittest.TestCase):
     bot comment in the hash and trigger false drift each tick. The body
     marker (`_ORCH_COMMENT_MARKER`) must keep the hash stable."""
 
-    def test_marker_excludes_orchestrator_comment_even_when_id_unknown(
+    def test_excludes_orchestrator_comment_when_id_unknown(
         self,
     ) -> None:
         # Simulate an orchestrator comment whose id has been evicted

--- a/tests/test_workflow_fixing.py
+++ b/tests/test_workflow_fixing.py
@@ -1888,7 +1888,7 @@ class HandleFixingTest(unittest.TestCase, _PatchedWorkflowMixin):
             int(data.get("silent_park_count") or 0), 1,
         )
 
-    def test_session_limit_message_parks_retryable_then_continue_retries(
+    def test_session_limit_parks_then_continue_retries(
         self,
     ) -> None:
         # #705 regression, #699 shape: a Claude session-limit notice arrives
@@ -1918,17 +1918,17 @@ class HandleFixingTest(unittest.TestCase, _PatchedWorkflowMixin):
                 head_shas=(SHA_BEFORE, SHA_BEFORE),
             )
 
-        data = gh.pinned_data(ISSUE)
-        self.assertTrue(data.get(AWAITING_HUMAN))
+        pinned_state = gh.pinned_data(ISSUE)
+        self.assertTrue(pinned_state.get(AWAITING_HUMAN))
         # The retryable reason -- NOT None -- is the crux of the fix.
-        self.assertEqual(data.get(PARK_REASON), PARK_AGENT_SILENT)
+        self.assertEqual(pinned_state.get(PARK_REASON), PARK_AGENT_SILENT)
         self.assertNotIn((ISSUE, VALIDATING), gh.label_history)
         # The HITL note names the limit + retry command instead of
         # impersonating an "agent needs your input" question.
-        joined = "\n".join(b for _, b in gh.posted_comments)
-        self.assertIn("session/usage limit", joined)
-        self.assertIn("/orchestrator continue", joined)
-        self.assertNotIn("needs your input to proceed", joined)
+        hitl_comment_text = "\n".join(body for _, body in gh.posted_comments)
+        self.assertIn("session/usage limit", hitl_comment_text)
+        self.assertIn("/orchestrator continue", hitl_comment_text)
+        self.assertNotIn("needs your input to proceed", hitl_comment_text)
 
         # --- Tick 2: `/orchestrator continue` retries, does not refuse ----
         issue.comments.append(
@@ -1949,9 +1949,9 @@ class HandleFixingTest(unittest.TestCase, _PatchedWorkflowMixin):
         # dropped (fresh spawn, no resume id) and the PRESERVED feedback batch
         # is replayed rather than the bare command text.
         mocks[RUN_AGENT].assert_called_once()
-        call = mocks[RUN_AGENT].call_args
-        self.assertIsNone(call.kwargs.get("resume_session_id"))
-        self.assertIn("please fix the flaky test", call.args[1])
+        agent_call = mocks[RUN_AGENT].call_args
+        self.assertIsNone(agent_call.kwargs.get("resume_session_id"))
+        self.assertIn("please fix the flaky test", agent_call.args[1])
         self.assertFalse(any(
             "needs your actual guidance" in body
             for _, body in gh.posted_comments
@@ -2111,9 +2111,9 @@ class ReconstructPendingFixBatchTest(unittest.TestCase):
             pending_fix_review_summary_ids=BATCH_SUMMARY_IDS,
             pending_fix_review_summary_max_id=BATCH_SUMMARY_ID,
         )
-        state = gh.read_pinned_state(issue)
+        pinned_state = gh.read_pinned_state(issue)
 
-        batch = _reconstruct_pending_fix_batch(gh, issue, pr, state)
+        batch = _reconstruct_pending_fix_batch(gh, issue, pr, pinned_state)
 
         # Exact batch: issue-space, then inline, then summaries; each surface
         # sorted by id.
@@ -2134,7 +2134,7 @@ class ReconstructPendingFixBatchTest(unittest.TestCase):
                      "inline ask two", "please address"):
             self.assertIn(body, prompt)
 
-    def test_legacy_max_id_only_reconstructs_conservative_single_item(self) -> None:
+    def test_legacy_max_id_reconstructs_single_item(self) -> None:
         gh, issue, pr = self._pr_with_feedback()
         # An issue parked before the id lists existed: only the max_id
         # bookmarks survive. Reconstruction must include ONLY the max-id

--- a/tests/test_workflow_fixing_paused.py
+++ b/tests/test_workflow_fixing_paused.py
@@ -82,7 +82,7 @@ class FixingLivePauseTest(unittest.TestCase, _PatchedWorkflowMixin):
         )
         return issue
 
-    def test_paused_during_resume_blocks_publish_relabel_and_watermark(
+    def test_resume_blocks_publish_relabel_and_watermark(
         self,
     ) -> None:
         # The handler's `issue` snapshot carries no `paused`; the operator

--- a/tests/test_workflow_fixing_routing.py
+++ b/tests/test_workflow_fixing_routing.py
@@ -60,7 +60,7 @@ class FixingLabelRoutingTest(unittest.TestCase, _PatchedWorkflowMixin):
         names = [name for name, _, _ in WORKFLOW_LABEL_SPECS]
         self.assertIn("fixing", names)
 
-    def test_fixing_label_sits_between_in_review_and_resolving_conflict(
+    def test_label_sits_between_in_review_and_resolving_conflict(
         self,
     ) -> None:
         # Lifecycle order matters: `fixing` is the next stage after
@@ -139,7 +139,7 @@ class FixingLabelRoutingTest(unittest.TestCase, _PatchedWorkflowMixin):
         # the operator in control of the next move.
         self.assertEqual(gh.label_history, [])
 
-    def test_fixing_without_pr_number_is_idempotent_when_already_parked(
+    def test_missing_pr_number_is_idempotent_when_parked(
         self,
     ) -> None:
         # A second tick on an already-parked no-PR fixing issue must

--- a/tests/test_workflow_implementing_drift.py
+++ b/tests/test_workflow_implementing_drift.py
@@ -467,7 +467,7 @@ class ImplementingContinueCommandTest(
         )
         return gh, issue
 
-    def test_agent_silent_bare_continue_retries_without_drift_notice(
+    def test_silent_bare_continue_retries_without_drift_notice(
         self,
     ) -> None:
         # The #720 shape: parked `agent_silent`, stale watermark, human posts
@@ -506,7 +506,7 @@ class ImplementingContinueCommandTest(
         self.assertEqual(len(gh.opened_prs), 1)
         self.assertEqual(gh.pinned_data(730).get("last_action_comment_id"), 9000)
 
-    def test_bare_continue_on_question_park_refuses_and_does_not_loop(
+    def test_question_park_bare_continue_refuses(
         self,
     ) -> None:
         # A real agent question parks with `park_reason=None`. A content-free

--- a/tests/test_workflow_implementing_fresh.py
+++ b/tests/test_workflow_implementing_fresh.py
@@ -255,7 +255,7 @@ class HandleImplementingInterruptedTest(unittest.TestCase, _PatchedWorkflowMixin
     park, post a HITL question, consume `awaiting_human`, advance the
     action watermark, or open a PR off a partial result."""
 
-    def test_awaiting_human_resume_interrupted_leaves_state_untouched(
+    def test_awaiting_human_resume_leaves_state(
         self,
     ) -> None:
         gh = FakeGitHubClient()

--- a/tests/test_workflow_implementing_full_spec.py
+++ b/tests/test_workflow_implementing_full_spec.py
@@ -651,7 +651,7 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
             "stored codex args must survive across the config flip",
         )
 
-    def test_decomposer_spec_pinned_when_spawn_returns_no_session_id(self) -> None:
+    def test_decomposer_spec_pinned_without_session_id(self) -> None:
         # Same reviewer concern, decomposer side: a fresh decomposer
         # that emits a manifest without surfacing a session id (or
         # parks awaiting human after a question) must still pin

--- a/tests/test_workflow_implementing_paused.py
+++ b/tests/test_workflow_implementing_paused.py
@@ -42,7 +42,7 @@ def _paused_view(number: int) -> object:
 
 
 class ImplementingLivePauseFreshSpawnTest(unittest.TestCase, _PatchedWorkflowMixin):
-    def test_paused_during_run_blocks_pr_and_relabel_reading_fresh_issue(
+    def test_run_blocks_pr_and_relabel_from_fresh_issue(
         self,
     ) -> None:
         # The handler's `issue` snapshot carries no `paused`; the operator
@@ -79,13 +79,13 @@ class ImplementingLivePauseFreshSpawnTest(unittest.TestCase, _PatchedWorkflowMix
         # Durable state untouched: the fresh session id is discarded and no
         # pinned-state advancement is written, so the next tick resumes intact.
         self.assertEqual(gh.write_state_calls, before_writes)
-        state = gh.pinned_data(1)
-        self.assertNotIn("dev_session_id", state)
-        self.assertFalse(state.get("awaiting_human"))
+        pinned_state = gh.pinned_data(1)
+        self.assertNotIn("dev_session_id", pinned_state)
+        self.assertFalse(pinned_state.get("awaiting_human"))
 
 
 class ImplementingLivePauseResumeTest(unittest.TestCase, _PatchedWorkflowMixin):
-    def test_paused_during_resume_skips_poisoned_retry_and_is_not_refetched(
+    def test_poisoned_retry_is_skipped_without_refetch(
         self,
     ) -> None:
         # Awaiting-human resume whose first result is a poisoned Claude session
@@ -117,9 +117,9 @@ class ImplementingLivePauseResumeTest(unittest.TestCase, _PatchedWorkflowMixin):
         )
         before_writes = gh.write_state_calls
 
-        unpaused = make_issue(720, label="implementing")
+        unpaused_view = make_issue(720, label="implementing")
         get_issue_mock = MagicMock(
-            side_effect=[_paused_view(720), unpaused, unpaused],
+            side_effect=[_paused_view(720), unpaused_view, unpaused_view],
         )
         with patch.object(gh, "get_issue", get_issue_mock):
             mocks = self._run(
@@ -141,10 +141,10 @@ class ImplementingLivePauseResumeTest(unittest.TestCase, _PatchedWorkflowMixin):
         # No pinned-state advancement: the session id, park flag, and action
         # watermark all stay exactly as the prior tick left them.
         self.assertEqual(gh.write_state_calls, before_writes)
-        state = gh.pinned_data(720)
-        self.assertEqual(state.get("dev_session_id"), "sess-old")
-        self.assertTrue(state.get("awaiting_human"))
-        self.assertEqual(state.get("last_action_comment_id"), 900)
+        pinned_state = gh.pinned_data(720)
+        self.assertEqual(pinned_state.get("dev_session_id"), "sess-old")
+        self.assertTrue(pinned_state.get("awaiting_human"))
+        self.assertEqual(pinned_state.get("last_action_comment_id"), 900)
 
 
 class ImplementingLivePauseRecoveryTest(unittest.TestCase, _PatchedWorkflowMixin):

--- a/tests/test_workflow_implementing_retry.py
+++ b/tests/test_workflow_implementing_retry.py
@@ -1036,7 +1036,7 @@ class ProactiveSessionRotationTest(unittest.TestCase, _PatchedWorkflowMixin):
             "the new session starts its resume budget from zero",
         )
 
-    def test_entry_without_session_id_empty_result_keeps_session_clear(self) -> None:
+    def test_missing_session_empty_result_keeps_clear(self) -> None:
         # The recovery spawn ALSO returns no session id (another hiccup): the
         # session stays unpinned so the next tick fresh-spawns again rather
         # than resuming a phantom id, and the resume budget is not charged.

--- a/tests/test_workflow_in_review_fresh_feedback.py
+++ b/tests/test_workflow_in_review_fresh_feedback.py
@@ -60,7 +60,7 @@ class InReviewRoutesFreshFeedbackToFixingTest(
                 mergeable=True, check_state="success",
             )
         gh.add_pr(pr)
-        state = dict(
+        seed_state = dict(
             pr_number=pr.number,
             branch=self.BRANCH,
             dev_agent="claude",
@@ -70,11 +70,11 @@ class InReviewRoutesFreshFeedbackToFixingTest(
             pr_last_review_summary_id=0,
         )
         if extra_state:
-            state.update(extra_state)
-        gh.seed_state(880, **state)
+            seed_state.update(extra_state)
+        gh.seed_state(880, **seed_state)
         return gh, issue, pr
 
-    def test_fresh_pr_conversation_comment_flips_to_fixing_no_dev_spawn(
+    def test_pr_conversation_comment_routes_without_dev_spawn(
         self,
     ) -> None:
         # The headline contract: a single fresh PR conversation comment
@@ -115,12 +115,12 @@ class InReviewRoutesFreshFeedbackToFixingTest(
         self.assertIn((880, "fixing"), gh.label_history)
         # Pending-fix metadata records the triggering comment id and an
         # ISO timestamp so the fixing handler has a bookmark.
-        state = gh.pinned_data(880)
-        self.assertEqual(state.get("pending_fix_issue_max_id"), 3000)
-        self.assertIn("pending_fix_at", state)
+        pinned_state = gh.pinned_data(880)
+        self.assertEqual(pinned_state.get("pending_fix_issue_max_id"), 3000)
+        self.assertIn("pending_fix_at", pinned_state)
         # Watermark stays put so the fixing handler can rescan and reach
         # the triggering comment on its next tick.
-        self.assertEqual(state.get("pr_last_comment_id"), 1999)
+        self.assertEqual(pinned_state.get("pr_last_comment_id"), 1999)
 
     def test_route_persists_full_batch_id_lists_all_surfaces(self) -> None:
         # The route must persist the FULL per-surface id lists (not just the
@@ -241,7 +241,7 @@ class InReviewRoutesFreshFeedbackToFixingTest(
         self.assertNotIn((880, "fixing"), gh.label_history)
         self.assertIn("merged_at", gh.pinned_data(880))
 
-    def test_fresh_issue_thread_comment_routes_to_fixing_despite_drift_hash(
+    def test_issue_thread_comment_wins_over_drift_hash(
         self,
     ) -> None:
         # Regression test for the reviewer's reproducer: a normal fresh
@@ -297,14 +297,14 @@ class InReviewRoutesFreshFeedbackToFixingTest(
         # The issue routed to `fixing` and recorded the triggering
         # bookmark.
         self.assertIn((1660, "fixing"), gh.label_history)
-        state = gh.pinned_data(1660)
-        self.assertEqual(state.get("pending_fix_issue_max_id"), 7000)
-        self.assertIn("pending_fix_at", state)
+        pinned_state = gh.pinned_data(1660)
+        self.assertEqual(pinned_state.get("pending_fix_issue_max_id"), 7000)
+        self.assertIn("pending_fix_at", pinned_state)
         # And the hash was refreshed so the drift path does NOT
         # double-fire on the same comment changes after the fixing
         # handler (or an operator) bounces the issue back to `in_review`.
         self.assertNotEqual(
-            state.get("user_content_hash"),
+            pinned_state.get("user_content_hash"),
             "stale-hash-from-before-the-human-comment",
         )
 

--- a/tests/test_workflow_list_pollable.py
+++ b/tests/test_workflow_list_pollable.py
@@ -27,7 +27,7 @@ class ListPollableIssuesTest(unittest.TestCase):
         out = list(gh.list_pollable_issues())
         self.assertEqual({issue.number for issue in out}, {1, 2})
 
-    def test_includes_closed_in_review_for_external_merge_finalization(self) -> None:
+    def test_includes_closed_in_review_for_merge_finalization(self) -> None:
         gh = FakeGitHubClient()
         open_issue = make_issue(1, label="implementing")
         closed_in_review = make_issue(7, label="in_review")

--- a/tests/test_workflow_question.py
+++ b/tests/test_workflow_question.py
@@ -240,7 +240,7 @@ class HandleQuestionAwaitingHumanResumeTest(
         self.assertEqual(gh.label_history, [])
         self.assertEqual(gh.opened_prs, [])
 
-    def test_new_comment_resumes_locked_session_and_advances_watermark(
+    def test_new_comment_resumes_locked_session_and_watermark(
         self,
     ) -> None:
         gh = FakeGitHubClient()
@@ -770,7 +770,7 @@ class HandleQuestionUnsafeParkStabilityTest(
             branch=_issue_branch(304),
         )
 
-    def test_resume_after_unsafe_park_with_re_park_preserves_worktree(
+    def test_repark_preserves_worktree(
         self,
     ) -> None:
         # When the operator replies without resetting (and the
@@ -800,8 +800,8 @@ class HandleQuestionUnsafeParkStabilityTest(
             has_new_commits=True,
         )
         mocks["run_agent"].assert_called_once()
-        data = gh.pinned_data(305)
-        self.assertEqual(data["park_reason"], "question_commits")
+        pinned_state = gh.pinned_data(305)
+        self.assertEqual(pinned_state["park_reason"], "question_commits")
         mocks["_cleanup_question_worktree"].assert_not_called()
 
 
@@ -951,7 +951,7 @@ class QuestionRelabelToImplementingTest(
         self.assertIn("question_commits", last)
         self.assertIn("reset the worktree", last.lower())
 
-    def test_relabel_with_missing_worktree_but_stale_branch_refuses_to_push(
+    def test_missing_worktree_stale_branch_refuses_push(
         self,
     ) -> None:
         # Regression: the worktree directory is gone (a prior safe
@@ -1004,9 +1004,9 @@ class QuestionRelabelToImplementingTest(
         mocks["_push_branch"].assert_not_called()
         self.assertEqual(gh.opened_prs, [])
         # State carries the unsafe-relabel park reason.
-        data = gh.pinned_data(86)
-        self.assertTrue(data["awaiting_human"])
-        self.assertEqual(data["park_reason"], "question_unsafe_relabel")
+        pinned_state = gh.pinned_data(86)
+        self.assertTrue(pinned_state["awaiting_human"])
+        self.assertEqual(pinned_state["park_reason"], "question_unsafe_relabel")
         # Message tells the operator about the branch and how to
         # reset it.
         last = gh.posted_comments[-1][1]
@@ -1801,7 +1801,7 @@ class HandleQuestionResumeTrustFilterTest(
         self.assertNotIn(self._MALICIOUS_URL, prompt)
         self.assertIn("please also handle empty input", prompt)
 
-    def test_consume_new_human_replies_advances_watermark_to_trusted_only(
+    def test_reply_watermark_advances_to_trusted_only(
         self,
     ) -> None:
         # Direct helper check: the consumed watermark advances only past the
@@ -1821,11 +1821,11 @@ class HandleQuestionResumeTrustFilterTest(
             user=FakeUser("mallory"),
         ))
         self._seed_live_session(gh, issue)
-        state = gh.read_pinned_state(issue)
+        pinned_state = gh.read_pinned_state(issue)
         with patch.object(config, "ALLOWED_ISSUE_AUTHORS", ("geserdugarov",)):
-            trusted = _consume_new_human_replies(gh, issue, state)
-        self.assertEqual([c.id for c in trusted], [TRUSTED_REPLY_ID])
-        self.assertEqual(state.get("last_action_comment_id"), TRUSTED_REPLY_ID)
+            trusted_comments = _consume_new_human_replies(gh, issue, pinned_state)
+        self.assertEqual([c.id for c in trusted_comments], [TRUSTED_REPLY_ID])
+        self.assertEqual(pinned_state.get("last_action_comment_id"), TRUSTED_REPLY_ID)
 
     def test_all_outsider_batch_does_not_resume(self) -> None:
         gh = FakeGitHubClient()

--- a/tests/test_workflow_tick_parallel.py
+++ b/tests/test_workflow_tick_parallel.py
@@ -582,7 +582,7 @@ class TickPerRepoParallelLimitTest(unittest.TestCase):
         # the caller thread).
         self.assertEqual(sorted(fanout_done), [10, 11, 12])
 
-    def test_concurrent_decomposing_and_blocked_do_not_race_child_state(
+    def test_decomposing_and_blocked_do_not_race_child_state(
         self,
     ) -> None:
         # Regression for the reproducer the reviewer flagged: a parent

--- a/tests/test_workflow_usage_accumulator.py
+++ b/tests/test_workflow_usage_accumulator.py
@@ -68,29 +68,29 @@ class AccumulateIssueUsageHelperTest(unittest.TestCase):
         )
         self.assertEqual(state.get("issue_total_tokens"), 140)
 
-    def test_accumulates_across_runs_deduping_sources_and_skipping_none_cost(
+    def test_multiple_runs_dedupe_sources_skip_none_cost(
         self,
     ) -> None:
-        state = PinnedState()
+        usage_state = PinnedState()
         # A priced run, an unpriced run (cost None), and a second priced run
         # sharing the first's source.
         workflow._accumulate_issue_usage(
-            state, _usage(input_tokens=10, cost_usd=1.0, cost_source="estimated"),
+            usage_state, _usage(input_tokens=10, cost_usd=1.0, cost_source="estimated"),
         )
         workflow._accumulate_issue_usage(
-            state,
+            usage_state,
             _usage(input_tokens=5, cost_usd=None, cost_source="unknown-price"),
         )
         workflow._accumulate_issue_usage(
-            state, _usage(output_tokens=7, cost_usd=2.0, cost_source="estimated"),
+            usage_state, _usage(output_tokens=7, cost_usd=2.0, cost_source="estimated"),
         )
-        self.assertEqual(state.get("issue_agent_runs"), 3)
-        self.assertEqual(state.get("issue_total_tokens"), 22)
+        self.assertEqual(usage_state.get("issue_agent_runs"), 3)
+        self.assertEqual(usage_state.get("issue_total_tokens"), 22)
         # None-cost run contributes nothing to the dollar total.
-        self.assertEqual(state.get("issue_total_cost_usd"), 3.0)
+        self.assertEqual(usage_state.get("issue_total_cost_usd"), 3.0)
         # Distinct sources, sorted, for the terminal verdict's (est.)/unknown.
         self.assertEqual(
-            state.get("issue_cost_sources"), ["estimated", "unknown-price"],
+            usage_state.get("issue_cost_sources"), ["estimated", "unknown-price"],
         )
 
     def test_none_usage_is_noop(self) -> None:

--- a/tests/test_workflow_validating_paused.py
+++ b/tests/test_workflow_validating_paused.py
@@ -98,7 +98,7 @@ class ValidatingLivePauseDriftResumeTest(
 class ValidatingLivePauseAwaitingHumanTest(
     unittest.TestCase, _PatchedWorkflowMixin
 ):
-    def test_pause_during_awaiting_human_resume_skips_fix_disposition(
+    def test_resume_skips_fix_disposition(
         self,
     ) -> None:
         # Parked on a question (dev-side, non-transient), a human replied and

--- a/tests/test_workflow_validating_review.py
+++ b/tests/test_workflow_validating_review.py
@@ -236,7 +236,7 @@ class HandleValidatingFreshReviewTest(unittest.TestCase, _PatchedWorkflowMixin):
         self.assertTrue(state.get("awaiting_human"))
         self.assertIsNone(state.get("park_reason"))
 
-    def test_reviewer_empty_message_with_zero_exit_does_not_tag_failed(self) -> None:
+    def test_empty_zero_exit_message_not_failed(self) -> None:
         # Defensive: empty last_message but exit_code == 0 is not a
         # crash -- the agent reported success without producing output.
         # Don't tag transient; a clean exit with no text needs human
@@ -520,7 +520,7 @@ class HandleValidatingFixLoopEdgeCasesTest(unittest.TestCase, _PatchedWorkflowMi
 
 
 class HandleValidatingAwaitingHumanResumeTest(unittest.TestCase, _PatchedWorkflowMixin):
-    def test_human_reply_resumes_dev_bumps_round_no_reviewer_this_tick(self) -> None:
+    def test_human_reply_bumps_round_without_reviewer(self) -> None:
         gh = FakeGitHubClient()
         issue = make_issue(7, label="validating")
         issue.comments.append(
@@ -638,7 +638,7 @@ class HandleValidatingContinueCommandTest(
         )
         return gh, issue
 
-    def test_agent_silent_bare_continue_retries_without_literal_command(
+    def test_silent_bare_continue_retries_without_literal(
         self,
     ) -> None:
         gh, issue = self._seed(7, park_reason="agent_silent")
@@ -1063,18 +1063,18 @@ class ValidatingDevFixInterruptedHelperTest(unittest.TestCase):
         gh.seed_state(7, **state)
         return gh, gh.read_pinned_state(issue), issue
 
-    def test_handle_dev_fix_result_interrupted_returns_false_no_side_effects(
+    def test_result_returns_false_without_side_effects(
         self,
     ) -> None:
         gh, state, issue = self._seeded()
-        result = _agent(
+        agent_result = _agent(
             session_id="dev-sess",
             interrupted=True,
             last_message="partial output before the shutdown SIGTERM",
         )
 
         pushed = workflow._handle_dev_fix_result(
-            gh, _TEST_SPEC, issue, state, Path("/tmp/wt"), result, "sha-before",
+            gh, _TEST_SPEC, issue, state, Path("/tmp/wt"), agent_result, "sha-before",
         )
 
         self.assertFalse(pushed)
@@ -1087,18 +1087,18 @@ class ValidatingDevFixInterruptedHelperTest(unittest.TestCase):
         self.assertEqual(gh.posted_comments, [])
         self.assertEqual(gh.posted_pr_comments, [])
 
-    def test_post_user_content_change_result_interrupted_returns_parked(
+    def test_user_content_change_result_returns_parked(
         self,
     ) -> None:
         gh, state, issue = self._seeded()
-        result = _agent(
+        agent_result = _agent(
             session_id="dev-sess",
             interrupted=True,
             last_message="ACK: looks fine",  # partial; must NOT be honored
         )
 
         outcome = workflow._post_user_content_change_result(
-            gh, _TEST_SPEC, issue, state, Path("/tmp/wt"), result, "sha-before",
+            gh, _TEST_SPEC, issue, state, Path("/tmp/wt"), agent_result, "sha-before",
         )
 
         # Reported parked, but WITHOUT swallowing the partial message as an
@@ -1119,7 +1119,7 @@ class ValidatingInterruptedResumeHandlerTest(
     consumption pre-staged before the spawn, so the next tick retries the
     resume rather than treating the input as already handled."""
 
-    def test_user_content_change_interrupted_resume_does_not_persist(
+    def test_user_content_change_resume_does_not_persist(
         self,
     ) -> None:
         gh = FakeGitHubClient()
@@ -1280,7 +1280,7 @@ class HandleValidatingResumeTrustFilterTest(
             "review-cap reset" in body for _, body in gh.posted_comments
         ))
 
-    def test_trusted_add_review_rounds_command_honored_under_allowlist(
+    def test_add_review_rounds_command_honored(
         self,
     ) -> None:
         gh = FakeGitHubClient()

--- a/tests/test_workflow_validating_squash.py
+++ b/tests/test_workflow_validating_squash.py
@@ -85,7 +85,7 @@ class SquashOnApprovalTest(unittest.TestCase, _PatchedWorkflowMixin):
         )
         return gh, issue, pr
 
-    def test_approval_squashes_and_lands_in_review_without_re_review(
+    def test_lands_in_review_without_re_review(
         self,
     ) -> None:
         # End-to-end: validating approves, squash + force-push runs (mocked
@@ -364,7 +364,7 @@ class SquashHelperRealGitTest(unittest.TestCase):
         self.assertEqual(body, "fix: typo")
         self.assertNotIn("Squashed commits:", body)
 
-    def test_squash_uses_issue_title_when_no_conventional_first_subject(
+    def test_uses_issue_title_without_conventional_subject(
         self,
     ) -> None:
         # Reset and rebuild the branch with non-conv-commit first subject.

--- a/tests/test_workflow_validating_verify.py
+++ b/tests/test_workflow_validating_verify.py
@@ -417,7 +417,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
         self.assertIn("TAIL", run.output)
         self.assertLessEqual(len(run.output), 4096)
 
-    def test_secret_straddling_truncation_boundary_is_fully_redacted(self) -> None:
+    def test_truncation_boundary_secret_fully_redacted(self) -> None:
         # Regression: `_redact_secrets` does `str.replace(value, "***")`
         # on the full value, so a secret whose bytes straddle the
         # truncation cut would no longer match a post-truncation replace
@@ -493,7 +493,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
         # exposed to the verify command.)
         self.assertNotIn("ghp_ORCHESTRATOR_PAT_SHOULD_NOT_LEAK", run.output)
 
-    def test_write_credential_locators_stripped_from_verify_environment(self) -> None:
+    def test_strips_write_credential_locators_from_env(self) -> None:
         # Issue #213 review: SSH-agent socket, askpass binaries, and
         # `GIT_SSH_COMMAND` are write-credential pointers, not secret-
         # shaped values. Leaving them in the verify shell lets a
@@ -527,7 +527,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
         self.assertNotIn("/tmp/ssh-test/agent.42", run.output)
         self.assertNotIn("/home/op/.ssh/deploy-key", run.output)
 
-    def test_credential_file_locators_stripped_from_verify_environment(self) -> None:
+    def test_strips_credential_file_locators_from_env(self) -> None:
         # Issue #213 review: credential-file LOCATORS (env vars whose
         # value is a path to a file holding the secret) must also be
         # stripped. The verify shell runs as the same OS user as the
@@ -566,7 +566,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
         self.assertNotIn("/etc/secrets/gcp.json", run.output)
         self.assertNotIn("/etc/secrets/aws-creds", run.output)
 
-    def test_production_secret_shapes_stripped_from_verify_environment(self) -> None:
+    def test_strips_production_secret_shapes_from_env(self) -> None:
         # Issue #213: GitHub-token aliases are not the only credential
         # shape that should not be inherited by operator-configured
         # verify shell. Production-secret-shaped variables (suffix or
@@ -647,7 +647,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
         # And the worktree was clean on detection (not the dirty branch).
         self.assertEqual(run.dirty_files, ())
 
-    def test_dirty_attribution_names_responsible_command_and_keeps_output(self) -> None:
+    def test_dirty_attribution_keeps_command_and_output(self) -> None:
         # Regression: previously the dirty check ran once at the end of
         # the loop, so a dirty failure always blamed `commands[-1]` and
         # discarded every command's captured output. The fix checks

--- a/tests/test_workflow_worktree_paths.py
+++ b/tests/test_workflow_worktree_paths.py
@@ -340,7 +340,7 @@ class ResolveBranchNameLegacyMigrationTest(unittest.TestCase):
             "orchestrator/geserdugarov__agent-orchestrator/issue-7",
         )
 
-    def test_pinned_branch_outside_orchestrator_namespace_is_ignored(
+    def test_outside_namespace_pinned_branch_is_ignored(
         self,
     ) -> None:
         # A corrupted / foreign pinned `branch` value must not redirect


### PR DESCRIPTION
Resolves #772 

Implemented the test-name cleanup.

Renamed 66 very long test methods across the test suite, keeping the scenario-specific parts and relying on module/class context for repeated stage/helper wording. Also renamed ambiguous locals in touched tests to domain names like `pinned_state`, `agent_result`, `sync_result`, `reviewer_record`, and `hitl_comment_text`.