### PR TITLE
refactor: split workflow stage decisions

### DIFF
--- a/orchestrator/stages/decomposition.py
+++ b/orchestrator/stages/decomposition.py
@@ -40,6 +40,7 @@ reference that test patches against `workflow.X` could not affect.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from github.Issue import Issue
@@ -50,6 +51,12 @@ from ..comment_trust import filter_trusted
 from ..config import RepoSpec
 from ..state_machine import WorkflowLabel
 from ..github import GitHubClient, PinnedState
+
+
+@dataclass(frozen=True)
+class _DecomposerRunPlan:
+    result: Optional[AgentResult]
+    keep_worktree: bool = False
 
 
 def _read_decomposer_session(
@@ -725,6 +732,38 @@ def _dispatch_decomposer_manifest(
     _finalize_split(gh, issue, state, created, dep_graph, is_umbrella)
 
 
+def _prepare_decomposer_run(
+    gh: GitHubClient,
+    spec: RepoSpec,
+    issue: Issue,
+    state: PinnedState,
+) -> Optional[_DecomposerRunPlan]:
+    # User-content drift FIRST, so it runs BEFORE the half-finished recovery:
+    # otherwise recovery could finalize against a stale manifest when the issue
+    # was edited during a crash window.
+    _reset_decomposing_on_drift(gh, issue, state)
+
+    if _recover_stale_manifest(gh, issue, state):
+        return None
+
+    if _route_disabled_to_implementing(gh, spec, issue, state):
+        return None
+
+    if state.get("awaiting_human"):
+        result = _resume_decomposer_on_human_reply(gh, spec, issue, state)
+        if result is None:
+            # Keep the worktree intact: if a prior tick parked on dirty/commits,
+            # the HITL message asks the operator to inspect and reset it before
+            # resuming, and cleanup here would silently delete that state.
+            return _DecomposerRunPlan(result=None, keep_worktree=True)
+        return _DecomposerRunPlan(result=result)
+
+    result = _spawn_fresh_decomposer(gh, spec, issue, state)
+    if result is None:
+        return None
+    return _DecomposerRunPlan(result=result)
+
+
 def _handle_decomposing(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
     from .. import workflow as _wf
 
@@ -738,31 +777,13 @@ def _handle_decomposing(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
     # `origin/<base>`.
     keep_worktree = False
     try:
-        # User-content drift FIRST, so it runs BEFORE the half-finished
-        # recovery -- otherwise the recovery branch would finalize against a
-        # stale manifest when the issue was edited during a crash window.
-        _reset_decomposing_on_drift(gh, issue, state)
-
-        if _recover_stale_manifest(gh, issue, state):
+        run_plan = _prepare_decomposer_run(gh, spec, issue, state)
+        if run_plan is None:
             return
-
-        if _route_disabled_to_implementing(gh, spec, issue, state):
+        keep_worktree = run_plan.keep_worktree
+        if run_plan.result is None:
             return
-
-        if state.get("awaiting_human"):
-            result = _resume_decomposer_on_human_reply(gh, spec, issue, state)
-            if result is None:
-                # No human reply yet. Keep the worktree intact -- if a
-                # prior tick parked on the dirty/commits reason, the
-                # HITL message explicitly asks the operator to inspect
-                # and reset it before resuming, and cleanup here would
-                # silently delete that state on every subsequent poll.
-                keep_worktree = True
-                return
-        else:
-            result = _spawn_fresh_decomposer(gh, spec, issue, state)
-            if result is None:
-                return
+        result = run_plan.result
 
         if _settle_decomposer_run(gh, issue, state, result):
             return

--- a/orchestrator/stages/fixing.py
+++ b/orchestrator/stages/fixing.py
@@ -146,6 +146,7 @@ patch could not affect.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -156,6 +157,20 @@ from ..comment_trust import filter_trusted
 from ..config import RepoSpec
 from ..state_machine import WorkflowLabel
 from ..github import GitHubClient
+
+
+@dataclass(frozen=True)
+class _FixingFeedback:
+    issue_space: list
+    review_comments: list
+    review_summaries: list
+    all_items: list
+
+
+@dataclass(frozen=True)
+class _ParkedFixingDecision:
+    stop: bool
+    replay_batch: Optional[list] = None
 
 
 def _fixing_preflight(gh: GitHubClient, spec: RepoSpec, issue: Issue, state):
@@ -241,13 +256,14 @@ def _fixing_preflight(gh: GitHubClient, spec: RepoSpec, issue: Issue, state):
     return pr
 
 
-def _rescan_fixing_feedback(gh: GitHubClient, issue: Issue, pr, state) -> tuple:
+def _rescan_fixing_feedback(
+    gh: GitHubClient, issue: Issue, pr, state,
+) -> _FixingFeedback:
     """Rescan the four PR-feedback surfaces for comments past the in_review
     watermarks (NOT the `pending_fix_*` bookmarks -- those stay in pinned
     state as the reconstruction source for `_reconstruct_pending_fix_batch`).
 
-    Returns ``(issue_space_new, review_space_new, review_summary_new,
-    new_feedback)`` where `new_feedback` is the three surfaces concatenated
+    Returns the three per-surface batches plus `all_items`, the concatenated
     in prompt order: issue-space (issue-thread + PR-conversation), then
     inline review comments, then review summaries. Untrusted authors are
     dropped from every surface (see `filter_trusted`) so outsider feedback
@@ -302,8 +318,12 @@ def _rescan_fixing_feedback(gh: GitHubClient, issue: Issue, pr, state) -> tuple:
     review_summary_new = filter_trusted(
         sorted(new_pr_reviews, key=lambda r: r.id)
     )
-    new_feedback = issue_space_new + review_space_new + review_summary_new
-    return issue_space_new, review_space_new, review_summary_new, new_feedback
+    return _FixingFeedback(
+        issue_space=issue_space_new,
+        review_comments=review_space_new,
+        review_summaries=review_summary_new,
+        all_items=issue_space_new + review_space_new + review_summary_new,
+    )
 
 
 def _dispatch_parked_fixing(
@@ -312,14 +332,11 @@ def _dispatch_parked_fixing(
     issue: Issue,
     state,
     pr,
-    new_feedback: list,
-    issue_space_new: list,
-    review_space_new: list,
-    review_summary_new: list,
-) -> tuple:
+    feedback: _FixingFeedback,
+) -> _ParkedFixingDecision:
     """Reconcile a `fixing` tick that arrived with `awaiting_human` set.
 
-    Returns ``(stop, replay_batch)``. ``stop=True`` means the tick is fully
+    Returns a decision object. ``stop=True`` means the tick is fully
     handled and the caller must return immediately (auto-rebase park, a
     refused `/orchestrator continue`, a silent validating-route recovery, a
     worktree-drift reroute, or a stay-parked-until-fresh-reply). ``stop=False``
@@ -338,7 +355,7 @@ def _dispatch_parked_fixing(
     # spawn it on a prompt that has nothing to do with the
     # outstanding fix.
     if park_reason in _wf._AUTO_REBASE_PARK_REASONS:
-        return True, None
+        return _ParkedFixingDecision(stop=True)
 
     # `/orchestrator continue` operator command (exact line, so a comment
     # carrying the command AND real guidance still counts). Handled on
@@ -359,16 +376,14 @@ def _dispatch_parked_fixing(
     #     park with no replayable batch: fall through to the normal resume
     #     so that guidance (not a bare continue) drives the dev.
     replay_batch = None
-    continue_cmds = _wf._parse_orchestrator_continue(issue_space_new)
+    continue_cmds = _wf._parse_orchestrator_continue(feedback.issue_space)
     if continue_cmds:
         action, items = _handle_continue_command(
-            gh, issue, state, pr, park_reason, continue_cmds,
-            new_feedback, issue_space_new, review_space_new,
-            review_summary_new,
+            gh, issue, state, pr, park_reason, continue_cmds, feedback,
         )
         if action == "refuse":
             gh.write_pinned_state(issue, state)
-            return True, None
+            return _ParkedFixingDecision(stop=True)
         if action == "replay":
             replay_batch = items
         # "passthrough": fall through to the normal resume below.
@@ -390,7 +405,7 @@ def _dispatch_parked_fixing(
     # (set by the in_review route, unset by the validating route).
     validating_routed = state.get("pending_fix_at") is None
     if (
-        not new_feedback
+        not feedback.all_items
         and park_reason in _wf._VALIDATING_TRANSIENT_PARK_REASONS
         and validating_routed
     ):
@@ -410,7 +425,7 @@ def _dispatch_parked_fixing(
             # through to the bare stay-parked return below and keep
             # waiting for a human comment.
             _reconcile_parked_fixing(gh, spec, issue, state, pr)
-            return True, None
+            return _ParkedFixingDecision(stop=True)
         # Conditions resolved (either no fix landed or a deferred
         # push finished). Clear the park flags and flip back to
         # `validating` so the reviewer re-evaluates the current head
@@ -426,9 +441,9 @@ def _dispatch_parked_fixing(
         _clear_pending_fix_bookmarks(state)
         gh.set_workflow_label(issue, WorkflowLabel.VALIDATING)
         gh.write_pinned_state(issue, state)
-        return True, None
+        return _ParkedFixingDecision(stop=True)
 
-    if not new_feedback:
+    if not feedback.all_items:
         # All other awaiting_human shapes (question parks, dirty
         # worktree parks, silent-crash parks, in_review-route
         # transients) stay parked until a fresh human reply lands.
@@ -442,14 +457,16 @@ def _dispatch_parked_fixing(
         # automatic exit from `fixing` for the in_review route is
         # the ACK fast path in the resume tail (on the same tick the
         # dev explicitly marks its no-commit reply with `ACK:`).
-        return True, None
+        return _ParkedFixingDecision(stop=True)
 
     state.set("awaiting_human", False)
     state.set("park_reason", None)
-    return False, replay_batch
+    return _ParkedFixingDecision(stop=False, replay_batch=replay_batch)
 
 
-def _fixing_debounce_open(new_feedback: list, replay_batch) -> bool:
+def _fixing_debounce_open(
+    feedback: _FixingFeedback, replay_batch,
+) -> bool:
     """True while the quiet window is still open: hold the resume until no
     comment has landed for `IN_REVIEW_DEBOUNCE_SECONDS`.
 
@@ -467,7 +484,7 @@ def _fixing_debounce_open(new_feedback: list, replay_batch) -> bool:
         return False
     now = datetime.now(timezone.utc)
     latest_ts: Optional[datetime] = None
-    for c in new_feedback:
+    for c in feedback.all_items:
         ts = _wf._comment_created_at(c)
         if ts is None:
             continue
@@ -505,12 +522,9 @@ def _resume_fixing_and_dispatch_result(
     spec: RepoSpec,
     issue: Issue,
     state,
-    new_feedback: list,
+    feedback: _FixingFeedback,
     replay_batch,
     pending_fix_at_was_set: bool,
-    issue_space_new: list,
-    review_space_new: list,
-    review_summary_new: list,
 ) -> None:
     """Resume the locked dev session over the unread feedback (or a
     preserved `/orchestrator continue` batch), then dispatch the result:
@@ -528,7 +542,7 @@ def _resume_fixing_and_dispatch_result(
     # text -- the whole point of the command is to not lose the review
     # feedback the parked session never addressed.
     followup = _wf._build_pr_comment_followup(
-        replay_batch if replay_batch is not None else new_feedback
+        replay_batch if replay_batch is not None else feedback.all_items
     )
     wt = _wf._worktree_path(spec, issue.number)
     if not wt.exists():
@@ -628,7 +642,7 @@ def _resume_fixing_and_dispatch_result(
             after_sha and _wf._stranded_fix_unpushed(spec, wt, state, issue)
         ):
             _advance_consumed_watermarks(
-                state, issue_space_new, review_space_new, review_summary_new,
+                state, feedback,
             )
             _clear_pending_fix_bookmarks(state)
             quoted = "> " + ack_reason.replace("\n", "\n> ")
@@ -679,7 +693,7 @@ def _resume_fixing_and_dispatch_result(
     # sits below it. The legacy in_review pushed-fix path had the same
     # constraint.
     _advance_consumed_watermarks(
-        state, issue_space_new, review_space_new, review_summary_new,
+        state, feedback,
     )
 
     if not pushed:
@@ -716,12 +730,7 @@ def _handle_fixing(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
     # in_review-route ACK fast path in the resume tail.
     pending_fix_at_was_set = state.get("pending_fix_at") is not None
 
-    (
-        issue_space_new,
-        review_space_new,
-        review_summary_new,
-        new_feedback,
-    ) = _rescan_fixing_feedback(gh, issue, pr, state)
+    feedback = _rescan_fixing_feedback(gh, issue, pr, state)
 
     # `replay_batch` is set only by an accepted `/orchestrator continue`
     # command inside `_dispatch_parked_fixing`: the PRESERVED PR-feedback
@@ -736,11 +745,11 @@ def _handle_fixing(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
     # would loop on every poll, spamming the same dev-resume prompt.
     replay_batch: Optional[list] = None
     if state.get("awaiting_human"):
-        stop, replay_batch = _dispatch_parked_fixing(
-            gh, spec, issue, state, pr, new_feedback,
-            issue_space_new, review_space_new, review_summary_new,
+        parked = _dispatch_parked_fixing(
+            gh, spec, issue, state, pr, feedback,
         )
-        if stop:
+        replay_batch = parked.replay_batch
+        if parked.stop:
             return
 
     # Watermarks already cover the triggering bookmarks (a prior tick
@@ -749,19 +758,18 @@ def _handle_fixing(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
     # `validating` so the reviewer re-evaluates against the current
     # head instead of leaving the issue stuck in `fixing` with no
     # work.
-    if not new_feedback:
+    if not feedback.all_items:
         _clear_pending_fix_bookmarks(state)
         gh.set_workflow_label(issue, WorkflowLabel.VALIDATING)
         gh.write_pinned_state(issue, state)
         return
 
-    if _fixing_debounce_open(new_feedback, replay_batch):
+    if _fixing_debounce_open(feedback, replay_batch):
         return
 
     _resume_fixing_and_dispatch_result(
-        gh, spec, issue, state, new_feedback, replay_batch,
+        gh, spec, issue, state, feedback, replay_batch,
         pending_fix_at_was_set,
-        issue_space_new, review_space_new, review_summary_new,
     )
 
 
@@ -1042,10 +1050,7 @@ def _reconstruct_pending_fix_batch(gh, issue, pr, state) -> list:
 
 
 def _advance_consumed_watermarks(
-    state,
-    issue_space_new: list,
-    review_space_new: list,
-    review_summary_new: list,
+    state, feedback: _FixingFeedback,
 ) -> None:
     """Advance the three in_review watermarks ONLY to the max id consumed
     per surface, ratcheted against the existing watermark.
@@ -1063,22 +1068,22 @@ def _advance_consumed_watermarks(
     `awaiting_human and not new_feedback` gate would drop it).
     """
     cur_issue_wm = state.get("pr_last_comment_id")
-    if issue_space_new:
-        new_wm = max(c.id for c in issue_space_new)
+    if feedback.issue_space:
+        new_wm = max(c.id for c in feedback.issue_space)
         if isinstance(cur_issue_wm, int):
             new_wm = max(new_wm, cur_issue_wm)
         state.set("pr_last_comment_id", new_wm)
 
     cur_review_wm = state.get("pr_last_review_comment_id")
-    if review_space_new:
-        new_wm = max(c.id for c in review_space_new)
+    if feedback.review_comments:
+        new_wm = max(c.id for c in feedback.review_comments)
         if isinstance(cur_review_wm, int):
             new_wm = max(new_wm, cur_review_wm)
         state.set("pr_last_review_comment_id", new_wm)
 
     cur_summary_wm = state.get("pr_last_review_summary_id")
-    if review_summary_new:
-        new_wm = max(r.id for r in review_summary_new)
+    if feedback.review_summaries:
+        new_wm = max(r.id for r in feedback.review_summaries)
         if isinstance(cur_summary_wm, int):
             new_wm = max(new_wm, cur_summary_wm)
         state.set("pr_last_review_summary_id", new_wm)
@@ -1091,10 +1096,7 @@ def _handle_continue_command(
     pr,
     park_reason,
     continue_cmds: list,
-    new_feedback: list,
-    issue_space_new: list,
-    review_space_new: list,
-    review_summary_new: list,
+    feedback: _FixingFeedback,
 ) -> tuple:
     """Dispatch a `/orchestrator continue` operator command on a parked
     `fixing` issue.
@@ -1150,14 +1152,21 @@ def _handle_continue_command(
         # verbatim into the replay: the resume tail advances the watermarks
         # past all of `new_feedback`, so anything omitted here would be
         # consumed without the dev ever seeing it.
-        return "replay", batch + new_feedback
+        return "replay", batch + feedback.all_items
 
-    if all(_wf._is_bare_orchestrator_continue(c) for c in new_feedback):
+    if all(_wf._is_bare_orchestrator_continue(c) for c in feedback.all_items):
         # Content-free continue with nothing else to act on. Consume only the
         # command comment(s) (`new_feedback` is all bare commands here, so this
         # covers them) so the refusal is not re-posted every tick, then stay
         # parked with a reason.
-        _advance_consumed_watermarks(state, list(continue_cmds), [], [])
+        command_items = list(continue_cmds)
+        command_feedback = _FixingFeedback(
+            issue_space=command_items,
+            review_comments=[],
+            review_summaries=[],
+            all_items=command_items,
+        )
+        _advance_consumed_watermarks(state, command_feedback)
         if park_reason in _wf._CONTINUE_PARK_REASONS:
             message = (
                 f"{config.HITL_MENTIONS} `/orchestrator continue`: no "

--- a/orchestrator/stages/implementing.py
+++ b/orchestrator/stages/implementing.py
@@ -26,6 +26,7 @@ reference that test patches against `workflow.X` could not affect.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -108,6 +109,13 @@ _CLAUDE_SESSION_LIMIT_MESSAGE_MARKERS: Tuple[str, ...] = (
     "claude usage limit reached",
     "claude ai usage limit reached",
 )
+
+
+@dataclass(frozen=True)
+class _PreparedDevRun:
+    result: AgentResult
+    before_sha: Optional[str]
+    paused: bool
 
 
 def _read_dev_session(
@@ -1120,10 +1128,10 @@ def _handle_user_content_drift(
 
 def _prepare_dev_run(
     gh: GitHubClient, spec: RepoSpec, issue: Issue, state: PinnedState
-) -> Optional[Tuple[AgentResult, Optional[str], bool]]:
+) -> Optional[_PreparedDevRun]:
     """Set up and run (or recover) the dev agent for one implementing tick.
 
-    Returns `(result, before_sha, paused)` for the caller to dispose, or None
+    Returns a prepared run for the caller to dispose, or None
     when the tick is already complete and the caller must return:
       * awaiting-human with an `agent_timeout` park and no human reply -> a
         silent `_try_recover_implementing_timeout_park` attempt (state written
@@ -1178,7 +1186,7 @@ def _prepare_dev_run(
         if resumed is None:
             return None
         _, result, paused = resumed
-        return result, before_sha, paused
+        return _PreparedDevRun(result, before_sha, paused)
 
     wt = _wf._ensure_worktree(
         spec, issue.number,
@@ -1250,7 +1258,7 @@ def _prepare_dev_run(
         # decision without a second read.
         paused = _wf._paused_during_agent_run(gh, issue)
     state.set("branch", _wf._resolve_branch_name(state, spec, issue.number))
-    return result, before_sha, paused
+    return _PreparedDevRun(result, before_sha, paused)
 
 
 def _dispose_agent_result(
@@ -1343,7 +1351,6 @@ def _handle_implementing(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None
     prepared = _prepare_dev_run(gh, spec, issue, state)
     if prepared is None:
         return
-    result, before_sha, paused = prepared
 
     state.set("last_agent_action_at", _wf._now_iso())
 
@@ -1352,7 +1359,7 @@ def _handle_implementing(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None
     # pinned state (the in-memory `awaiting_human=False` / watermark / session
     # mutations in `_prepare_dev_run` are discarded) so the next process
     # retries from durable state. Must precede the disposition below.
-    if _wf._ignore_if_interrupted(issue, result):
+    if _wf._ignore_if_interrupted(issue, prepared.result):
         return
 
     # Live pause applied while the agent ran: honor the single decision made in
@@ -1362,10 +1369,12 @@ def _handle_implementing(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None
     # the disposition opens a PR, relabels, parks, or advances pinned state.
     # Once the operator removes the label a later tick republishes the
     # carried-over commit normally.
-    if paused:
+    if prepared.paused:
         return
 
-    _dispose_agent_result(gh, spec, issue, state, result, before_sha)
+    _dispose_agent_result(
+        gh, spec, issue, state, prepared.result, prepared.before_sha,
+    )
 
 
 # GitHub rejects PR (and issue) bodies longer than 65,536 characters. The dev

--- a/orchestrator/stages/validating.py
+++ b/orchestrator/stages/validating.py
@@ -38,6 +38,7 @@ reference that test patches against `workflow.X` could not affect.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 import re
 from pathlib import Path
 from typing import Any, Optional, Tuple
@@ -61,6 +62,14 @@ _ADD_REVIEW_ROUNDS_RE = re.compile(
     r"^\s*/orchestrator\s+add-review-rounds\s+(\d+)\s*$",
     re.IGNORECASE | re.MULTILINE,
 )
+
+
+@dataclass(frozen=True)
+class _ReviewerRun:
+    wt: Path
+    round_n: int
+    pr_number: Any
+    result: AgentResult
 
 
 def _parse_add_review_rounds(
@@ -1351,57 +1360,43 @@ def _handle_validating_changes_requested(
     gh.write_pinned_state(issue, state)
 
 
-def _handle_validating(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
+def _park_review_cap(
+    gh: GitHubClient,
+    issue: Issue,
+    state: PinnedState,
+    round_n: int,
+) -> None:
     from .. import workflow as _wf
 
-    state = gh.read_pinned_state(issue)
-    pr_number = state.get("pr_number")
+    _wf._park_awaiting_human(
+        gh, issue, state,
+        f"{config.HITL_MENTIONS} review still has comments after "
+        f"{round_n} round(s); manual intervention needed. To grant "
+        "more rounds without losing the PR/worktree, reply with "
+        "`/orchestrator add-review-rounds N` "
+        "(N = additional rounds, e.g. `1`).",
+        reason="review_cap",
+    )
+    # `_park_awaiting_human` clears `park_reason` by contract; the
+    # awaiting-human branch needs this transient reason to route the
+    # operator's `/orchestrator add-review-rounds` command.
+    state.set("park_reason", "review_cap")
+    gh.write_pinned_state(issue, state)
 
-    if _finalize_validating_terminal(gh, spec, issue, state):
-        return
 
-    # User-content drift resume runs before the awaiting-human and reviewer
-    # branches: a body edit mid-review must resume the dev on the new body
-    # rather than re-review stale work. Returns True when it fully handled the
-    # tick; a reviewer-side (`reviewer_timeout` / `reviewer_failed`) or
-    # `review_cap` park defers to the awaiting-human branch below (that branch
-    # owns the human's "retry" / `/orchestrator add-review-rounds` comment).
-    if _resume_dev_on_validating_drift(gh, spec, issue, state):
-        return
-
-    # Awaiting-human path: human replied after a park (or a transient
-    # condition self-resolved). The helper resumes the dev on their feedback,
-    # recovers transient parks silently, or clears a reviewer-side / review-cap
-    # park into a reviewer re-run. "return" -> the tick is fully handled;
-    # "spawn_reviewer" -> fall through to the round-cap check and reviewer
-    # spawn below.
-    if state.get("awaiting_human"):
-        if _handle_validating_awaiting_human(
-            gh, spec, issue, state
-        ) == "return":
-            return
+def _run_reviewer_round(
+    gh: GitHubClient,
+    spec: RepoSpec,
+    issue: Issue,
+    state: PinnedState,
+    pr_number,
+) -> Optional[_ReviewerRun]:
+    from .. import workflow as _wf
 
     round_n = int(state.get("review_round") or 0)
     if round_n >= config.MAX_REVIEW_ROUNDS:
-        _wf._park_awaiting_human(
-            gh, issue, state,
-            f"{config.HITL_MENTIONS} review still has comments after "
-            f"{round_n} round(s); manual intervention needed. To grant "
-            "more rounds without losing the PR/worktree, reply with "
-            "`/orchestrator add-review-rounds N` "
-            "(N = additional rounds, e.g. `1`).",
-            reason="review_cap",
-        )
-        # Persist the park reason so the next tick's awaiting-human
-        # branch can route the operator's `/orchestrator add-review-rounds`
-        # comment through the cap-reset path (it gates on
-        # `park_reason == "review_cap"`). `_park_awaiting_human` clears
-        # `park_reason` to None by contract (the `reason=` kwarg only
-        # feeds the audit event), so callers that need a transient or
-        # cap-specific reason re-set it themselves.
-        state.set("park_reason", "review_cap")
-        gh.write_pinned_state(issue, state)
-        return
+        _park_review_cap(gh, issue, state, round_n)
+        return None
 
     wt = _wf._ensure_worktree(
         spec, issue.number,
@@ -1441,7 +1436,7 @@ def _handle_validating(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
     # is removed. Nothing is stranded: the reviewer is read-only and spawns
     # fresh each round.
     if _wf._paused_during_agent_run(gh, issue):
-        return
+        return None
     _wf._accumulate_issue_usage(state, review.usage)
     if review.session_id:
         state.set("last_review_session_id", review.session_id)
@@ -1456,8 +1451,26 @@ def _handle_validating(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
     # next process re-spawns the reviewer. Must precede the timeout/verdict
     # branches.
     if _wf._ignore_if_interrupted(issue, review):
-        return
+        return None
 
+    return _ReviewerRun(
+        wt=wt,
+        round_n=round_n,
+        pr_number=pr_number,
+        result=review,
+    )
+
+
+def _dispatch_reviewer_result(
+    gh: GitHubClient,
+    spec: RepoSpec,
+    issue: Issue,
+    state: PinnedState,
+    reviewer_run: _ReviewerRun,
+) -> None:
+    from .. import workflow as _wf
+
+    review = reviewer_run.result
     if review.timed_out:
         _wf._park_awaiting_human(
             gh, issue, state,
@@ -1478,13 +1491,18 @@ def _handle_validating(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
         issue_number=issue.number,
         stage="validating",
         verdict=verdict,
-        review_round=round_n,
-        pr_number=int(pr_number) if pr_number is not None else None,
+        review_round=reviewer_run.round_n,
+        pr_number=(
+            int(reviewer_run.pr_number)
+            if reviewer_run.pr_number is not None else None
+        ),
         session_id=review.session_id,
     )
 
     if verdict == "approved":
-        _finalize_validating_approval(gh, spec, issue, state, wt, pr_number)
+        _finalize_validating_approval(
+            gh, spec, issue, state, reviewer_run.wt, reviewer_run.pr_number,
+        )
         return
 
     if verdict == "unknown":
@@ -1497,5 +1515,41 @@ def _handle_validating(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
     # on any park the issue stays on `fixing` and the fixing handler owns the
     # awaiting-human rescan.
     _handle_validating_changes_requested(
-        gh, spec, issue, state, wt, pr_number, review, body, round_n,
+        gh, spec, issue, state, reviewer_run.wt, reviewer_run.pr_number,
+        review, body, reviewer_run.round_n,
     )
+
+
+def _handle_validating(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
+    state = gh.read_pinned_state(issue)
+    pr_number = state.get("pr_number")
+
+    if _finalize_validating_terminal(gh, spec, issue, state):
+        return
+
+    # User-content drift resume runs before the awaiting-human and reviewer
+    # branches: a body edit mid-review must resume the dev on the new body
+    # rather than re-review stale work. Returns True when it fully handled the
+    # tick; a reviewer-side (`reviewer_timeout` / `reviewer_failed`) or
+    # `review_cap` park defers to the awaiting-human branch below (that branch
+    # owns the human's "retry" / `/orchestrator add-review-rounds` comment).
+    if _resume_dev_on_validating_drift(gh, spec, issue, state):
+        return
+
+    # Awaiting-human path: human replied after a park (or a transient
+    # condition self-resolved). The helper resumes the dev on their feedback,
+    # recovers transient parks silently, or clears a reviewer-side / review-cap
+    # park into a reviewer re-run. "return" -> the tick is fully handled;
+    # "spawn_reviewer" -> fall through to the round-cap check and reviewer
+    # spawn below.
+    if state.get("awaiting_human"):
+        if _handle_validating_awaiting_human(
+            gh, spec, issue, state
+        ) == "return":
+            return
+
+    reviewer_run = _run_reviewer_round(gh, spec, issue, state, pr_number)
+    if reviewer_run is None:
+        return
+
+    _dispatch_reviewer_result(gh, spec, issue, state, reviewer_run)

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -1257,6 +1257,70 @@ def _drain_scheduler_family_bucket(
             )
 
 
+def _scheduler_per_repo_cap(spec: RepoSpec) -> int:
+    return max(1, int(getattr(spec, "parallel_limit", 1) or 1))
+
+
+def _submit_scheduler_family_bucket(
+    gh: GitHubClient,
+    spec: RepoSpec,
+    scheduler: IssueScheduler,
+    partition: _PollablePartition,
+    per_repo_cap: int,
+) -> None:
+    family_numbers = partition.family_numbers
+    if not family_numbers:
+        return
+
+    submitted = scheduler.submit(
+        spec.slug,
+        _FAMILY_BUCKET_ISSUE,
+        functools.partial(
+            _drain_scheduler_family_bucket, gh, spec, scheduler, family_numbers,
+        ),
+        family=True,
+        cap_exempt=_family_bucket_cap_exempt(partition.family_labels),
+        per_repo_cap=per_repo_cap,
+    )
+    if submitted:
+        return
+
+    # The scheduler logs the precise skip reason (closed, family_slot_held,
+    # cap, ...) inside `submit`; this line gives the dispatch-layer context
+    # -- which issues were waiting on this bucket -- so an operator can
+    # correlate "umbrella not advancing" with a previous tick's bucket
+    # still in flight.
+    log.info(
+        "repo=%s family bucket (%d issues) not submitted this "
+        "tick; next polling pass retries",
+        spec.slug, len(family_numbers),
+    )
+
+
+def _submit_scheduler_fanout_issues(
+    gh: GitHubClient,
+    spec: RepoSpec,
+    scheduler: IssueScheduler,
+    partition: _PollablePartition,
+    per_repo_cap: int,
+) -> None:
+    for n in partition.fanout_numbers:
+        scheduler.submit(
+            spec.slug,
+            n,
+            functools.partial(_refetch_and_process, gh, spec, n),
+            family=False,
+            # A closed issue's handler is a cheap terminal finalization with
+            # no agent spawn -- exempt it from the per-repo / global caps so
+            # a merged-PR or closed-question issue flips to `done` promptly
+            # instead of being starved behind active agent work under
+            # `parallel_limit=1` (mirrors the `_CAP_EXEMPT_FAMILY_LABELS`
+            # exemption for `blocked` / `umbrella`).
+            cap_exempt=(n in partition.fanout_closed),
+            per_repo_cap=per_repo_cap,
+        )
+
+
 def _dispatch_via_scheduler(
     gh: GitHubClient, spec: RepoSpec, scheduler: IssueScheduler,
 ) -> None:
@@ -1332,7 +1396,7 @@ def _dispatch_via_scheduler(
     while a sibling ``validating`` / ``documenting`` agent holds the only
     per-repo slot.
     """
-    per_repo_cap = max(1, int(getattr(spec, "parallel_limit", 1) or 1))
+    per_repo_cap = _scheduler_per_repo_cap(spec)
     # `_partition_pollable_issues` owns the skip-label filtering, per-issue
     # label-read isolation, and the family/fanout split (including the closed
     # fan-out set). `backlog` / `paused` issues are dropped there so a parked,
@@ -1340,50 +1404,14 @@ def _dispatch_via_scheduler(
     # cap-counted, which would reserve the only per-repo slot and starve
     # fanout under `parallel_limit=1`.
     partition = _partition_pollable_issues(gh, spec)
-    family_numbers = partition.family_numbers
-    fanout_numbers = partition.fanout_numbers
 
     # One `family=True` submit per repo drains every family-aware issue
     # sequentially (see `_drain_scheduler_family_bucket`). The bucket is
     # cap-exempt only when every family issue runs a no-agent handler
-    # (`_family_bucket_cap_exempt`); short-circuit `and` keeps the exempt
-    # probe and the submit off the no-family path entirely.
-    if family_numbers and not scheduler.submit(
-        spec.slug,
-        _FAMILY_BUCKET_ISSUE,
-        functools.partial(
-            _drain_scheduler_family_bucket, gh, spec, scheduler, family_numbers,
-        ),
-        family=True,
-        cap_exempt=_family_bucket_cap_exempt(partition.family_labels),
-        per_repo_cap=per_repo_cap,
-    ):
-        # The scheduler logs the precise skip reason (closed, family_slot_held,
-        # cap, ...) inside `submit`; this line gives the dispatch-layer context
-        # -- which issues were waiting on this bucket -- so an operator can
-        # correlate "umbrella not advancing" with a previous tick's bucket
-        # still in flight.
-        log.info(
-            "repo=%s family bucket (%d issues) not submitted this "
-            "tick; next polling pass retries",
-            spec.slug, len(family_numbers),
-        )
-
-    for n in fanout_numbers:
-        scheduler.submit(
-            spec.slug,
-            n,
-            functools.partial(_refetch_and_process, gh, spec, n),
-            family=False,
-            # A closed issue's handler is a cheap terminal finalization with
-            # no agent spawn -- exempt it from the per-repo / global caps so
-            # a merged-PR or closed-question issue flips to `done` promptly
-            # instead of being starved behind active agent work under
-            # `parallel_limit=1` (mirrors the `_CAP_EXEMPT_FAMILY_LABELS`
-            # exemption for `blocked` / `umbrella`).
-            cap_exempt=(n in partition.fanout_closed),
-            per_repo_cap=per_repo_cap,
-        )
+    # (`_family_bucket_cap_exempt`); the helper keeps the exempt probe and
+    # the submit off the no-family path entirely.
+    _submit_scheduler_family_bucket(gh, spec, scheduler, partition, per_repo_cap)
+    _submit_scheduler_fanout_issues(gh, spec, scheduler, partition, per_repo_cap)
 
 
 def _route_issue_to_handler(


### PR DESCRIPTION
Resolve #773 

Changes made:

- Added small frozen dataclasses for named stage decisions/results:
    - `_PreparedDevRun`
    - `_FixingFeedback`
    - `_ParkedFixingDecision`
    - `_ReviewerRun`
    - `_DecomposerRunPlan`

- Split reviewer setup/result routing out of `_handle_validating`.
- Split decomposer run preparation out of `_handle_decomposing`.
- Replaced fixing’s four-list feedback plumbing with a single feedback bundle.
- Split scheduler family/fanout submission helpers out of `_dispatch_via_scheduler`.
- Kept facade-compatible stage behavior intact.
