### PR TITLE
test: centralize test import bootstrap

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for the orchestrator package."""
 
-import os
-
-# Keep ignored local deployment settings out of deterministic unit tests.
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
+# Runs before pytest imports package-local test modules.
+from . import bootstrap as bootstrap

--- a/tests/bootstrap.py
+++ b/tests/bootstrap.py
@@ -1,0 +1,22 @@
+# Copyright 2026 Geser Dugarov
+# SPDX-License-Identifier: Apache-2.0
+"""Import-time environment normalization for the test suite.
+
+The settings here are read by `orchestrator.config` during import, so
+they must be normalized before any test imports orchestrator modules.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
+
+# Agent specs and comment-trust authors are import-time config values. Tests
+# patch the parsed config objects inline when they need non-default behavior.
+for _name in (
+    "DEV_AGENT",
+    "REVIEW_AGENT",
+    "DECOMPOSE_AGENT",
+    "ALLOWED_ISSUE_AUTHORS",
+):
+    os.environ.pop(_name, None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,37 +26,12 @@ unwinds back to `None`.
 """
 from __future__ import annotations
 
-import os
+from unittest.mock import patch
 
-# `orchestrator.config` reads `DEV_AGENT` / `REVIEW_AGENT` /
-# `DECOMPOSE_AGENT` from the ambient env at import time and exposes both
-# the raw spec (`*_SPEC`) and the parsed name (`config.REVIEW_AGENT`).
-# Tests patch `config.REVIEW_AGENT` to a bare agent name, but stage
-# handlers actually pin `config.REVIEW_AGENT_SPEC`, so an operator's
-# `REVIEW_AGENT="codex -m ..."` shell export leaks into pinned-state
-# assertions and trips `uv run pytest`. Clearing these BEFORE the first
-# `orchestrator.config` import below makes the suite hermetic regardless
-# of the shell environment.
-#
-# `ALLOWED_ISSUE_AUTHORS` is the same class of leak: config reads it at
-# import time, and the comment-trust filter now drops non-allowlisted
-# authors from prompt conversation text and the drift hash. An operator
-# who exported it (a real deployment does) would otherwise see the
-# suite's default fake authors (`alice`, `human`, `geserdugarov`)
-# filtered and dozens of stage tests fail. Clearing it pins the legacy
-# empty-allowlist ("trust everyone") default the stage tests assume;
-# tests that exercise the allowlist patch `config.ALLOWED_ISSUE_AUTHORS`
-# to a populated value inline, which overrides the import-time value.
-for _agent_var in (
-    "DEV_AGENT", "REVIEW_AGENT", "DECOMPOSE_AGENT", "ALLOWED_ISSUE_AUTHORS",
-):
-    os.environ.pop(_agent_var, None)
+import pytest
 
-from unittest.mock import patch  # noqa: E402
-
-import pytest  # noqa: E402
-
-from orchestrator import analytics  # noqa: E402
+from tests import bootstrap as bootstrap
+from orchestrator import analytics
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_comment_trust.py
+++ b/tests/test_comment_trust.py
@@ -6,11 +6,8 @@
 matches logins case-insensitively, bots follow the same login rule)."""
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config
 from orchestrator.comment_trust import filter_trusted, is_trusted_author

--- a/tests/test_develop_skill_metadata.py
+++ b/tests/test_develop_skill_metadata.py
@@ -13,11 +13,8 @@ must stay aligned with, so the two cannot silently drift back apart.
 """
 from __future__ import annotations
 
-import os
 import unittest
 from pathlib import Path
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow_messages
 

--- a/tests/test_github_pinned_state.py
+++ b/tests/test_github_pinned_state.py
@@ -3,11 +3,8 @@
 from __future__ import annotations
 
 import json
-import os
 import unittest
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator.github import PINNED_STATE_TEMPLATE, GitHubClient
 

--- a/tests/test_reexport_surface.py
+++ b/tests/test_reexport_surface.py
@@ -11,10 +11,7 @@ to (or dropped from) the import block cannot silently drift out of `__all__`.
 from __future__ import annotations
 
 import ast
-import os
 import unittest
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import dashboard, workflow, worktrees
 from orchestrator.analytics import read as analytics_read

--- a/tests/test_skill_catalog.py
+++ b/tests/test_skill_catalog.py
@@ -9,8 +9,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
-
 from orchestrator import analytics, config, skill_catalog
 
 

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 import json
-import os
 import pathlib
 import re
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import base_sync, config, github, workflow
 from orchestrator.state_machine import (

--- a/tests/test_workflow_agent_analytics.py
+++ b/tests/test_workflow_agent_analytics.py
@@ -7,14 +7,11 @@ for codex stdout that omits the model field, and the disabled-sink knob."""
 from __future__ import annotations
 
 import json
-import os
 import tempfile
 import unittest
 from pathlib import Path
 from typing import Optional
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import analytics, config, usage, workflow
 from orchestrator.agents import AgentResult

--- a/tests/test_workflow_backlog_routing.py
+++ b/tests/test_workflow_backlog_routing.py
@@ -5,11 +5,8 @@ it prevents the orchestrator from decomposing, picking up, or otherwise
 advancing the state machine until a human removes the label."""
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 from orchestrator.github import BACKLOG_LABEL

--- a/tests/test_workflow_base_sync_real_git.py
+++ b/tests/test_workflow_base_sync_real_git.py
@@ -10,8 +10,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
-
 from orchestrator import base_sync, config, workflow
 
 from tests.fakes import FakeGitHubClient, FakePR, make_issue

--- a/tests/test_workflow_base_sync_unit.py
+++ b/tests/test_workflow_base_sync_unit.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 import contextlib
-import os
 import shutil
 import subprocess
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import base_sync, config, workflow
 from orchestrator.github import BACKLOG_LABEL, PAUSED_LABEL

--- a/tests/test_workflow_branch_publication.py
+++ b/tests/test_workflow_branch_publication.py
@@ -7,13 +7,10 @@ and per-spec token resolution so multi-repo deployments honor each
 `~/.config/<owner>/<repo>/token` file."""
 from __future__ import annotations
 
-import os
 import subprocess
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, git_plumbing, workflow
 

--- a/tests/test_workflow_cleanup.py
+++ b/tests/test_workflow_cleanup.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow, worktree_lifecycle
 

--- a/tests/test_workflow_comment_trust.py
+++ b/tests/test_workflow_comment_trust.py
@@ -11,11 +11,8 @@ coding agent nor shift the drift hash to re-trigger the workflow.
 """
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_community_contribution.py
+++ b/tests/test_workflow_community_contribution.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 from orchestrator.github import COMMUNITY_CONTRIBUTION_LABEL

--- a/tests/test_workflow_conflicts_agent.py
+++ b/tests/test_workflow_conflicts_agent.py
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from tests.workflow_helpers import (
     _FAKE_WT,

--- a/tests/test_workflow_conflicts_authed_fetch.py
+++ b/tests/test_workflow_conflicts_authed_fetch.py
@@ -6,8 +6,6 @@ import os
 import unittest
 from pathlib import Path
 
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
-
 from orchestrator import config, git_plumbing, workflow
 
 from tests.workflow_helpers import _TEST_SPEC, _temp_git_repo_with_local_config

--- a/tests/test_workflow_conflicts_clean_rebase.py
+++ b/tests/test_workflow_conflicts_clean_rebase.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_conflicts_dirty.py
+++ b/tests/test_workflow_conflicts_dirty.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_conflicts_diverged.py
+++ b/tests/test_workflow_conflicts_diverged.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_conflicts_drift.py
+++ b/tests/test_workflow_conflicts_drift.py
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_conflicts_event_emission.py
+++ b/tests/test_workflow_conflicts_event_emission.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_conflicts_git_identity.py
+++ b/tests/test_workflow_conflicts_git_identity.py
@@ -6,8 +6,6 @@ import os
 import unittest
 from pathlib import Path
 
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
-
 from orchestrator import config, workflow
 
 

--- a/tests/test_workflow_conflicts_list_pollable.py
+++ b/tests/test_workflow_conflicts_list_pollable.py
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from tests.fakes import FakeGitHubClient, make_issue
 

--- a/tests/test_workflow_conflicts_paused.py
+++ b/tests/test_workflow_conflicts_paused.py
@@ -11,11 +11,8 @@ in-progress rebase / resolved commit stays on the branch and the park (if any)
 stays intact until the label is removed."""
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator.github import PAUSED_LABEL
 

--- a/tests/test_workflow_conflicts_publish.py
+++ b/tests/test_workflow_conflicts_publish.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 from orchestrator.stages import conflicts

--- a/tests/test_workflow_conflicts_publish_guard.py
+++ b/tests/test_workflow_conflicts_publish_guard.py
@@ -2,12 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 from orchestrator.stages import conflicts

--- a/tests/test_workflow_conflicts_recovery.py
+++ b/tests/test_workflow_conflicts_recovery.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_conflicts_resume.py
+++ b/tests/test_workflow_conflicts_resume.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_conflicts_routing.py
+++ b/tests/test_workflow_conflicts_routing.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_conflicts_target_fetch.py
+++ b/tests/test_workflow_conflicts_target_fetch.py
@@ -6,8 +6,6 @@ import os
 import unittest
 from pathlib import Path
 
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
-
 from orchestrator import config, git_plumbing, workflow
 
 from tests.workflow_helpers import _TEST_SPEC, _temp_git_repo_with_local_config

--- a/tests/test_workflow_conflicts_worktree_restore.py
+++ b/tests/test_workflow_conflicts_worktree_restore.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow, worktree_lifecycle
 

--- a/tests/test_workflow_decomposition_blocked.py
+++ b/tests/test_workflow_decomposition_blocked.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from typing import Optional
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_decomposition_children.py
+++ b/tests/test_workflow_decomposition_children.py
@@ -2,10 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 
 class CreateChildIssueAlwaysUsesParentRepoTest(unittest.TestCase):

--- a/tests/test_workflow_decomposition_cleanup.py
+++ b/tests/test_workflow_decomposition_cleanup.py
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_decomposition_decomposing.py
+++ b/tests/test_workflow_decomposition_decomposing.py
@@ -2,12 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from typing import Optional
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_decomposition_drift.py
+++ b/tests/test_workflow_decomposition_drift.py
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_decomposition_finalize.py
+++ b/tests/test_workflow_decomposition_finalize.py
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_decomposition_manifest.py
+++ b/tests/test_workflow_decomposition_manifest.py
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_decomposition_ready.py
+++ b/tests/test_workflow_decomposition_ready.py
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_decomposition_umbrella.py
+++ b/tests/test_workflow_decomposition_umbrella.py
@@ -2,12 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from typing import Optional
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_documenting.py
+++ b/tests/test_workflow_documenting.py
@@ -2,14 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import tempfile
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_documenting_paused.py
+++ b/tests/test_workflow_documenting_paused.py
@@ -11,11 +11,8 @@ through the recovered-worktree path. Covers both docs resumes: the initial pass
 and the awaiting-human follow-up."""
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 from orchestrator.github import PAUSED_LABEL

--- a/tests/test_workflow_documenting_routing.py
+++ b/tests/test_workflow_documenting_routing.py
@@ -6,11 +6,8 @@ no-`pr_number` park stability checks. Handler-behavior tests live in
 `tests/test_workflow_documenting.py`."""
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_drain_terminals.py
+++ b/tests/test_workflow_drain_terminals.py
@@ -10,10 +10,7 @@ contract, the already-closed-issue merged arc, and the terminal
 usage-verdict receipt each arc posts before its pinned-state write."""
 from __future__ import annotations
 
-import os
 import unittest
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_drift.py
+++ b/tests/test_workflow_drift.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_event_emission.py
+++ b/tests/test_workflow_event_emission.py
@@ -7,14 +7,11 @@ the JSONL sink driven by `EVENT_LOG_PATH`."""
 from __future__ import annotations
 
 import json
-import os
 import tempfile
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_finalize_pr_merged.py
+++ b/tests/test_workflow_finalize_pr_merged.py
@@ -6,10 +6,7 @@ merged-PR finalize on an open vs. already-closed issue, and the terminal
 usage-verdict receipt it posts (tracked before the pinned-state write)."""
 from __future__ import annotations
 
-import os
 import unittest
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_fixing.py
+++ b/tests/test_workflow_fixing.py
@@ -21,13 +21,10 @@ are covered in `tests/test_workflow_fixing_routing.py`'s
 """
 from __future__ import annotations
 
-import os
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 from orchestrator.stages.fixing import (

--- a/tests/test_workflow_fixing_paused.py
+++ b/tests/test_workflow_fixing_paused.py
@@ -10,12 +10,9 @@ unconsumed and the committed work stays on the branch until the label is
 removed, when a later tick re-discovers the feedback and republishes."""
 from __future__ import annotations
 
-import os
 import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 from orchestrator.github import PAUSED_LABEL

--- a/tests/test_workflow_fixing_routing.py
+++ b/tests/test_workflow_fixing_routing.py
@@ -10,15 +10,12 @@ leaves conflicted files -> `resolving_conflict`). The quiet-window /
 dev-resume tests live in `tests/test_workflow_fixing.py`."""
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import base_sync, config, workflow
 

--- a/tests/test_workflow_implementing_drift.py
+++ b/tests/test_workflow_implementing_drift.py
@@ -6,10 +6,7 @@ failures on recovered worktrees, and the no-dev-session drift branches park
 or fall through to a fresh spawn with the full implement prompt."""
 from __future__ import annotations
 
-import os
 import unittest
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_implementing_fresh.py
+++ b/tests/test_workflow_implementing_fresh.py
@@ -5,10 +5,7 @@ silent failures / pushed-failure, awaiting-human resume, and the
 recovered-worktree shortcut that skips the dev agent."""
 from __future__ import annotations
 
-import os
 import unittest
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_implementing_full_spec.py
+++ b/tests/test_workflow_implementing_full_spec.py
@@ -6,11 +6,8 @@ not just the parsed backend, and resumes / poisoned-session drops must
 preserve the recorded spec across config flips."""
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_implementing_paused.py
+++ b/tests/test_workflow_implementing_paused.py
@@ -9,11 +9,8 @@ parking, consuming the action watermark, or advancing pinned state -- so once
 the label is removed a later tick republishes the committed work normally."""
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 from orchestrator.github import PAUSED_LABEL

--- a/tests/test_workflow_implementing_pr_reuse.py
+++ b/tests/test_workflow_implementing_pr_reuse.py
@@ -5,12 +5,9 @@ that derive the PR title from the first commit subject (with per-spec base
 branch and remote)."""
 from __future__ import annotations
 
-import os
 import unittest
 from pathlib import Path
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import branch_publication, config, workflow, worktree_lifecycle
 from orchestrator.stages import implementing

--- a/tests/test_workflow_implementing_retry.py
+++ b/tests/test_workflow_implementing_retry.py
@@ -5,12 +5,9 @@ configurable dev/review backends, silent-session fallback after consecutive
 silent parks, and stale-session immediate retry for the claude CLI."""
 from __future__ import annotations
 
-import os
 import unittest
 from typing import Optional
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_implementing_terminal.py
+++ b/tests/test_workflow_implementing_terminal.py
@@ -7,10 +7,7 @@ terminal usage receipt the shared `_finalize_if_issue_closed` helper posts
 before its pinned-state write."""
 from __future__ import annotations
 
-import os
 import unittest
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_implementing_timeout.py
+++ b/tests/test_workflow_implementing_timeout.py
@@ -10,12 +10,9 @@ timeout parks tagged `agent_timeout` + `pre_implement_sha` so the next tick
 can publish a late-landing commit without a human comment."""
 from __future__ import annotations
 
-import os
 import unittest
 from pathlib import Path
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_in_review_checks.py
+++ b/tests/test_workflow_in_review_checks.py
@@ -4,10 +4,8 @@
 surfaces (check-runs 403 scope hint, partial-read downgrade)."""
 from __future__ import annotations
 
-import os
 import unittest
 
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 
 class GitHubClientClosedIssueSweepLabelTest(unittest.TestCase):

--- a/tests/test_workflow_in_review_drift.py
+++ b/tests/test_workflow_in_review_drift.py
@@ -5,11 +5,8 @@ validating, park-on-failure, and the fresh-feedback scan that covers both the
 issue thread and the PR-conversation surface."""
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_in_review_filtering.py
+++ b/tests/test_workflow_in_review_filtering.py
@@ -4,12 +4,9 @@
 on inline / review-summary feedback."""
 from __future__ import annotations
 
-import os
 import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_in_review_fresh_feedback.py
+++ b/tests/test_workflow_in_review_fresh_feedback.py
@@ -11,12 +11,9 @@ feedback. The drift-hash regression also lives here: a stale
 trigger a `validating` flip ahead of the fresh-feedback scan."""
 from __future__ import annotations
 
-import os
 import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_in_review_migration.py
+++ b/tests/test_workflow_in_review_migration.py
@@ -5,12 +5,9 @@ fallback that keeps a legacy '0' from being displaced by a higher
 last_action_comment_id."""
 from __future__ import annotations
 
-import os
 import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_in_review_parked.py
+++ b/tests/test_workflow_in_review_parked.py
@@ -5,12 +5,9 @@ manually-closed issues with a still-open PR, and the stale-park-reason clear
 on the route to fixing."""
 from __future__ import annotations
 
-import os
 import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_in_review_paused.py
+++ b/tests/test_workflow_in_review_paused.py
@@ -10,11 +10,8 @@ unconsumed (the stale hash stands) and the committed work stays on the branch
 until the label is removed."""
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 from orchestrator.github import PAUSED_LABEL

--- a/tests/test_workflow_in_review_routing.py
+++ b/tests/test_workflow_in_review_routing.py
@@ -5,12 +5,9 @@ HITL ready-ping gates, PR-comment debounce, and the PR-review-summary
 surface."""
 from __future__ import annotations
 
-import os
 import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_in_review_watermarks.py
+++ b/tests/test_workflow_in_review_watermarks.py
@@ -4,11 +4,8 @@
 watermark bump and the split issue / inline-review id namespaces."""
 from __future__ import annotations
 
-import os
 import unittest
 from datetime import datetime, timedelta, timezone
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_list_pollable.py
+++ b/tests/test_workflow_list_pollable.py
@@ -2,11 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from unittest import mock
 
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from github import GithubException
 

--- a/tests/test_workflow_model_extraction.py
+++ b/tests/test_workflow_model_extraction.py
@@ -6,10 +6,7 @@
 backend's CLI surface."""
 from __future__ import annotations
 
-import os
 import unittest
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_paused_agent_guard.py
+++ b/tests/test_workflow_paused_agent_guard.py
@@ -16,11 +16,8 @@ these cases establish the pattern for future direct `_run_agent_tracked` paths.
 """
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 from orchestrator.github import PAUSED_LABEL

--- a/tests/test_workflow_paused_routing.py
+++ b/tests/test_workflow_paused_routing.py
@@ -14,11 +14,8 @@ post-agent side effects; those live-guard cases live in
 `test_workflow_paused_agent_guard.py` and the per-stage `_paused` modules."""
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 from orchestrator.github import (

--- a/tests/test_workflow_pickup.py
+++ b/tests/test_workflow_pickup.py
@@ -5,11 +5,8 @@ implementing and the `ALLOWED_ISSUE_AUTHORS` allowlist (case-insensitive
 match, empty-list disables filter)."""
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_pr_lifecycle.py
+++ b/tests/test_workflow_pr_lifecycle.py
@@ -5,13 +5,10 @@ PR lifecycle (`pr_opened` / `pr_merged` / `pr_closed_without_merge` /
 `merge_attempt`), and the disabled-sink behavioral guarantee."""
 from __future__ import annotations
 
-import os
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_prompt_redaction.py
+++ b/tests/test_workflow_prompt_redaction.py
@@ -10,8 +10,6 @@ import os
 import unittest
 from unittest.mock import patch
 
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
-
 from orchestrator import config, workflow
 from orchestrator.agents import AgentResult
 

--- a/tests/test_workflow_question.py
+++ b/tests/test_workflow_question.py
@@ -9,8 +9,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
-
 from orchestrator import config, workflow, worktrees
 
 from tests.fakes import FakeComment, FakeGitHubClient, FakeUser, make_issue

--- a/tests/test_workflow_question_routing.py
+++ b/tests/test_workflow_question_routing.py
@@ -7,11 +7,8 @@ that keeps the dispatcher from falling through to pickup or
 implementing on a `question`-labeled issue."""
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 

--- a/tests/test_workflow_scheduler_routing.py
+++ b/tests/test_workflow_scheduler_routing.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 import logging
-import os
 import time
 import unittest
 from pathlib import Path
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import base_sync, config, workflow
 from orchestrator.github import BACKLOG_LABEL, PAUSED_LABEL

--- a/tests/test_workflow_stage_analytics.py
+++ b/tests/test_workflow_stage_analytics.py
@@ -8,14 +8,11 @@ analytics record per non-None label transition."""
 from __future__ import annotations
 
 import json
-import os
 import tempfile
 import unittest
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import analytics, workflow
 from orchestrator.github import BACKLOG_LABEL, PAUSED_LABEL

--- a/tests/test_workflow_tick_parallel.py
+++ b/tests/test_workflow_tick_parallel.py
@@ -2,13 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import time
 import unittest
 from pathlib import Path
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_tracked_repos.py
+++ b/tests/test_workflow_tracked_repos.py
@@ -10,12 +10,9 @@ secret or remote field.
 """
 from __future__ import annotations
 
-import os
 import unittest
 from pathlib import Path
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow, workflow_messages
 

--- a/tests/test_workflow_tracked_repos_prompts.py
+++ b/tests/test_workflow_tracked_repos_prompts.py
@@ -14,12 +14,9 @@ stages must keep their no-write contract intact alongside the block.
 from __future__ import annotations
 
 import contextlib
-import os
 import unittest
 from pathlib import Path
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_usage_accumulator.py
+++ b/tests/test_workflow_usage_accumulator.py
@@ -9,12 +9,9 @@ single-writer discipline that leaves an interrupted run's counters
 unpersisted."""
 from __future__ import annotations
 
-import os
 import unittest
 from typing import Optional
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 from orchestrator.github import PinnedState

--- a/tests/test_workflow_validating_drift.py
+++ b/tests/test_workflow_validating_drift.py
@@ -2,12 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from pathlib import Path
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_validating_handoff.py
+++ b/tests/test_workflow_validating_handoff.py
@@ -2,13 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_validating_paused.py
+++ b/tests/test_workflow_validating_paused.py
@@ -11,11 +11,8 @@ the three validating dev resumes: the user-content drift resume, the
 awaiting-human resume, and the CHANGES_REQUESTED reviewer-feedback fix."""
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import workflow
 from orchestrator.github import PAUSED_LABEL

--- a/tests/test_workflow_validating_review.py
+++ b/tests/test_workflow_validating_review.py
@@ -2,13 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from pathlib import Path
 from typing import Optional
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_validating_squash.py
+++ b/tests/test_workflow_validating_squash.py
@@ -11,8 +11,6 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
-
 from orchestrator import branch_publication, config, workflow
 
 from tests.fakes import (

--- a/tests/test_workflow_validating_terminal.py
+++ b/tests/test_workflow_validating_terminal.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_validating_verify.py
+++ b/tests/test_workflow_validating_verify.py
@@ -10,8 +10,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
-
 from orchestrator import agents, config, verify, workflow
 
 from tests.fakes import (

--- a/tests/test_workflow_validating_watermarks.py
+++ b/tests/test_workflow_validating_watermarks.py
@@ -2,12 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_verdict_parsing.py
+++ b/tests/test_workflow_verdict_parsing.py
@@ -10,10 +10,7 @@ historical `orchestrator.workflow._parse_*` re-export as a compatibility
 contract."""
 from __future__ import annotations
 
-import os
 import unittest
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator.workflow_messages import (
     _parse_documentation_verdict,

--- a/tests/test_workflow_worktree_paths.py
+++ b/tests/test_workflow_worktree_paths.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
 import unittest
 from pathlib import Path
-
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
 
 from orchestrator import config, workflow
 

--- a/tests/test_workflow_worktree_serialization.py
+++ b/tests/test_workflow_worktree_serialization.py
@@ -18,8 +18,6 @@ from pathlib import Path
 from typing import Optional
 from unittest.mock import patch
 
-os.environ.setdefault("ORCHESTRATOR_SKIP_DOTENV", "1")
-
 from orchestrator import (
     base_sync,
     config,


### PR DESCRIPTION
Resolves #775 

Added `tests/bootstrap.py` for import-time env normalization, wired it through `tests/__init__.py` and `tests/conftest.py`, and removed the repeated per-file `ORCHESTRATOR_SKIP_DOTENV` setup plus now-unused `os` imports from test modules. The intentional pre-orchestrator setup is now isolated in one helper, and there are no remaining `E402` suppressions in `tests/`.