### PR TITLE
refactor: reduce dashboard rendering complexity

### DIFF
--- a/orchestrator/dashboard.py
+++ b/orchestrator/dashboard.py
@@ -462,97 +462,21 @@ def main() -> None:
             return
 
         # Insights + KPI strip ---------------------------------------
-        # Token totals include cache_read + cache_write so the
-        # headline figure matches the standalone mock's
-        # `input + output + cache_read + cache_write` accounting; the
-        # `cached_tokens` cumulative column is deliberately excluded
-        # so the cache band is not double-counted.
         banners = compute_insights(
             summary,
             cost_coverage_rows=cost_coverage_rows,
         )
         if banners:
             st.markdown(_insights_html(banners), unsafe_allow_html=True)
-        total_cost = float(summary.total_cost_usd or 0.0)
-        total_tokens = int(
-            (summary.total_input_tokens or 0)
-            + (summary.total_output_tokens or 0)
-            + (summary.total_cache_read_tokens or 0)
-            + (summary.total_cache_write_tokens or 0)
+        kpis, resolved, rejected = _build_kpi_strip_data(
+            theme=theme,
+            summary=summary,
+            prev_summary=prev_summary,
+            ts_points=ts_points,
+            throughput_rows=throughput_rows,
+            review_round_rows=review_round_rows,
+            days_in_window=days_in_window,
         )
-        total_cost_prev = float(prev_summary.total_cost_usd or 0.0)
-        total_tokens_prev = int(
-            (prev_summary.total_input_tokens or 0)
-            + (prev_summary.total_output_tokens or 0)
-            + (prev_summary.total_cache_read_tokens or 0)
-            + (prev_summary.total_cache_write_tokens or 0)
-        )
-        resolved = sum(int(r.resolved or 0) for r in throughput_rows)
-        rejected = sum(int(r.rejected or 0) for r in throughput_rows)
-        rr_total_cost, rr_rework_cost = rework_totals(review_round_rows)
-        rework_share = (
-            (rr_rework_cost / rr_total_cost) if rr_total_cost > 0 else 0.0
-        )
-
-        # Sparkline series, one entry per day in the window. Daily
-        # tokens mirror the KPI accounting and include the cache band.
-        days = sorted({p.day for p in ts_points})
-        days_index = {d: i for i, d in enumerate(days)}
-        daily_cost = [0.0] * len(days)
-        daily_tokens = [0.0] * len(days)
-        for p in ts_points:
-            i = days_index[p.day]
-            daily_cost[i] += float(p.cost_usd or 0.0)
-            daily_tokens[i] += float(
-                (p.input_tokens or 0)
-                + (p.output_tokens or 0)
-                + (p.cache_read_tokens or 0)
-                + (p.cache_write_tokens or 0)
-            )
-        done_index = {r.day: int(r.resolved or 0) for r in throughput_rows}
-        daily_done = [done_index.get(d, 0) for d in days]
-
-        kpis = [
-            {
-                "label": "Total spend",
-                "value": theme.fmt_money_exact(total_cost),
-                "delta": kpi_delta(total_cost, total_cost_prev),
-                "sub": (
-                    f"{theme.fmt_money(total_cost / days_in_window)}/day"
-                ),
-                "spark": daily_cost,
-                "spark_color": theme.ACCENT,
-            },
-            {
-                "label": "Total tokens",
-                "value": theme.fmt_tokens(total_tokens),
-                "delta": kpi_delta(total_tokens, total_tokens_prev),
-                "sub": f"{theme.fmt_tokens(total_tokens / days_in_window)}/day",
-                "spark": daily_tokens,
-                "spark_color": theme.TOKEN_TYPE_COLORS["Input"],
-            },
-            {
-                "label": "Cost / resolved issue",
-                "value": (
-                    f"${total_cost / resolved:,.2f}"
-                    if resolved > 0 else "—"
-                ),
-                "delta": None,
-                "sub": f"{resolved} resolved · {rejected} rejected",
-                "spark": daily_done,
-                "spark_color": theme.TOKEN_TYPE_COLORS["Cache"],
-            },
-            {
-                "label": "Rework share",
-                "value": f"{rework_share * 100:.0f}%",
-                "delta": None,
-                "sub": (
-                    f"{theme.fmt_money_exact(rr_rework_cost)} in review "
-                    "rounds >= 1"
-                ),
-                "spark": None,
-            },
-        ]
         st.markdown(_kpi_strip_html(kpis), unsafe_allow_html=True)
 
         # Second wave -- the remaining widget reads. The KPI strip
@@ -611,68 +535,11 @@ def main() -> None:
         tz_offset_choice=tz_offset_choice,
     )
 
-    # ── Skill trigger rates ────────────────────────────
-    # Opt-in read-side widget over the `skills_triggered` /
-    # `skills_triggered_count` fields `record_agent_exit` folds into
-    # `extras` when `TRACK_SKILL_TRIGGERS` is on. A `0%` rate is a real
-    # signal ("this role's skill is not firing"), but it cannot tell a
-    # tracked-but-quiet run from one whose tracking was off, so the
-    # caption names the switch when nothing has triggered yet.
-    with st.container(border=True):
-        st.markdown(
-            _card_header_html(
-                "Skill trigger rates",
-                "Share of agent runs that triggered a skill, by role and "
-                "backend (requires TRACK_SKILL_TRIGGERS)",
-            ),
-            unsafe_allow_html=True,
-        )
-        if skill_rows:
-            st.markdown(
-                _skill_triggers_html(skill_rows),
-                unsafe_allow_html=True,
-            )
-            if not any(r.skill_runs for r in skill_rows):
-                st.caption(
-                    "No skill triggers recorded in this window. Enable "
-                    "`TRACK_SKILL_TRIGGERS` (default off) so "
-                    "`record_agent_exit` records which skills each run "
-                    "pulls."
-                )
-            # Second table: the per-skill x (repo, role, backend) trigger
-            # matrix. Folds each repo's skill catalog into the observed
-            # triggers so an offered-but-never-triggered skill surfaces
-            # as an explicit `0` cell; `_skill_matrix_html` renders a
-            # clear fallback notice in place of the table when the read
-            # model returns no catalog-backed matrix (no catalog records
-            # matched and no run fired a skill). Folded into an expander
-            # (collapsed by default, mirroring "Recent agent runs" below)
-            # so the matrix -- capped at 100 rows by the read model
-            # (Runs-with-skill DESC then Runs DESC) and shown by default
-            # repo-ascending then trigger-rate-descending -- does not
-            # dominate the card until the operator opens it.
-            with st.expander(
-                "Per-skill trigger matrix · which skills each "
-                "repo × role × backend cohort reaches for",
-                expanded=False,
-            ):
-                # Clickable column headers re-sort the matrix: each header
-                # anchor writes `mtx_sort` / `mtx_dir` query params, which
-                # this parses back into a (column, direction) pair the
-                # render applies on top of the read model's default order.
-                matrix_sort_key, matrix_sort_desc = parse_skill_matrix_sort(
-                    st.query_params
-                )
-                st.markdown(
-                    _skill_matrix_html(
-                        skill_matrix_rows,
-                        sort_key=matrix_sort_key,
-                        descending=matrix_sort_desc,
-                    ),
-                    unsafe_allow_html=True,
-                )
-        else:
-            st.info("No `agent_exit` rows match the current filters.")
+    _render_skill_triggers(
+        st=st,
+        skill_rows=skill_rows,
+        skill_matrix_rows=skill_matrix_rows,
+    )
 
     _render_recent_runs(
         st=st,
@@ -1243,6 +1110,139 @@ def _build_read_keys(
     return key, prev_key
 
 
+def _summary_total_tokens(summary: Summary) -> int:
+    """Return the dashboard token total used by KPIs and sparklines.
+
+    Cache read/write tokens are counted with input/output so the KPI
+    total matches the hero chart's Cache band. The cumulative
+    `cached_tokens` field is intentionally excluded to avoid double
+    counting reused prompt slices.
+    """
+    return int(
+        (summary.total_input_tokens or 0)
+        + (summary.total_output_tokens or 0)
+        + (summary.total_cache_read_tokens or 0)
+        + (summary.total_cache_write_tokens or 0)
+    )
+
+
+def _time_series_total_tokens(point: Any) -> float:
+    return float(
+        (point.input_tokens or 0)
+        + (point.output_tokens or 0)
+        + (point.cache_read_tokens or 0)
+        + (point.cache_write_tokens or 0)
+    )
+
+
+def _throughput_totals(throughput_rows: Sequence[Any]) -> tuple[int, int]:
+    resolved = sum(int(row.resolved or 0) for row in throughput_rows)
+    rejected = sum(int(row.rejected or 0) for row in throughput_rows)
+    return resolved, rejected
+
+
+def _daily_kpi_series(
+    *, ts_points: Sequence[Any], throughput_rows: Sequence[Any]
+) -> tuple[list[float], list[float], list[int]]:
+    """Return cost/token/resolved sparkline series for KPI cards.
+
+    One entry is emitted per day present in the time-series read. Daily
+    tokens use the same input + output + cache_read + cache_write
+    accounting as the headline token KPI.
+    """
+    days = sorted({point.day for point in ts_points})
+    days_index = {day: i for i, day in enumerate(days)}
+    daily_cost = [0.0] * len(days)
+    daily_tokens = [0.0] * len(days)
+    for point in ts_points:
+        i = days_index[point.day]
+        daily_cost[i] += float(point.cost_usd or 0.0)
+        daily_tokens[i] += _time_series_total_tokens(point)
+
+    done_index = {row.day: int(row.resolved or 0) for row in throughput_rows}
+    daily_done = [done_index.get(day, 0) for day in days]
+    return daily_cost, daily_tokens, daily_done
+
+
+def _build_kpi_strip_data(
+    *,
+    theme: Any,
+    summary: Summary,
+    prev_summary: Summary,
+    ts_points: Sequence[Any],
+    throughput_rows: Sequence[Any],
+    review_round_rows: Sequence[Any],
+    days_in_window: int,
+) -> tuple[list[dict[str, Any]], int, int]:
+    """Build the KPI-strip dictionaries plus throughput totals."""
+    total_cost = float(summary.total_cost_usd or 0.0)
+    total_tokens = _summary_total_tokens(summary)
+    total_cost_prev = float(prev_summary.total_cost_usd or 0.0)
+    total_tokens_prev = _summary_total_tokens(prev_summary)
+    resolved, rejected = _throughput_totals(throughput_rows)
+    rr_total_cost, rr_rework_cost = rework_totals(review_round_rows)
+    rework_share = (
+        (rr_rework_cost / rr_total_cost) if rr_total_cost > 0 else 0.0
+    )
+    daily_cost, daily_tokens, daily_done = _daily_kpi_series(
+        ts_points=ts_points,
+        throughput_rows=throughput_rows,
+    )
+    cost_per_resolved = (
+        f"${total_cost / resolved:,.2f}" if resolved > 0 else "—"
+    )
+    kpis = [
+        {
+            "label": "Total spend",
+            "value": theme.fmt_money_exact(total_cost),
+            "delta": kpi_delta(total_cost, total_cost_prev),
+            "sub": f"{theme.fmt_money(total_cost / days_in_window)}/day",
+            "spark": daily_cost,
+            "spark_color": theme.ACCENT,
+        },
+        {
+            "label": "Total tokens",
+            "value": theme.fmt_tokens(total_tokens),
+            "delta": kpi_delta(total_tokens, total_tokens_prev),
+            "sub": f"{theme.fmt_tokens(total_tokens / days_in_window)}/day",
+            "spark": daily_tokens,
+            "spark_color": theme.TOKEN_TYPE_COLORS["Input"],
+        },
+        {
+            "label": "Cost / resolved issue",
+            "value": cost_per_resolved,
+            "delta": None,
+            "sub": f"{resolved} resolved · {rejected} rejected",
+            "spark": daily_done,
+            "spark_color": theme.TOKEN_TYPE_COLORS["Cache"],
+        },
+        {
+            "label": "Rework share",
+            "value": f"{rework_share * 100:.0f}%",
+            "delta": None,
+            "sub": (
+                f"{theme.fmt_money_exact(rr_rework_cost)} in review "
+                "rounds >= 1"
+            ),
+            "spark": None,
+        },
+    ]
+    return kpis, resolved, rejected
+
+
+def _backend_tokens_by_day(
+    backend_daily_rows: Sequence[Any],
+) -> dict[date, dict[str, float]]:
+    backend_by_day: dict[date, dict[str, float]] = {}
+    for row in backend_daily_rows:
+        by_backend = backend_by_day.setdefault(row.day, {})
+        by_backend[row.backend] = (
+            by_backend.get(row.backend, 0.0)
+            + float(row.total_tokens or 0)
+        )
+    return backend_by_day
+
+
 def _render_hero_usage(
     *,
     st: Any,
@@ -1280,21 +1280,15 @@ def _render_hero_usage(
         )
         st.session_state.stack_mode = stack_mode
 
-        backend_by_day: dict[date, dict[str, float]] = {}
-        if stack_mode == "backend":
-            for row in backend_daily_rows:
-                backend_by_day.setdefault(row.day, {})
-                backend_by_day[row.day][row.backend] = (
-                    backend_by_day[row.day].get(row.backend, 0)
-                    + int(row.total_tokens or 0)
-                )
+        backend_by_day = (
+            _backend_tokens_by_day(backend_daily_rows)
+            if stack_mode == "backend" else None
+        )
 
         st.plotly_chart(
             dashboard_charts.usage_over_time(
                 ts_points,
-                backend_rows_by_day=(
-                    backend_by_day if stack_mode == "backend" else None
-                ),
+                backend_rows_by_day=backend_by_day,
                 mode=stack_mode,
                 # The card header already renders the title; suppress
                 # the in-chart title so it is not duplicated.
@@ -1518,6 +1512,79 @@ def _render_activity_heatmap(
             ),
             use_container_width=True,
             config=PLOTLY_CONFIG,
+        )
+
+
+def _render_skill_triggers(
+    *,
+    st: Any,
+    skill_rows: Sequence[SkillTriggerRateRow],
+    skill_matrix_rows: Sequence[SkillTriggerMatrixRow],
+) -> None:
+    """Render the skill-trigger aggregate table and matrix expander.
+
+    The aggregate is an opt-in read-side widget over the
+    `skills_triggered` / `skills_triggered_count` fields
+    `record_agent_exit` folds into `extras` when
+    `TRACK_SKILL_TRIGGERS` is on. A `0%` rate is a real signal ("this
+    role's skill is not firing"), but it cannot tell a tracked-but-quiet
+    run from one whose tracking was off, so the caption names the switch
+    when nothing has triggered yet.
+    """
+    with st.container(border=True):
+        st.markdown(
+            _card_header_html(
+                "Skill trigger rates",
+                "Share of agent runs that triggered a skill, by role and "
+                "backend (requires TRACK_SKILL_TRIGGERS)",
+            ),
+            unsafe_allow_html=True,
+        )
+        if not skill_rows:
+            st.info("No `agent_exit` rows match the current filters.")
+            return
+
+        st.markdown(
+            _skill_triggers_html(skill_rows),
+            unsafe_allow_html=True,
+        )
+        if not any(row.skill_runs for row in skill_rows):
+            st.caption(
+                "No skill triggers recorded in this window. Enable "
+                "`TRACK_SKILL_TRIGGERS` (default off) so "
+                "`record_agent_exit` records which skills each run pulls."
+            )
+        _render_skill_matrix_expander(
+            st=st,
+            skill_matrix_rows=skill_matrix_rows,
+        )
+
+
+def _render_skill_matrix_expander(
+    *,
+    st: Any,
+    skill_matrix_rows: Sequence[SkillTriggerMatrixRow],
+) -> None:
+    """Render the per-skill trigger matrix inside a collapsed expander."""
+    with st.expander(
+        "Per-skill trigger matrix · which skills each "
+        "repo × role × backend cohort reaches for",
+        expanded=False,
+    ):
+        # Clickable column headers re-sort the matrix: each header anchor
+        # writes `mtx_sort` / `mtx_dir` query params, which this parses
+        # back into a (column, direction) pair the render applies on top
+        # of the read model's default order.
+        matrix_sort_key, matrix_sort_desc = parse_skill_matrix_sort(
+            st.query_params
+        )
+        st.markdown(
+            _skill_matrix_html(
+                skill_matrix_rows,
+                sort_key=matrix_sort_key,
+                descending=matrix_sort_desc,
+            ),
+            unsafe_allow_html=True,
         )
 
 

--- a/orchestrator/dashboard_charts.py
+++ b/orchestrator/dashboard_charts.py
@@ -75,6 +75,24 @@ _WEEKDAY_LABELS: tuple[str, ...] = (
 # row count follows `_WEEKDAY_LABELS` so the matrix and the y-axis labels
 # cannot drift apart; the column span is the hours in a day.
 _HOURS_PER_DAY = 24
+_USAGE_GRID_STEPS = 5
+_HORIZONTAL_BAR_ROW_HEIGHT = 40
+_HORIZONTAL_BAR_EXTRA_HEIGHT = 80
+_REVIEW_BAR_ROW_HEIGHT = 44
+_REVIEW_BAR_EXTRA_HEIGHT = 90
+_HORIZONTAL_BAR_MARGIN = {"l": 160, "r": 64, "b": 32}
+
+_REVIEW_ROUND_LABELS = {
+    "0": "Initial",
+    "1": "Round 1",
+    "2": "Round 2",
+    "3": "Round 3",
+    "4": "Round 4",
+    "5": "Round 5",
+    "6+": "Rounds 6+",
+    "unknown": "No review round",
+}
+_REVIEW_ROUND_ORDER = ("0", "1", "2", "3", "4", "5", "6+", "unknown")
 
 
 def _empty_figure(message: str, *, height: int) -> go.Figure:
@@ -142,6 +160,210 @@ def _nice_axis_max(value: float, steps: int) -> float:
     return nice * mag * steps
 
 
+def _money_text(values: Sequence[float]) -> list[str]:
+    return [theme.fmt_money(v) for v in values]
+
+
+def _monospace_textfont() -> dict[str, object]:
+    return {
+        "color": theme.TEXT,
+        "size": 12,
+        "family": theme.MONO_FONT_FAMILY,
+    }
+
+
+def _two_line_y_ticks(
+    labels: Sequence[str], subs: Sequence[str]
+) -> list[str]:
+    ticks: list[str] = []
+    for label, sub in zip(labels, subs):
+        label_html = f"<b>{label}</b>"
+        if sub:
+            ticks.append(
+                f"{label_html}<br>"
+                f"<span style='color:{theme.MUTED_TEXT};font-size:11px'>"
+                f"{sub}</span>"
+            )
+        else:
+            ticks.append(label_html)
+    return ticks
+
+
+def _reverse_lists(*values: Sequence) -> tuple[list, ...]:
+    return tuple(list(reversed(value)) for value in values)
+
+
+def _horizontal_panel_height(
+    row_count: int,
+    *,
+    height: Optional[int],
+    row_height: int = _HORIZONTAL_BAR_ROW_HEIGHT,
+    extra_height: int = _HORIZONTAL_BAR_EXTRA_HEIGHT,
+) -> int:
+    if height is not None:
+        return height
+    return row_height * max(row_count, 1) + extra_height
+
+
+def _horizontal_legend(*, traceorder: Optional[str] = None) -> dict[str, object]:
+    legend: dict[str, object] = {
+        "orientation": "h",
+        "x": 0,
+        "y": 1.12,
+        "xanchor": "left",
+        "yanchor": "bottom",
+    }
+    if traceorder is not None:
+        legend["traceorder"] = traceorder
+    return legend
+
+
+def _apply_horizontal_cost_layout(
+    fig: go.Figure,
+    *,
+    row_count: int,
+    height: Optional[int] = None,
+    title: Optional[str] = None,
+    barmode: Optional[str] = None,
+    legend: Optional[dict[str, object]] = None,
+    row_height: int = _HORIZONTAL_BAR_ROW_HEIGHT,
+    extra_height: int = _HORIZONTAL_BAR_EXTRA_HEIGHT,
+) -> None:
+    layout = theme.base_layout(title=title)
+    if barmode is not None:
+        layout["barmode"] = barmode
+    if legend is not None:
+        layout["legend"] = legend
+    layout["margin"] = {
+        **_HORIZONTAL_BAR_MARGIN,
+        "t": layout["margin"]["t"],
+    }
+    layout["height"] = _horizontal_panel_height(
+        row_count,
+        height=height,
+        row_height=row_height,
+        extra_height=extra_height,
+    )
+    fig.update_layout(**layout)
+    fig.update_xaxes(
+        title_text="USD", tickprefix="$",
+        showline=False, zeroline=False,
+    )
+    fig.update_yaxes(automargin=True, showline=False, ticks="")
+
+
+def _cost_bar_trace(
+    *,
+    name: str,
+    values: Sequence[float],
+    y_ticks: Sequence[str],
+    color,
+    hover_label: str,
+    offsetgroup: Optional[str] = None,
+    totals: Optional[Sequence[float]] = None,
+) -> go.Bar:
+    trace_kwargs = {
+        "x": list(values),
+        "y": list(y_ticks),
+        "name": name,
+        "orientation": "h",
+        "marker_color": color,
+        "cliponaxis": False,
+        "hovertemplate": (
+            "%{y}<br>" + hover_label + ": $%{x:,.2f}<extra></extra>"
+        ),
+    }
+    if offsetgroup is not None:
+        trace_kwargs["offsetgroup"] = offsetgroup
+    if totals is not None:
+        trace_kwargs["text"] = _money_text(totals)
+        trace_kwargs["textposition"] = "outside"
+        trace_kwargs["textfont"] = _monospace_textfont()
+    return go.Bar(**trace_kwargs)
+
+
+def _add_token_stack_trace(
+    fig: go.Figure,
+    *,
+    days: Sequence[date],
+    values: Sequence[float],
+    name: str,
+    color: str,
+) -> None:
+    fig.add_trace(
+        go.Scatter(
+            x=_date_axis(days),
+            y=list(values),
+            name=name,
+            mode="lines",
+            stackgroup="tokens",
+            line={"width": 0.5, "color": color},
+            fillcolor=color,
+            hovertemplate=(
+                "%{x}<br>" + name + ": %{y:,} tokens<extra></extra>"
+            ),
+        )
+    )
+
+
+def _roll_up_time_series(
+    points: Sequence[TimeSeriesPoint],
+) -> dict[date, dict[str, float]]:
+    daily: dict[date, dict[str, float]] = {}
+    for p in points:
+        bucket = daily.setdefault(
+            p.day,
+            {"input": 0.0, "output": 0.0, "cache": 0.0, "cost": 0.0},
+        )
+        bucket["input"] += float(p.input_tokens or 0)
+        bucket["output"] += float(p.output_tokens or 0)
+        # Total cache band: cache_read + cache_write -- matching the
+        # standalone mock's `r.cr + r.cw` accounting. `cached_tokens`
+        # (the cumulative cached count) is deliberately excluded so
+        # we do not double-count the same prompt slices.
+        bucket["cache"] += float(
+            (p.cache_read_tokens or 0) + (p.cache_write_tokens or 0)
+        )
+        bucket["cost"] += float(p.cost_usd or 0.0)
+    return daily
+
+
+def _ensure_backend_days(
+    daily: dict[date, dict[str, float]],
+    backend_rows_by_day: dict[date, dict[str, float]],
+) -> None:
+    for day in backend_rows_by_day:
+        daily.setdefault(
+            day,
+            {"input": 0.0, "output": 0.0, "cache": 0.0, "cost": 0.0},
+        )
+
+
+def _backend_names(
+    backend_rows_by_day: dict[date, dict[str, float]],
+) -> list[str]:
+    return sorted({
+        backend
+        for by_backend in backend_rows_by_day.values()
+        for backend in by_backend
+    })
+
+
+def _usage_stack_totals(
+    days: Sequence[date],
+    daily: dict[date, dict[str, float]],
+    *,
+    backend_rows_by_day: Optional[dict[date, dict[str, float]]],
+    mode: str,
+) -> list[float]:
+    if mode == "backend" and backend_rows_by_day:
+        return [sum(backend_rows_by_day.get(day, {}).values()) for day in days]
+    return [
+        daily[day]["input"] + daily[day]["output"] + daily[day]["cache"]
+        for day in days
+    ]
+
+
 def usage_over_time(
     points: Sequence[TimeSeriesPoint],
     *,
@@ -183,29 +405,10 @@ def usage_over_time(
             "No events match the current filters.", height=330,
         )
 
-    daily: dict[date, dict[str, float]] = {}
-    for p in points:
-        bucket = daily.setdefault(
-            p.day,
-            {"input": 0.0, "output": 0.0, "cache": 0.0, "cost": 0.0},
-        )
-        bucket["input"] += float(p.input_tokens or 0)
-        bucket["output"] += float(p.output_tokens or 0)
-        # Total cache band: cache_read + cache_write -- matching the
-        # standalone mock's `r.cr + r.cw` accounting. `cached_tokens`
-        # (the cumulative cached count) is deliberately excluded so
-        # we do not double-count the same prompt slices.
-        bucket["cache"] += float(
-            (p.cache_read_tokens or 0) + (p.cache_write_tokens or 0)
-        )
-        bucket["cost"] += float(p.cost_usd or 0.0)
+    daily = _roll_up_time_series(points)
 
     if mode == "backend" and backend_rows_by_day:
-        for day, by_backend in backend_rows_by_day.items():
-            daily.setdefault(
-                day,
-                {"input": 0.0, "output": 0.0, "cache": 0.0, "cost": 0.0},
-            )
+        _ensure_backend_days(daily, backend_rows_by_day)
 
     days = sorted(daily.keys())
     if not days:
@@ -215,34 +418,22 @@ def usage_over_time(
 
     fig = go.Figure()
     if mode == "backend" and backend_rows_by_day:
-        backends = sorted({
-            b
-            for by_backend in backend_rows_by_day.values()
-            for b in by_backend
-        })
+        backends = _backend_names(backend_rows_by_day)
         # Reverse the legend order so the first backend renders at
         # the bottom of the stack (matching how token type is drawn).
         for backend in backends:
             color = theme.color_for(
                 backend, backends, explicit=theme.BACKEND_COLORS
             )
-            fig.add_trace(
-                go.Scatter(
-                    x=_date_axis(days),
-                    y=[
-                        backend_rows_by_day.get(d, {}).get(backend, 0)
-                        for d in days
-                    ],
-                    name=backend,
-                    mode="lines",
-                    stackgroup="tokens",
-                    line={"width": 0.5, "color": color},
-                    fillcolor=color,
-                    hovertemplate=(
-                        "%{x}<br>" + backend +
-                        ": %{y:,} tokens<extra></extra>"
-                    ),
-                )
+            _add_token_stack_trace(
+                fig,
+                days=days,
+                values=[
+                    backend_rows_by_day.get(day, {}).get(backend, 0)
+                    for day in days
+                ],
+                name=backend,
+                color=color,
             )
     else:
         for band, label in (
@@ -251,20 +442,12 @@ def usage_over_time(
             ("cache", "Cache"),
         ):
             color = theme.TOKEN_TYPE_COLORS[label]
-            fig.add_trace(
-                go.Scatter(
-                    x=_date_axis(days),
-                    y=[daily[d][band] for d in days],
-                    name=label,
-                    mode="lines",
-                    stackgroup="tokens",
-                    line={"width": 0.5, "color": color},
-                    fillcolor=color,
-                    hovertemplate=(
-                        "%{x}<br>" + label +
-                        ": %{y:,} tokens<extra></extra>"
-                    ),
-                )
+            _add_token_stack_trace(
+                fig,
+                days=days,
+                values=[daily[day][band] for day in days],
+                name=label,
+                color=color,
             )
 
     fig.add_trace(
@@ -288,25 +471,18 @@ def usage_over_time(
     # ranges (e.g. 6 token lines from 0 to 1B vs 5 USD lines to $1000)
     # whose gridlines visually drift apart. Only the left (tokens) axis
     # draws the gridlines; the right (USD) axis ticks land on them.
-    if mode == "backend" and backend_rows_by_day:
-        stack_totals = [
-            sum(backend_rows_by_day.get(d, {}).values()) for d in days
-        ]
-    else:
-        stack_totals = [
-            daily[d]["input"] + daily[d]["output"] + daily[d]["cache"]
-            for d in days
-        ]
+    stack_totals = _usage_stack_totals(
+        days, daily, backend_rows_by_day=backend_rows_by_day, mode=mode
+    )
     token_max = max(stack_totals, default=0.0)
     cost_max = max((daily[d]["cost"] for d in days), default=0.0)
-    grid_steps = 5
-    token_top = _nice_axis_max(token_max, grid_steps)
-    cost_top = _nice_axis_max(cost_max, grid_steps)
+    token_top = _nice_axis_max(token_max, _USAGE_GRID_STEPS)
+    cost_top = _nice_axis_max(cost_max, _USAGE_GRID_STEPS)
     layout["yaxis"] = {
         **layout.get("yaxis", {}),
         "title": {"text": "tokens"},
         "range": [0, token_top],
-        "dtick": token_top / grid_steps,
+        "dtick": token_top / _USAGE_GRID_STEPS,
         "rangemode": "tozero",
         "showgrid": True,
     }
@@ -315,7 +491,7 @@ def usage_over_time(
         "overlaying": "y",
         "side": "right",
         "range": [0, cost_top],
-        "dtick": cost_top / grid_steps,
+        "dtick": cost_top / _USAGE_GRID_STEPS,
         "rangemode": "tozero",
         "gridcolor": theme.GRID,
         "linecolor": theme.GRID,
@@ -388,52 +564,31 @@ def cost_horizontal_bars(
     ]
     # Plotly draws the first y-value at the bottom of a horizontal
     # bar chart; reverse so the largest cost sits at the top.
-    labels.reverse()
-    subs.reverse()
-    values.reverse()
-    colors.reverse()
-    text = [theme.fmt_money(v) for v in values]
-    # Compose a Plotly-flavored two-line y-tick where the sub-label
-    # renders in muted gray underneath the bold label.
-    y_ticks = [
-        (
-            f"<b>{lbl}</b><br>"
-            f"<span style='color:{theme.MUTED_TEXT};font-size:11px'>"
-            f"{sub}</span>"
-        )
-        if sub
-        else f"<b>{lbl}</b>"
-        for lbl, sub in zip(labels, subs)
-    ]
+    labels, subs, values, colors = _reverse_lists(
+        labels, subs, values, colors
+    )
+    y_ticks = _two_line_y_ticks(labels, subs)
     fig = go.Figure(
         go.Bar(
             x=values,
             y=y_ticks,
             orientation="h",
             marker_color=colors,
-            text=text,
+            text=_money_text(values),
             textposition="outside",
-            textfont={"color": theme.TEXT, "size": 12,
-                      "family": theme.MONO_FONT_FAMILY},
+            textfont=_monospace_textfont(),
             cliponaxis=False,
             hovertemplate="%{y}: $%{x:,.2f}<extra></extra>",
         )
     )
-    layout = theme.base_layout(title=title)
-    layout["margin"] = {"l": 160, "r": 64, "t": layout["margin"]["t"], "b": 32}
     # Size the panel to the bar count: ~40px per row plus a fixed
     # top / bottom margin. Plotly's 450px default makes a 3-row
     # panel float in an empty box; a 6-row panel still fits inside
     # the same hero-chart height. An explicit `height` (e.g. to match
     # a paired panel) overrides the per-row computation.
-    n_rows = max(len(values), 1)
-    layout["height"] = height if height is not None else 40 * n_rows + 80
-    fig.update_layout(**layout)
-    fig.update_xaxes(
-        title_text="USD", tickprefix="$",
-        showline=False, zeroline=False,
+    _apply_horizontal_cost_layout(
+        fig, title=title, row_count=len(values), height=height
     )
-    fig.update_yaxes(automargin=True, showline=False, ticks="")
     return fig
 
 
@@ -493,26 +648,18 @@ def cost_by_stage(
     cache_colors = [_lighten_hex(c, 0.45) for c in colors]
     # Plotly draws the first y-value at the bottom of a horizontal
     # bar chart; reverse so the largest cost sits at the top.
-    labels.reverse()
-    subs.reverse()
-    no_cache.reverse()
-    cache.reverse()
-    totals.reverse()
-    colors.reverse()
-    cache_colors.reverse()
-    y_ticks = [
-        (
-            f"<b>{lbl}</b><br>"
-            f"<span style='color:{theme.MUTED_TEXT};font-size:11px'>"
-            f"{sub}</span>"
-        )
-        for lbl, sub in zip(labels, subs)
-    ]
-    monofont = {
-        "color": theme.TEXT,
-        "size": 12,
-        "family": theme.MONO_FONT_FAMILY,
-    }
+    (
+        labels,
+        subs,
+        no_cache,
+        cache,
+        totals,
+        colors,
+        cache_colors,
+    ) = _reverse_lists(
+        labels, subs, no_cache, cache, totals, colors, cache_colors
+    )
+    y_ticks = _two_line_y_ticks(labels, subs)
     fig = go.Figure()
     # No-cache trace is added first so it reads as the base segment
     # and cache stacks outward -- matching the issue's "with and
@@ -520,52 +667,31 @@ def cost_by_stage(
     # carries the per-stage total text so the dollar label lands once
     # per bar instead of duplicating on each segment.
     fig.add_trace(
-        go.Bar(
-            x=no_cache,
-            y=y_ticks,
+        _cost_bar_trace(
             name="No cache",
-            orientation="h",
-            marker_color=colors,
-            cliponaxis=False,
-            hovertemplate=(
-                "%{y}<br>No cache: $%{x:,.2f}<extra></extra>"
-            ),
+            values=no_cache,
+            y_ticks=y_ticks,
+            color=colors,
+            hover_label="No cache",
         )
     )
     fig.add_trace(
-        go.Bar(
-            x=cache,
-            y=y_ticks,
+        _cost_bar_trace(
             name="Cache",
-            orientation="h",
-            marker_color=cache_colors,
-            text=[theme.fmt_money(v) for v in totals],
-            textposition="outside",
-            textfont=monofont,
-            cliponaxis=False,
-            hovertemplate=(
-                "%{y}<br>Cache: $%{x:,.2f}<extra></extra>"
-            ),
+            values=cache,
+            y_ticks=y_ticks,
+            color=cache_colors,
+            hover_label="Cache",
+            totals=totals,
         )
     )
-    layout = theme.base_layout()
-    layout["barmode"] = "stack"
-    layout["margin"] = {"l": 160, "r": 64, "t": layout["margin"]["t"], "b": 32}
-    n_rows = max(len(y_ticks), 1)
-    layout["height"] = height if height is not None else 40 * n_rows + 80
-    layout["legend"] = {
-        "orientation": "h",
-        "x": 0,
-        "y": 1.12,
-        "xanchor": "left",
-        "yanchor": "bottom",
-    }
-    fig.update_layout(**layout)
-    fig.update_xaxes(
-        title_text="USD", tickprefix="$",
-        showline=False, zeroline=False,
+    _apply_horizontal_cost_layout(
+        fig,
+        row_count=len(y_ticks),
+        height=height,
+        barmode="stack",
+        legend=_horizontal_legend(),
     )
-    fig.update_yaxes(automargin=True, showline=False, ticks="")
     return fig
 
 
@@ -610,27 +736,23 @@ def cost_by_review_round(
             "No `agent_exit` rows match the current filters.",
             height=height or 120,
         )
-    label_map = {
-        "0": "Initial",
-        "1": "Round 1",
-        "2": "Round 2",
-        "3": "Round 3",
-        "4": "Round 4",
-        "5": "Round 5",
-        "6+": "Rounds 6+",
-        "unknown": "No review round",
-    }
     # Logical sequence before Plotly's horizontal-bar reversal:
     # Initial -> Round 1 -> ... -> No review round.
-    order = ["0", "1", "2", "3", "4", "5", "6+", "unknown"]
     by_bucket = {r.bucket: r for r in rows}
-    ordered_rows = [by_bucket[b] for b in order if b in by_bucket]
+    ordered_rows = [
+        by_bucket[bucket]
+        for bucket in _REVIEW_ROUND_ORDER
+        if bucket in by_bucket
+    ]
     if not ordered_rows:
         return _empty_figure(
             "No development or review runs match the current filters.",
             height=height or 120,
         )
-    labels = [label_map.get(r.bucket, r.bucket) for r in ordered_rows]
+    labels = [
+        _REVIEW_ROUND_LABELS.get(r.bucket, r.bucket)
+        for r in ordered_rows
+    ]
     subs = [
         (
             f"{int(r.developer_runs or 0):,} dev / "
@@ -659,22 +781,20 @@ def cost_by_review_round(
 
     # Plotly draws the first y-value at the bottom of a horizontal
     # grouped bar chart, so reverse to keep Initial at the top.
-    labels.reverse()
-    subs.reverse()
-    dev_no_cache.reverse()
-    dev_cache.reverse()
-    review_no_cache.reverse()
-    review_cache.reverse()
-    dev_totals.reverse()
-    review_totals.reverse()
-    y_ticks = [
-        (
-            f"<b>{lbl}</b><br>"
-            f"<span style='color:{theme.MUTED_TEXT};font-size:11px'>"
-            f"{sub}</span>"
-        )
-        for lbl, sub in zip(labels, subs)
-    ]
+    (
+        labels,
+        subs,
+        dev_no_cache,
+        dev_cache,
+        review_no_cache,
+        review_cache,
+        dev_totals,
+        review_totals,
+    ) = _reverse_lists(
+        labels, subs, dev_no_cache, dev_cache, review_no_cache,
+        review_cache, dev_totals, review_totals,
+    )
+    y_ticks = _two_line_y_ticks(labels, subs)
     dev_color = theme.AGENT_ROLE_COLORS["developer"]
     review_color = theme.AGENT_ROLE_COLORS["reviewer"]
     # 0.45 alpha keeps the cache segment legible on the page
@@ -692,11 +812,6 @@ def cost_by_review_round(
     # offset, the no-cache trace is added before the cache trace so
     # no-cache reads as the base segment and cache stacks outward --
     # matching the issue's "no-cache + cache in stacked form" framing.
-    monofont = {
-        "color": theme.TEXT,
-        "size": 12,
-        "family": theme.MONO_FONT_FAMILY,
-    }
     for name, values, color, offset, totals in (
         (
             "Review (no cache)", review_no_cache, review_color,
@@ -718,48 +833,29 @@ def cost_by_review_round(
         # Only the outer (cache) trace carries the per-role total
         # text so the dollar label still lands once per role bar
         # instead of duplicating on each segment.
-        text = (
-            [theme.fmt_money(v) for v in totals]
-            if totals is not None else None
-        )
         fig.add_trace(
-            go.Bar(
-                x=values,
-                y=y_ticks,
+            _cost_bar_trace(
                 name=name,
-                orientation="h",
-                marker_color=color,
+                values=values,
+                y_ticks=y_ticks,
+                color=color,
                 offsetgroup=offset,
-                text=text,
-                textposition="outside" if text is not None else "none",
-                textfont=monofont if text is not None else None,
-                cliponaxis=False,
-                hovertemplate=(
-                    "%{y}<br>" + name + ": $%{x:,.2f}<extra></extra>"
-                ),
+                totals=totals,
+                hover_label=name,
             )
         )
-    layout = theme.base_layout()
     # `relative` honors `offsetgroup` so same-offset traces stack and
     # different-offset traces sit side-by-side. With all-positive
     # values this acts identically to `stack` per offset.
-    layout["barmode"] = "relative"
-    layout["margin"] = {"l": 160, "r": 64, "t": layout["margin"]["t"], "b": 32}
-    layout["height"] = height if height is not None else 44 * len(y_ticks) + 90
-    layout["legend"] = {
-        "orientation": "h",
-        "x": 0,
-        "y": 1.12,
-        "xanchor": "left",
-        "yanchor": "bottom",
-        "traceorder": "reversed",
-    }
-    fig.update_layout(**layout)
-    fig.update_xaxes(
-        title_text="USD", tickprefix="$",
-        showline=False, zeroline=False,
+    _apply_horizontal_cost_layout(
+        fig,
+        row_count=len(y_ticks),
+        height=height,
+        barmode="relative",
+        legend=_horizontal_legend(traceorder="reversed"),
+        row_height=_REVIEW_BAR_ROW_HEIGHT,
+        extra_height=_REVIEW_BAR_EXTRA_HEIGHT,
     )
-    fig.update_yaxes(automargin=True, showline=False, ticks="")
     return fig
 
 

--- a/orchestrator/dashboard_html.py
+++ b/orchestrator/dashboard_html.py
@@ -35,6 +35,57 @@ from orchestrator.analytics.read import (
 from orchestrator.dashboard_kpis import InsightBanner
 
 
+def _table_css(table_class: str, *, extra_rules: str = "") -> str:
+    """Return the shared inline CSS block for compact dashboard tables."""
+    return f"""
+<style>
+  .{table_class} {{ width: 100%; border-collapse: collapse;
+    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 12.5px; }}
+  .{table_class} thead th {{ color: var(--orch-muted);
+    font-size: 11px; font-weight: 500; letter-spacing: 0.05em;
+    text-transform: uppercase; text-align: left;
+    padding: 4px 6px 8px; border-bottom: 1px solid var(--orch-border); }}
+  .{table_class} thead th.r {{ text-align: right; }}
+  .{table_class} tbody td {{ padding: 8px 6px; vertical-align: middle;
+    border-bottom: 1px solid var(--orch-grid); }}
+  .{table_class} tbody tr:last-child td {{ border-bottom: 0; }}
+  .{table_class} td.r {{ text-align: right; font-family:
+    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-variant-numeric: tabular-nums; color: var(--orch-ink); }}
+{extra_rules}
+</style>
+"""
+
+
+def _table_head_html(columns: Sequence[tuple[str, bool]]) -> str:
+    cells = []
+    for label, right in columns:
+        cls = ' class="r"' if right else ""
+        cells.append(f"<th{cls}>{html.escape(label)}</th>")
+    return "<thead><tr>" + "".join(cells) + "</tr></thead>"
+
+
+def _table_html(
+    *, table_class: str, css: str, head: str, rows: Sequence[str]
+) -> str:
+    return (
+        css
+        + f'<table class="{table_class}">'
+        + head
+        + "<tbody>" + "".join(rows) + "</tbody>"
+        + "</table>"
+    )
+
+
+def _relative_width_pct(value: float, maximum: float) -> float:
+    return (value / maximum * 100.0) if maximum > 0 else 0.0
+
+
+def _short_repo_name(repo: str) -> str:
+    return repo.split("/")[-1] if "/" in repo else repo
+
+
 def _sparkline_svg(
     values: Sequence[float], *, color: str, w: int = 96, h: int = 26
 ) -> str:
@@ -187,6 +238,88 @@ def _kpi_strip_html(kpis: Sequence[dict]) -> str:
     return '<div class="orch-kpis">' + "".join(cells) + '</div>'
 
 
+_ISSUES_TABLE_COLUMNS = (
+    ("Issue", False),
+    ("Cost", True),
+    ("Runs", True),
+    ("Review rds", True),
+    ("Retries", True),
+    ("Status", True),
+)
+
+_ISSUES_TABLE_EXTRA_CSS = """
+  .orch-issues td.strong { font-weight: 600; }
+  .orch-issue-cell { display: flex; flex-direction: column;
+    gap: 4px; }
+  .orch-issue-name { color: var(--orch-ink); font-weight: 500; }
+  .orch-issue-num { color: var(--orch-muted); font-weight: 400;
+    margin-left: 2px; }
+  .orch-issue-bar { display: block; height: 4px; border-radius: 2px;
+    background: var(--orch-grid); overflow: hidden; }
+  .orch-issue-bar > span { display: block; height: 100%;
+    background: var(--orch-accent); border-radius: 2px; }
+  .orch-pill { display: inline-block; padding: 2px 9px;
+    border-radius: 999px; font-size: 11.5px; font-weight: 500;
+    font-family: -apple-system, BlinkMacSystemFont, sans-serif; }
+  .orch-pill.ok { background: rgba(26, 163, 154, 0.14);
+    color: var(--orch-success); }
+  .orch-pill.bad { background: rgba(217, 83, 74, 0.14);
+    color: var(--orch-danger); }
+  .orch-badge-warn { color: var(--orch-warn); font-weight: 600; }
+"""
+
+
+def _issue_status_pill(failed: int) -> str:
+    if failed:
+        return f'<span class="orch-pill bad">{failed} fail</span>'
+    return '<span class="orch-pill ok">clean</span>'
+
+
+def _review_round_html(review_rounds: int) -> str:
+    if review_rounds >= 3:
+        return f'<span class="orch-badge-warn">{review_rounds}</span>'
+    return str(review_rounds)
+
+
+def _issue_table_row_html(row: IssueSummaryRow, *, max_cost: float) -> str:
+    short = _short_repo_name(row.repo)
+    cost = float(row.total_cost_usd or 0.0)
+    bar_pct = _relative_width_pct(cost, max_cost)
+    cost_text = (
+        f"${row.total_cost_usd:,.2f}"
+        if row.total_cost_usd is not None
+        else "—"
+    )
+    review_rounds = (
+        int(row.max_review_round)
+        if row.max_review_round is not None
+        else 0
+    )
+    retries = (
+        int(row.max_retry_count)
+        if row.max_retry_count is not None
+        else 0
+    )
+    failed = int(row.failed_agent_runs or 0)
+    return (
+        "<tr>"
+        "<td>"
+        '<div class="orch-issue-cell">'
+        f'<span><span class="orch-issue-name">{html.escape(short)}</span>'
+        f' <span class="orch-issue-num">#{int(row.issue)}</span></span>'
+        f'<span class="orch-issue-bar"><span style="width:{bar_pct:.1f}%">'
+        "</span></span>"
+        "</div>"
+        "</td>"
+        f'<td class="r strong">{html.escape(cost_text)}</td>'
+        f'<td class="r">{int(row.agent_exits or 0)}</td>'
+        f'<td class="r">{_review_round_html(review_rounds)}</td>'
+        f'<td class="r">{retries}</td>'
+        f'<td class="r">{_issue_status_pill(failed)}</td>'
+        "</tr>"
+    )
+
+
 def _issues_table_html(rows: Sequence[IssueSummaryRow]) -> str:
     """Render the "Most expensive issues" table to inline HTML.
 
@@ -210,108 +343,60 @@ def _issues_table_html(rows: Sequence[IssueSummaryRow]) -> str:
         (float(r.total_cost_usd or 0.0) for r in rows),
         default=0.0,
     ) or 1.0
-    css = """
-<style>
-  .orch-issues { width: 100%; border-collapse: collapse;
-    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-    font-size: 12.5px; }
-  .orch-issues thead th { color: var(--orch-muted);
-    font-size: 11px; font-weight: 500; letter-spacing: 0.05em;
-    text-transform: uppercase; text-align: left;
-    padding: 4px 6px 8px; border-bottom: 1px solid var(--orch-border); }
-  .orch-issues thead th.r { text-align: right; }
-  .orch-issues tbody td { padding: 8px 6px; vertical-align: middle;
-    border-bottom: 1px solid var(--orch-grid); }
-  .orch-issues tbody tr:last-child td { border-bottom: 0; }
-  .orch-issues td.r { text-align: right; font-family:
-    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-    font-variant-numeric: tabular-nums; color: var(--orch-ink); }
-  .orch-issues td.strong { font-weight: 600; }
-  .orch-issue-cell { display: flex; flex-direction: column;
-    gap: 4px; }
-  .orch-issue-name { color: var(--orch-ink); font-weight: 500; }
-  .orch-issue-num { color: var(--orch-muted); font-weight: 400;
-    margin-left: 2px; }
-  .orch-issue-bar { display: block; height: 4px; border-radius: 2px;
-    background: var(--orch-grid); overflow: hidden; }
-  .orch-issue-bar > span { display: block; height: 100%;
-    background: var(--orch-accent); border-radius: 2px; }
-  .orch-pill { display: inline-block; padding: 2px 9px;
-    border-radius: 999px; font-size: 11.5px; font-weight: 500;
-    font-family: -apple-system, BlinkMacSystemFont, sans-serif; }
-  .orch-pill.ok { background: rgba(26, 163, 154, 0.14);
-    color: var(--orch-success); }
-  .orch-pill.bad { background: rgba(217, 83, 74, 0.14);
-    color: var(--orch-danger); }
-  .orch-badge-warn { color: var(--orch-warn); font-weight: 600; }
-</style>
-"""
-    body: list[str] = []
-    for r in rows:
-        short = r.repo.split("/")[-1] if "/" in r.repo else r.repo
-        cost = float(r.total_cost_usd or 0.0)
-        bar_pct = (cost / max_cost * 100.0) if max_cost > 0 else 0.0
-        cost_text = (
-            f"${r.total_cost_usd:,.2f}"
-            if r.total_cost_usd is not None
-            else "—"
-        )
-        review_rounds = (
-            int(r.max_review_round)
-            if r.max_review_round is not None
-            else 0
-        )
-        retries = (
-            int(r.max_retry_count)
-            if r.max_retry_count is not None
-            else 0
-        )
-        failed = int(r.failed_agent_runs or 0)
-        if failed:
-            pill = f'<span class="orch-pill bad">{failed} fail</span>'
-        else:
-            pill = '<span class="orch-pill ok">clean</span>'
-        # High review-round counts get a warning color so the
-        # operator can spot rework-heavy issues without reading the
-        # number.
-        review_html = (
-            f'<span class="orch-badge-warn">{review_rounds}</span>'
-            if review_rounds >= 3
-            else str(review_rounds)
-        )
-        body.append(
-            "<tr>"
-            "<td>"
-            '<div class="orch-issue-cell">'
-            f'<span><span class="orch-issue-name">{html.escape(short)}</span>'
-            f' <span class="orch-issue-num">#{int(r.issue)}</span></span>'
-            f'<span class="orch-issue-bar"><span style="width:{bar_pct:.1f}%">'
-            "</span></span>"
-            "</div>"
-            "</td>"
-            f'<td class="r strong">{html.escape(cost_text)}</td>'
-            f'<td class="r">{int(r.agent_exits or 0)}</td>'
-            f'<td class="r">{review_html}</td>'
-            f'<td class="r">{retries}</td>'
-            f'<td class="r">{pill}</td>'
-            "</tr>"
-        )
-    head = (
-        "<thead><tr>"
-        "<th>Issue</th>"
-        '<th class="r">Cost</th>'
-        '<th class="r">Runs</th>'
-        '<th class="r">Review rds</th>'
-        '<th class="r">Retries</th>'
-        '<th class="r">Status</th>'
-        "</tr></thead>"
+    css = _table_css("orch-issues", extra_rules=_ISSUES_TABLE_EXTRA_CSS)
+    body = [
+        _issue_table_row_html(row, max_cost=max_cost)
+        for row in rows
+    ]
+    return _table_html(
+        table_class="orch-issues",
+        css=css,
+        head=_table_head_html(_ISSUES_TABLE_COLUMNS),
+        rows=body,
     )
+
+
+_SKILL_TRIGGERS_TABLE_COLUMNS = (
+    ("Role", False),
+    ("Backend", False),
+    ("Runs", True),
+    ("Skill runs", True),
+    ("Trigger rate", True),
+    ("Triggers", True),
+)
+
+_SKILL_TRIGGERS_EXTRA_CSS = """
+  .orch-skills td.strong { font-weight: 600; color: var(--orch-ink); }
+  .orch-skill-rate { display: flex; align-items: center; gap: 8px;
+    justify-content: flex-end; }
+  .orch-skill-bar { display: block; height: 4px; width: 64px;
+    border-radius: 2px; background: var(--orch-grid); overflow: hidden; }
+  .orch-skill-bar > span { display: block; height: 100%;
+    background: var(--orch-accent); border-radius: 2px; }
+  .orch-skill-pct { min-width: 34px; color: var(--orch-ink); }
+"""
+
+
+def _skill_trigger_row_html(
+    row: SkillTriggerRateRow, *, max_rate: float
+) -> str:
+    role = row.agent_role or "unknown"
+    backend = row.backend or "unknown"
+    rate_pct = row.rate * 100.0
+    bar_pct = _relative_width_pct(row.rate, max_rate)
     return (
-        css
-        + '<table class="orch-issues">'
-        + head
-        + "<tbody>" + "".join(body) + "</tbody>"
-        + "</table>"
+        "<tr>"
+        f'<td class="strong">{html.escape(role)}</td>'
+        f'<td>{html.escape(backend)}</td>'
+        f'<td class="r">{int(row.runs)}</td>'
+        f'<td class="r">{int(row.skill_runs)}</td>'
+        '<td class="r"><span class="orch-skill-rate">'
+        '<span class="orch-skill-bar">'
+        f'<span style="width:{bar_pct:.1f}%"></span></span>'
+        f'<span class="orch-skill-pct">{rate_pct:.0f}%</span>'
+        "</span></td>"
+        f'<td class="r">{int(row.total_triggers)}</td>'
+        "</tr>"
     )
 
 
@@ -332,68 +417,18 @@ def _skill_triggers_html(rows: Sequence[SkillTriggerRateRow]) -> str:
     only consumer -- and reuses the shared `var(--orch-*)` theme tokens.
     """
     max_rate = max((r.rate for r in rows), default=0.0) or 1.0
-    css = """
-<style>
-  .orch-skills { width: 100%; border-collapse: collapse;
-    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-    font-size: 12.5px; }
-  .orch-skills thead th { color: var(--orch-muted);
-    font-size: 11px; font-weight: 500; letter-spacing: 0.05em;
-    text-transform: uppercase; text-align: left;
-    padding: 4px 6px 8px; border-bottom: 1px solid var(--orch-border); }
-  .orch-skills thead th.r { text-align: right; }
-  .orch-skills tbody td { padding: 8px 6px; vertical-align: middle;
-    border-bottom: 1px solid var(--orch-grid); }
-  .orch-skills tbody tr:last-child td { border-bottom: 0; }
-  .orch-skills td.r { text-align: right; font-family:
-    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-    font-variant-numeric: tabular-nums; color: var(--orch-ink); }
-  .orch-skills td.strong { font-weight: 600; color: var(--orch-ink); }
-  .orch-skill-rate { display: flex; align-items: center; gap: 8px;
-    justify-content: flex-end; }
-  .orch-skill-bar { display: block; height: 4px; width: 64px;
-    border-radius: 2px; background: var(--orch-grid); overflow: hidden; }
-  .orch-skill-bar > span { display: block; height: 100%;
-    background: var(--orch-accent); border-radius: 2px; }
-  .orch-skill-pct { min-width: 34px; color: var(--orch-ink); }
-</style>
-"""
-    body: list[str] = []
-    for r in rows:
-        role = r.agent_role or "unknown"
-        backend = r.backend or "unknown"
-        rate_pct = r.rate * 100.0
-        bar_pct = (r.rate / max_rate * 100.0) if max_rate > 0 else 0.0
-        body.append(
-            "<tr>"
-            f'<td class="strong">{html.escape(role)}</td>'
-            f'<td>{html.escape(backend)}</td>'
-            f'<td class="r">{int(r.runs)}</td>'
-            f'<td class="r">{int(r.skill_runs)}</td>'
-            '<td class="r"><span class="orch-skill-rate">'
-            '<span class="orch-skill-bar">'
-            f'<span style="width:{bar_pct:.1f}%"></span></span>'
-            f'<span class="orch-skill-pct">{rate_pct:.0f}%</span>'
-            "</span></td>"
-            f'<td class="r">{int(r.total_triggers)}</td>'
-            "</tr>"
-        )
-    head = (
-        "<thead><tr>"
-        "<th>Role</th>"
-        "<th>Backend</th>"
-        '<th class="r">Runs</th>'
-        '<th class="r">Skill runs</th>'
-        '<th class="r">Trigger rate</th>'
-        '<th class="r">Triggers</th>'
-        "</tr></thead>"
+    css = _table_css(
+        "orch-skills", extra_rules=_SKILL_TRIGGERS_EXTRA_CSS
     )
-    return (
-        css
-        + '<table class="orch-skills">'
-        + head
-        + "<tbody>" + "".join(body) + "</tbody>"
-        + "</table>"
+    body = [
+        _skill_trigger_row_html(row, max_rate=max_rate)
+        for row in rows
+    ]
+    return _table_html(
+        table_class="orch-skills",
+        css=css,
+        head=_table_head_html(_SKILL_TRIGGERS_TABLE_COLUMNS),
+        rows=body,
     )
 
 
@@ -409,6 +444,16 @@ SKILL_MATRIX_EMPTY_MESSAGE = (
     "has recorded a repo skill catalog and at least one run's triggered "
     "skills."
 )
+
+_SKILL_MATRIX_EXTRA_CSS = """
+  .orch-skillmatrix td.strong { font-weight: 600; color: var(--orch-ink); }
+  .orch-skillmatrix-zero { color: var(--orch-muted-soft); }
+  .orch-skillmatrix thead th a.orch-skillmatrix-h { color: inherit;
+    text-decoration: none; cursor: pointer; }
+  .orch-skillmatrix thead th a.orch-skillmatrix-h:hover {
+    color: var(--orch-ink); text-decoration: underline; }
+  .orch-skillmatrix-sort { margin-left: 3px; color: var(--orch-accent); }
+"""
 
 # Column model for the per-skill trigger matrix. Each entry is
 # `(param key, header label, right-aligned?, sort-value function)`. The
@@ -527,6 +572,38 @@ def _skill_matrix_header_html(active_key: Optional[str], descending: bool) -> st
     return "<thead><tr>" + "".join(cells) + "</tr></thead>"
 
 
+def _muted_zero_html(value: str) -> str:
+    return f'<span class="orch-skillmatrix-zero">{value}</span>'
+
+
+def _skill_matrix_row_html(row: SkillTriggerMatrixRow) -> str:
+    repo = row.repo or "unknown"
+    role = row.agent_role or "unknown"
+    backend = row.backend or "unknown"
+    skill = row.skill or "unknown"
+    runs = int(row.runs)
+    skill_runs = int(row.skill_runs)
+    skill_runs_html = (
+        _muted_zero_html("0") if skill_runs == 0 else str(skill_runs)
+    )
+    rate_html = (
+        _muted_zero_html("0%")
+        if skill_runs == 0
+        else f"{row.rate * 100.0:.0f}%"
+    )
+    return (
+        "<tr>"
+        f'<td class="strong">{html.escape(repo)}</td>'
+        f'<td>{html.escape(role)}</td>'
+        f'<td>{html.escape(backend)}</td>'
+        f'<td>{html.escape(skill)}</td>'
+        f'<td class="r">{runs}</td>'
+        f'<td class="r">{skill_runs_html}</td>'
+        f'<td class="r">{rate_html}</td>'
+        "</tr>"
+    )
+
+
 def _skill_matrix_html(
     rows: Sequence[SkillTriggerMatrixRow],
     *,
@@ -577,79 +654,18 @@ def _skill_matrix_html(
             f"{html.escape(SKILL_MATRIX_EMPTY_MESSAGE)}"
             "</div>"
         )
-    css = """
-<style>
-  .orch-skillmatrix { width: 100%; border-collapse: collapse;
-    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-    font-size: 12.5px; }
-  .orch-skillmatrix thead th { color: var(--orch-muted);
-    font-size: 11px; font-weight: 500; letter-spacing: 0.05em;
-    text-transform: uppercase; text-align: left;
-    padding: 4px 6px 8px; border-bottom: 1px solid var(--orch-border); }
-  .orch-skillmatrix thead th.r { text-align: right; }
-  .orch-skillmatrix tbody td { padding: 8px 6px; vertical-align: middle;
-    border-bottom: 1px solid var(--orch-grid); }
-  .orch-skillmatrix tbody tr:last-child td { border-bottom: 0; }
-  .orch-skillmatrix td.r { text-align: right; font-family:
-    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-    font-variant-numeric: tabular-nums; color: var(--orch-ink); }
-  .orch-skillmatrix td.strong { font-weight: 600; color: var(--orch-ink); }
-  .orch-skillmatrix-zero { color: var(--orch-muted-soft); }
-  .orch-skillmatrix thead th a.orch-skillmatrix-h { color: inherit;
-    text-decoration: none; cursor: pointer; }
-  .orch-skillmatrix thead th a.orch-skillmatrix-h:hover {
-    color: var(--orch-ink); text-decoration: underline; }
-  .orch-skillmatrix-sort { margin-left: 3px; color: var(--orch-accent); }
-</style>
-"""
     rows = (
         _sort_skill_matrix_rows(rows, sort_key, descending)
         if sort_key is not None
         else _default_sort_skill_matrix_rows(rows)
     )
-    body: list[str] = []
-    for r in rows:
-        repo = r.repo or "unknown"
-        role = r.agent_role or "unknown"
-        backend = r.backend or "unknown"
-        skill = r.skill or "unknown"
-        runs = int(r.runs)
-        skill_runs = int(r.skill_runs)
-        # A `0` "Runs with skill" is an offered-but-never-triggered
-        # catalog cell -- mute it so the cells that actually fired stand
-        # out at a glance. The cohort `Runs` total is never muted (it is
-        # always >= 1 for a cohort that ran).
-        skill_runs_html = (
-            '<span class="orch-skillmatrix-zero">0</span>'
-            if skill_runs == 0
-            else str(skill_runs)
-        )
-        # The rate is derived from the two counts above, so mute it on the
-        # same offered-but-never-triggered signal that mutes `skill_runs`:
-        # a `0%` cell reads as quiet-but-offered, not as a live rate.
-        rate_html = (
-            '<span class="orch-skillmatrix-zero">0%</span>'
-            if skill_runs == 0
-            else f"{r.rate * 100.0:.0f}%"
-        )
-        body.append(
-            "<tr>"
-            f'<td class="strong">{html.escape(repo)}</td>'
-            f'<td>{html.escape(role)}</td>'
-            f'<td>{html.escape(backend)}</td>'
-            f'<td>{html.escape(skill)}</td>'
-            f'<td class="r">{runs}</td>'
-            f'<td class="r">{skill_runs_html}</td>'
-            f'<td class="r">{rate_html}</td>'
-            "</tr>"
-        )
-    head = _skill_matrix_header_html(sort_key, descending)
-    return (
-        css
-        + '<table class="orch-skillmatrix">'
-        + head
-        + "<tbody>" + "".join(body) + "</tbody>"
-        + "</table>"
+    return _table_html(
+        table_class="orch-skillmatrix",
+        css=_table_css(
+            "orch-skillmatrix", extra_rules=_SKILL_MATRIX_EXTRA_CSS
+        ),
+        head=_skill_matrix_header_html(sort_key, descending),
+        rows=[_skill_matrix_row_html(row) for row in rows],
     )
 
 
@@ -728,25 +744,8 @@ def _backend_efficiency_card_html(
     handle so this module stays free of the theme import (and the
     lazy-import invariant the dashboard relies on).
     """
-    tokens = int(
-        (row.total_input_tokens or 0)
-        + (row.total_output_tokens or 0)
-        + (row.total_cache_read_tokens or 0)
-        + (row.total_cache_write_tokens or 0)
-    )
-    cost_per_m = (
-        (row.total_cost_usd / (tokens / 1_000_000))
-        if tokens > 0 else 0.0
-    )
-    cost_per_run = (
-        (row.total_cost_usd / row.runs)
-        if row.runs > 0 else 0.0
-    )
-    cache_read = int(row.total_cache_read_tokens or 0)
-    input_tok = int(row.total_input_tokens or 0)
-    cache_hit_pct = (
-        (cache_read / (cache_read + input_tok) * 100)
-        if (cache_read + input_tok) > 0 else 0.0
+    tokens, cost_per_m, cost_per_run, cache_hit_pct = (
+        _backend_efficiency_metrics(row)
     )
     color = theme.color_for(
         row.backend, explicit=theme.BACKEND_COLORS
@@ -785,6 +784,53 @@ def _backend_efficiency_card_html(
     )
 
 
+def _backend_efficiency_metrics(
+    row: BackendEfficiencyRow,
+) -> tuple[int, float, float, float]:
+    tokens = int(
+        (row.total_input_tokens or 0)
+        + (row.total_output_tokens or 0)
+        + (row.total_cache_read_tokens or 0)
+        + (row.total_cache_write_tokens or 0)
+    )
+    cost_per_m = (
+        (row.total_cost_usd / (tokens / 1_000_000))
+        if tokens > 0 else 0.0
+    )
+    cost_per_run = (
+        (row.total_cost_usd / row.runs)
+        if row.runs > 0 else 0.0
+    )
+    cache_read = int(row.total_cache_read_tokens or 0)
+    input_tok = int(row.total_input_tokens or 0)
+    cache_input_total = cache_read + input_tok
+    cache_hit_pct = (
+        (cache_read / cache_input_total * 100)
+        if cache_input_total > 0 else 0.0
+    )
+    return tokens, cost_per_m, cost_per_run, cache_hit_pct
+
+
+def _cost_coverage_weights(
+    rows: Sequence[CostCoverageRow],
+) -> tuple[list[int], int]:
+    total_tokens = sum(int(row.total_tokens or 0) for row in rows)
+    if total_tokens > 0:
+        return [int(row.total_tokens or 0) for row in rows], total_tokens
+    weights = [int(row.runs or 0) for row in rows]
+    return weights, sum(weights) or 1
+
+
+def _cost_source_color(
+    cost_source: str, cost_sources: Sequence[str], theme
+) -> str:
+    return theme.color_for(
+        cost_source,
+        cost_sources,
+        explicit=theme.COST_SOURCE_COLORS,
+    )
+
+
 def _cost_coverage_bar_html(
     rows: Sequence[CostCoverageRow], *, theme
 ) -> str:
@@ -798,22 +844,13 @@ def _cost_coverage_bar_html(
     `agent_exit` rows that never reported usage). Colors / formatters
     come from the caller's `dashboard_theme` handle.
     """
-    total_tokens = sum(int(r.total_tokens or 0) for r in rows)
-    if total_tokens > 0:
-        weights = [int(r.total_tokens or 0) for r in rows]
-        total = total_tokens
-    else:
-        weights = [int(r.runs or 0) for r in rows]
-        total = sum(weights) or 1
+    weights, total = _cost_coverage_weights(rows)
+    cost_sources = [row.cost_source for row in rows]
     segs = []
     legend = []
     for r, w in zip(rows, weights):
         pct = w / total * 100
-        color = theme.color_for(
-            r.cost_source,
-            [r.cost_source for r in rows],
-            explicit=theme.COST_SOURCE_COLORS,
-        )
+        color = _cost_source_color(r.cost_source, cost_sources, theme)
         segs.append(
             f'<span style="width:{pct:.1f}%;background:{color}" '
             f'title="{html.escape(r.cost_source)}"></span>'

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1522,7 +1522,100 @@ class BuildReadKeysTest(unittest.TestCase):
         self.assertEqual(
             prev_key,
             (prev.start, prev.end, CACHE_REPO, EVENT_NAMES, None,
-             ISSUE_NUMBER),
+            ISSUE_NUMBER),
+        )
+
+
+class DashboardDataPrepTest(unittest.TestCase):
+    """Small data-prep helpers keep `main()` focused on render sequencing."""
+
+    def test_kpi_strip_data_uses_cache_tokens_and_daily_sparks(self) -> None:
+        _, dashboard = _reload()
+        from orchestrator import dashboard_theme as theme
+        from orchestrator.analytics.read import (
+            ReviewRoundBucketRow,
+            ThroughputDayRow,
+            TimeSeriesPoint,
+        )
+
+        summary = dashboard.Summary(
+            total_cost_usd=12.0,
+            total_input_tokens=10,
+            total_output_tokens=20,
+            total_cache_read_tokens=3,
+            total_cache_write_tokens=7,
+        )
+        prev_summary = dashboard.Summary(
+            total_cost_usd=6.0,
+            total_input_tokens=5,
+            total_output_tokens=5,
+            total_cache_read_tokens=5,
+            total_cache_write_tokens=5,
+        )
+        ts_points = [
+            TimeSeriesPoint(
+                day=MAY_1, event="agent_exit", count=1,
+                cost_usd=1.5, input_tokens=10, output_tokens=5,
+                cache_read_tokens=2, cache_write_tokens=3,
+            ),
+            TimeSeriesPoint(
+                day=MAY_1, event="agent_exit", count=1,
+                cost_usd=0.5, input_tokens=1, output_tokens=2,
+            ),
+            TimeSeriesPoint(
+                day=MAY_7, event="agent_exit", count=1,
+                cost_usd=4.0, input_tokens=2, output_tokens=3,
+                cache_read_tokens=1, cache_write_tokens=1,
+            ),
+        ]
+        throughput_rows = [
+            ThroughputDayRow(day=MAY_1, resolved=2, rejected=1),
+            ThroughputDayRow(day=MAY_7, resolved=0, rejected=1),
+        ]
+        review_round_rows = [
+            ReviewRoundBucketRow(bucket="0", runs=2, total_cost_usd=5.0),
+            ReviewRoundBucketRow(bucket="1", runs=1, total_cost_usd=3.0),
+        ]
+
+        kpis, resolved, rejected = dashboard._build_kpi_strip_data(
+            theme=theme,
+            summary=summary,
+            prev_summary=prev_summary,
+            ts_points=ts_points,
+            throughput_rows=throughput_rows,
+            review_round_rows=review_round_rows,
+            days_in_window=2,
+        )
+
+        by_label = {kpi["label"]: kpi for kpi in kpis}
+        self.assertEqual((resolved, rejected), (2, 2))
+        self.assertEqual(by_label["Total tokens"]["value"], "40")
+        self.assertEqual(by_label["Total tokens"]["delta"], 1.0)
+        self.assertEqual(by_label["Total tokens"]["spark"], [23.0, 7.0])
+        self.assertEqual(by_label["Total spend"]["spark"], [2.0, 4.0])
+        self.assertEqual(by_label["Cost / resolved issue"]["value"], "$6.00")
+        self.assertEqual(
+            by_label["Cost / resolved issue"]["spark"], [2, 0],
+        )
+        self.assertEqual(by_label["Rework share"]["value"], "38%")
+
+    def test_backend_tokens_by_day_accumulates_duplicate_cells(self) -> None:
+        _, dashboard = _reload()
+        from orchestrator.analytics.read import BackendDailyTokensRow
+
+        rows = [
+            BackendDailyTokensRow(day=MAY_1, backend="claude", total_tokens=10),
+            BackendDailyTokensRow(day=MAY_1, backend="claude", total_tokens=5),
+            BackendDailyTokensRow(day=MAY_1, backend="codex", total_tokens=3),
+            BackendDailyTokensRow(day=MAY_7, backend="claude", total_tokens=8),
+        ]
+
+        self.assertEqual(
+            dashboard._backend_tokens_by_day(rows),
+            {
+                MAY_1: {"claude": 15.0, "codex": 3.0},
+                MAY_7: {"claude": 8.0},
+            },
         )
 
 
@@ -1999,9 +2092,7 @@ class FanOutReadsParallelTest(unittest.TestCase):
 class MainRenderDispatchTest(_MainSourceTest):
     """`main()` dispatches its body through focused `_render_*` helpers
     -- the sidebar / date filter bar up top, then the widget cards in
-    top-to-bottom page order after the fan-out. The skill-trigger card
-    stays inline in `main()` between the heatmap and recent-runs
-    helpers (its wiring is source-inspected by `SkillMatrixWiringTest`).
+    top-to-bottom page order after the fan-out.
     """
 
     def test_render_helpers_called_in_page_order(self) -> None:
@@ -2014,6 +2105,7 @@ class MainRenderDispatchTest(_MainSourceTest):
             "_render_issues_and_backends(",
             "_render_repo_and_reliability(",
             "_render_activity_heatmap(",
+            "_render_skill_triggers(",
             "_render_recent_runs(",
         ]
         idxs = [src.index(marker) for marker in order]
@@ -2028,7 +2120,7 @@ class MainRenderDispatchTest(_MainSourceTest):
     ) -> None:
         src = self._main_source()
         heatmap = src.index("_render_activity_heatmap(")
-        skill = src.index("_skill_triggers_html(skill_rows)")
+        skill = src.index("_render_skill_triggers(")
         recent = src.index("_render_recent_runs(")
         self.assertLess(heatmap, skill)
         self.assertLess(skill, recent)
@@ -2110,7 +2202,7 @@ class SkillMatrixWiringTest(_MainSourceTest):
     """The per-skill trigger matrix rides the same cached / fan-out
     read pattern as every other widget (its wrapper lives in
     `_widget_readers`) and renders as the second table under the
-    "Skill trigger rates" aggregate (inline in `main`). Streamlit is
+    "Skill trigger rates" aggregate. Streamlit is
     not installed for the default sync, so these inspect the rendered
     sources rather than driving the page under Streamlit.
     """
@@ -2156,32 +2248,32 @@ class SkillMatrixWiringTest(_MainSourceTest):
     def test_matrix_rendered_as_second_table_under_aggregate(self) -> None:
         # The matrix is the SECOND table: it renders after the aggregate
         # `_skill_triggers_html(skill_rows)` table, inside the same card.
-        src = self._main_source()
+        src = self._source_of("_render_skill_triggers")
         agg = src.index("_skill_triggers_html(skill_rows)")
-        matrix = src.index("_skill_matrix_html(")
+        matrix = src.index("_render_skill_matrix_expander(")
         self.assertLess(agg, matrix)
 
     def test_matrix_only_renders_when_aggregate_has_rows(self) -> None:
-        # The matrix render sits inside the `if skill_rows:` branch, so
-        # the empty-panel path still shows the single no-rows notice
-        # rather than a fallback for each table.
-        src = self._main_source()
-        branch = src.index("if skill_rows:")
+        # The matrix render sits after the empty aggregate's early return,
+        # so the no-rows path still shows the single notice rather than a
+        # fallback for each table.
+        src = self._source_of("_render_skill_triggers")
+        branch = src.index("if not skill_rows:")
         else_branch = src.index(
             'st.info("No `agent_exit` rows match the current filters.")',
             branch,
         )
-        matrix = src.index("_skill_matrix_html(")
+        matrix = src.index("_render_skill_matrix_expander(")
         self.assertLess(branch, matrix)
-        self.assertLess(matrix, else_branch)
+        self.assertLess(else_branch, matrix)
 
     def test_matrix_rendered_inside_collapsed_expander(self) -> None:
         # The matrix folds into a collapsed expander (mirroring the
         # "Recent agent runs" block) so it does not dominate the card by
         # default. The `_skill_matrix_html` render must sit after an
         # `st.expander(..., expanded=False)` opened for the matrix.
-        src = self._main_source()
-        expander = src.index('with st.expander(\n                "Per-skill')
+        src = self._source_of("_render_skill_matrix_expander")
+        expander = src.index('with st.expander(\n        "Per-skill')
         matrix = src.index("_skill_matrix_html(")
         self.assertLess(expander, matrix)
         # The expander block carrying the matrix opens collapsed.


### PR DESCRIPTION
Resolves #774 

Implemented the dashboard complexity refactor.

Changed:

- `orchestrator/dashboard_charts.py`: extracted shared chart helpers for two-line ticks, horizontal bar layout, money labels, stacked cost traces, usage rollups, and review-round ordering.
- `orchestrator/dashboard.py`: moved KPI prep, throughput totals, backend daily-token aggregation, and skill-trigger rendering into focused helpers.
- `orchestrator/dashboard_html.py`: centralized table CSS/header/table assembly and split row rendering for issues, skill triggers, and skill matrix.
- `tests/test_dashboard.py`: updated source-inspection tests for the new render helper boundary and added direct coverage for KPI/backend data-prep helpers.