### PR TITLE
test: consolidate workflow test constants

### DIFF
--- a/tests/test_workflow_agent_analytics.py
+++ b/tests/test_workflow_agent_analytics.py
@@ -17,7 +17,24 @@ from orchestrator import analytics, config, usage, workflow
 from orchestrator.agents import AgentResult
 
 from tests.fakes import FakeGitHubClient, FakePR, make_issue
-from tests.workflow_helpers import _FAKE_WT, _PatchedWorkflowMixin, _TEST_SPEC
+from tests.workflow_helpers import (
+    BACKEND_CLAUDE,
+    BACKEND_CODEX,
+    EVENT_AGENT_EXIT,
+    EVENT_AGENT_SPAWN,
+    EVENT_AGENT_TRAJECTORY,
+    EVENT_SKILL_TRIGGERED,
+    LABEL_IMPLEMENTING,
+    LABEL_VALIDATING,
+    REVIEW_APPROVED_MESSAGE,
+    ROLE_DEVELOPER,
+    ROLE_REVIEWER,
+    TEST_BASE_BRANCH,
+    TEST_REPO_SLUG,
+    _FAKE_WT,
+    _PatchedWorkflowMixin,
+    _TEST_SPEC,
+)
 
 
 def _codex_stdout_no_model(
@@ -139,7 +156,7 @@ class AgentAnalyticsTest(unittest.TestCase, _PatchedWorkflowMixin):
             path = Path(td) / "analytics.jsonl"
             stdout = _claude_stdout(total_cost_usd=0.0123)
             gh = FakeGitHubClient()
-            issue = make_issue(101, label="implementing")
+            issue = make_issue(101, label=LABEL_IMPLEMENTING)
             gh.add_issue(issue)
             self._run(
                 lambda: workflow._handle_implementing(
@@ -162,11 +179,11 @@ class AgentAnalyticsTest(unittest.TestCase, _PatchedWorkflowMixin):
             rec = records[0]
             # Audit context — same shape `agent_exit` uses, so an
             # operator can correlate sinks one-to-one.
-            self.assertEqual(rec["event"], "agent_exit")
-            self.assertEqual(rec["repo"], "geserdugarov/agent-orchestrator")
+            self.assertEqual(rec["event"], EVENT_AGENT_EXIT)
+            self.assertEqual(rec["repo"], TEST_REPO_SLUG)
             self.assertEqual(rec["issue"], 101)
-            self.assertEqual(rec["stage"], "implementing")
-            self.assertEqual(rec["agent_role"], "developer")
+            self.assertEqual(rec["stage"], LABEL_IMPLEMENTING)
+            self.assertEqual(rec["agent_role"], ROLE_DEVELOPER)
             self.assertEqual(rec["backend"], config.DEV_AGENT)
             # Configured spec: implementing's fresh-spawn branch persists
             # DEV_AGENT_SPEC in pinned state before invoking the wrapper.
@@ -204,7 +221,7 @@ class AgentAnalyticsTest(unittest.TestCase, _PatchedWorkflowMixin):
             gh = FakeGitHubClient()
             issue = make_issue(
                 102,
-                label="implementing",
+                label=LABEL_IMPLEMENTING,
                 body=f"please use token {secret_marker}",
             )
             gh.add_issue(issue)
@@ -250,12 +267,12 @@ class AgentAnalyticsTest(unittest.TestCase, _PatchedWorkflowMixin):
             path = Path(td) / "analytics.jsonl"
             stdout = _claude_stdout(msg_id="msg-review")
             gh = FakeGitHubClient()
-            issue = make_issue(103, label="validating")
+            issue = make_issue(103, label=LABEL_VALIDATING)
             gh.add_issue(issue)
             pr = FakePR(
                 number=44,
                 head_branch="orchestrator/geserdugarov__agent-orchestrator/issue-103",
-                base_branch="main",
+                base_branch=TEST_BASE_BRANCH,
                 mergeable=True,
                 check_state="success",
                 approved=False,
@@ -272,7 +289,7 @@ class AgentAnalyticsTest(unittest.TestCase, _PatchedWorkflowMixin):
                     ),
                     run_agent=AgentResult(
                         session_id="sess-review",
-                        last_message="VERDICT: APPROVED",
+                        last_message=REVIEW_APPROVED_MESSAGE,
                         exit_code=0,
                         timed_out=False,
                         stdout=stdout,
@@ -285,11 +302,11 @@ class AgentAnalyticsTest(unittest.TestCase, _PatchedWorkflowMixin):
             records = self._exit_records(path)
             reviewer = [
                 record for record in records
-                if record.get("agent_role") == "reviewer"
+                if record.get("agent_role") == ROLE_REVIEWER
             ]
             self.assertEqual(len(reviewer), 1)
             reviewer_record = reviewer[0]
-            self.assertEqual(reviewer_record["stage"], "validating")
+            self.assertEqual(reviewer_record["stage"], LABEL_VALIDATING)
             self.assertEqual(reviewer_record["backend"], config.REVIEW_AGENT)
             self.assertEqual(reviewer_record["agent_spec"], config.REVIEW_AGENT_SPEC)
             self.assertEqual(reviewer_record["review_round"], 2)
@@ -306,7 +323,7 @@ class AgentAnalyticsTest(unittest.TestCase, _PatchedWorkflowMixin):
         with tempfile.TemporaryDirectory(prefix="analytics-timeout-") as td:
             path = Path(td) / "analytics.jsonl"
             gh = FakeGitHubClient()
-            issue = make_issue(104, label="implementing")
+            issue = make_issue(104, label=LABEL_IMPLEMENTING)
             gh.add_issue(issue)
             self._run(
                 lambda: workflow._handle_implementing(
@@ -346,7 +363,7 @@ class AgentAnalyticsTest(unittest.TestCase, _PatchedWorkflowMixin):
             path = Path(td) / "analytics.jsonl"
             stdout = _claude_stdout()
             gh = FakeGitHubClient()
-            issue = make_issue(105, label="implementing")
+            issue = make_issue(105, label=LABEL_IMPLEMENTING)
             gh.add_issue(issue)
             self._run(
                 lambda: workflow._handle_implementing(
@@ -366,11 +383,11 @@ class AgentAnalyticsTest(unittest.TestCase, _PatchedWorkflowMixin):
 
             spawns = [
                 event for event in gh.recorded_events
-                if event["event"] == "agent_spawn"
+                if event["event"] == EVENT_AGENT_SPAWN
             ]
             exits = [
                 event for event in gh.recorded_events
-                if event["event"] == "agent_exit"
+                if event["event"] == EVENT_AGENT_EXIT
             ]
             self.assertEqual(len(spawns), 1)
             self.assertEqual(len(exits), 1)
@@ -388,7 +405,7 @@ class AgentAnalyticsTest(unittest.TestCase, _PatchedWorkflowMixin):
         with tempfile.TemporaryDirectory(prefix="analytics-off-") as td:
             sentinel = Path(td) / "must-not-exist.jsonl"
             gh = FakeGitHubClient()
-            issue = make_issue(106, label="implementing")
+            issue = make_issue(106, label=LABEL_IMPLEMENTING)
             gh.add_issue(issue)
             self._run(
                 lambda: workflow._handle_implementing(
@@ -408,7 +425,7 @@ class AgentAnalyticsTest(unittest.TestCase, _PatchedWorkflowMixin):
             self.assertEqual(list(Path(td).iterdir()), [])
             # Audit events are still captured in memory.
             self.assertIn(
-                "agent_exit",
+                EVENT_AGENT_EXIT,
                 {event["event"] for event in gh.recorded_events},
             )
 
@@ -437,9 +454,9 @@ class AgentAnalyticsTest(unittest.TestCase, _PatchedWorkflowMixin):
                 gh = FakeGitHubClient()
                 workflow._run_agent_tracked(
                     gh, 107,
-                    agent_role="developer",
-                    stage="implementing",
-                    backend="codex",
+                    agent_role=ROLE_DEVELOPER,
+                    stage=LABEL_IMPLEMENTING,
+                    backend=BACKEND_CODEX,
                     prompt="ignored",
                     cwd=_FAKE_WT,
                     agent_spec="codex -m gpt-5-codex",
@@ -450,7 +467,7 @@ class AgentAnalyticsTest(unittest.TestCase, _PatchedWorkflowMixin):
             records = self._exit_records(path)
             self.assertEqual(len(records), 1)
             rec = records[0]
-            self.assertEqual(rec["backend"], "codex")
+            self.assertEqual(rec["backend"], BACKEND_CODEX)
             self.assertEqual(rec["agent_spec"], "codex -m gpt-5-codex")
             # Fallback wired the configured model into both the model
             # list and the cost estimate.
@@ -485,9 +502,9 @@ class AgentAnalyticsTest(unittest.TestCase, _PatchedWorkflowMixin):
                 gh = FakeGitHubClient()
                 workflow._run_agent_tracked(
                     gh, 108,
-                    agent_role="developer",
-                    stage="implementing",
-                    backend="claude",
+                    agent_role=ROLE_DEVELOPER,
+                    stage=LABEL_IMPLEMENTING,
+                    backend=BACKEND_CLAUDE,
                     prompt="ignored",
                     cwd=_FAKE_WT,
                     agent_spec="claude --model claude-opus-4-7",
@@ -521,7 +538,7 @@ class RunUsageSurfacedTest(unittest.TestCase):
         self,
         *,
         stdout: str,
-        backend: str = "claude",
+        backend: str = BACKEND_CLAUDE,
         track: bool = False,
         analytics_path: Optional[Path] = None,
         extra_args: tuple[str, ...] = (),
@@ -541,8 +558,8 @@ class RunUsageSurfacedTest(unittest.TestCase):
             )
             result = workflow._run_agent_tracked(
                 gh, 401,
-                agent_role="developer",
-                stage="implementing",
+                agent_role=ROLE_DEVELOPER,
+                stage=LABEL_IMPLEMENTING,
                 backend=backend,
                 prompt="ignored",
                 cwd=_FAKE_WT,
@@ -570,7 +587,7 @@ class RunUsageSurfacedTest(unittest.TestCase):
             analytics_path=None,
         )
         self.assertIsInstance(result.usage, usage.UsageMetrics)
-        self.assertEqual(result.usage.backend, "claude")
+        self.assertEqual(result.usage.backend, BACKEND_CLAUDE)
         self.assertEqual(result.usage.input_tokens, 1234)
         self.assertEqual(result.usage.output_tokens, 567)
         self.assertEqual(result.usage.cache_read_tokens, 100)
@@ -581,7 +598,7 @@ class RunUsageSurfacedTest(unittest.TestCase):
         self.assertAlmostEqual(result.usage.cost_usd, 0.0123)
         # The lifecycle audit still fired even with the sink disabled.
         self.assertIn(
-            "agent_exit", {event["event"] for event in gh.recorded_events},
+            EVENT_AGENT_EXIT, {event["event"] for event in gh.recorded_events},
         )
 
     def test_usage_reflects_spec_fallback_model(self) -> None:
@@ -590,7 +607,7 @@ class RunUsageSurfacedTest(unittest.TestCase):
         # -> `fallback_model`) is visible on `.usage` too.
         _, result = self._run(
             stdout=_codex_stdout_no_model(),
-            backend="codex",
+            backend=BACKEND_CODEX,
             extra_args=("-m", "gpt-5-codex"),
         )
         self.assertIsNotNone(result.usage)
@@ -618,7 +635,7 @@ class RunUsageSurfacedTest(unittest.TestCase):
             self.assertEqual(self._records(path), [])
             # Lifecycle audit events fired before the analytics parse ran.
             self.assertIn(
-                "agent_exit", {event["event"] for event in gh.recorded_events},
+                EVENT_AGENT_EXIT, {event["event"] for event in gh.recorded_events},
             )
 
     def test_analytics_and_skill_events_unchanged(
@@ -639,7 +656,7 @@ class RunUsageSurfacedTest(unittest.TestCase):
             records = self._records(path)
             self.assertEqual(len(records), 1)
             exit_record = records[0]
-            self.assertEqual(exit_record["event"], "agent_exit")
+            self.assertEqual(exit_record["event"], EVENT_AGENT_EXIT)
             self.assertEqual(exit_record["input_tokens"], 1000)
             self.assertEqual(exit_record["output_tokens"], 500)
             # The record shape is unchanged -- the surfaced field name must
@@ -651,7 +668,7 @@ class RunUsageSurfacedTest(unittest.TestCase):
             # Skill-trigger audit events are unaffected.
             skill_events = [
                 event for event in gh.recorded_events
-                if event["event"] == "skill_triggered"
+                if event["event"] == EVENT_SKILL_TRIGGERED
             ]
             self.assertEqual(
                 [event["skill"] for event in skill_events], ["develop", "review"],
@@ -716,7 +733,7 @@ class TrajectoryRecordingTest(unittest.TestCase):
         prompt: str,
         traj_path: Optional[Path],
         analytics_path: Optional[Path] = None,
-        backend: str = "claude",
+        backend: str = BACKEND_CLAUDE,
         track: bool = False,
     ) -> AgentResult:
         gh = FakeGitHubClient()
@@ -734,8 +751,8 @@ class TrajectoryRecordingTest(unittest.TestCase):
             )
             return workflow._run_agent_tracked(
                 gh, 301,
-                agent_role="developer",
-                stage="implementing",
+                agent_role=ROLE_DEVELOPER,
+                stage=LABEL_IMPLEMENTING,
                 backend=backend,
                 prompt=prompt,
                 cwd=_FAKE_WT,
@@ -757,9 +774,9 @@ class TrajectoryRecordingTest(unittest.TestCase):
             )
             workflow._run_agent_tracked(
                 gh, 302,
-                agent_role="developer",
-                stage="implementing",
-                backend="claude",
+                agent_role=ROLE_DEVELOPER,
+                stage=LABEL_IMPLEMENTING,
+                backend=BACKEND_CLAUDE,
                 prompt="PROMPT-MARKER-XYZ",
                 cwd=_FAKE_WT,
             )
@@ -781,10 +798,10 @@ class TrajectoryRecordingTest(unittest.TestCase):
             traj = self._records(t_path)
             self.assertEqual(len(traj), 1)
             rec = traj[0]
-            self.assertEqual(rec["event"], "agent_trajectory")
+            self.assertEqual(rec["event"], EVENT_AGENT_TRAJECTORY)
             self.assertEqual(rec["issue"], 301)
-            self.assertEqual(rec["stage"], "implementing")
-            self.assertEqual(rec["agent_role"], "developer")
+            self.assertEqual(rec["stage"], LABEL_IMPLEMENTING)
+            self.assertEqual(rec["agent_role"], ROLE_DEVELOPER)
             self.assertEqual(rec["user_input"], "implement the widget")
             self.assertEqual(rec["output"], "implemented")
             self.assertEqual(
@@ -794,7 +811,7 @@ class TrajectoryRecordingTest(unittest.TestCase):
             # Baseline agent_exit analytics record still written, sans prompt.
             base = self._records(a_path)
             self.assertEqual(len(base), 1)
-            self.assertEqual(base[0]["event"], "agent_exit")
+            self.assertEqual(base[0]["event"], EVENT_AGENT_EXIT)
             self.assertNotIn("user_input", base[0])
 
     def test_no_trajectory_record_when_sink_off(self) -> None:
@@ -840,15 +857,16 @@ class TrajectoryRecordingTest(unittest.TestCase):
                 )
                 workflow._run_agent_tracked(
                     gh, 303,
-                    agent_role="developer",
-                    stage="implementing",
-                    backend="claude",
+                    agent_role=ROLE_DEVELOPER,
+                    stage=LABEL_IMPLEMENTING,
+                    backend=BACKEND_CLAUDE,
                     prompt="p",
                     cwd=_FAKE_WT,
-                    agent_spec="claude",
+                    agent_spec=BACKEND_CLAUDE,
                 )
             skill_events = [
-                event for event in gh.recorded_events if event["event"] == "skill_triggered"
+                event for event in gh.recorded_events
+                if event["event"] == EVENT_SKILL_TRIGGERED
             ]
             self.assertEqual([event["skill"] for event in skill_events], ["develop"])
             self.assertFalse(t_path.exists())
@@ -875,9 +893,9 @@ class TrajectorySinkHermeticityTest(unittest.TestCase):
             )
             workflow._run_agent_tracked(
                 gh, 562,
-                agent_role="developer",
-                stage="implementing",
-                backend="claude",
+                agent_role=ROLE_DEVELOPER,
+                stage=LABEL_IMPLEMENTING,
+                backend=BACKEND_CLAUDE,
                 prompt="implement the widget",
                 cwd=_FAKE_WT,
             )
@@ -938,7 +956,10 @@ class SkillTriggeredEventTest(unittest.TestCase):
 
     @staticmethod
     def _skill_events(gh: FakeGitHubClient) -> list[dict]:
-        return [event for event in gh.recorded_events if event["event"] == "skill_triggered"]
+        return [
+            event for event in gh.recorded_events
+            if event["event"] == EVENT_SKILL_TRIGGERED
+        ]
 
     def _run(
         self,
@@ -946,7 +967,7 @@ class SkillTriggeredEventTest(unittest.TestCase):
         *,
         stdout: str,
         track: bool,
-        backend: str = "claude",
+        backend: str = BACKEND_CLAUDE,
         review_round: Optional[int] = 2,
         retry_count: Optional[int] = 1,
     ) -> AgentResult:
@@ -969,8 +990,8 @@ class SkillTriggeredEventTest(unittest.TestCase):
             )
             return workflow._run_agent_tracked(
                 gh, 201,
-                agent_role="developer",
-                stage="implementing",
+                agent_role=ROLE_DEVELOPER,
+                stage=LABEL_IMPLEMENTING,
                 backend=backend,
                 prompt="ignored",
                 cwd=_FAKE_WT,
@@ -993,15 +1014,15 @@ class SkillTriggeredEventTest(unittest.TestCase):
         events = self._skill_events(gh)
         self.assertEqual([event["skill"] for event in events], ["develop", "review"])
         for event in events:
-            self.assertEqual(event["agent"], "claude")
-            self.assertEqual(event["agent_role"], "developer")
-            self.assertEqual(event["stage"], "implementing")
+            self.assertEqual(event["agent"], BACKEND_CLAUDE)
+            self.assertEqual(event["agent_role"], ROLE_DEVELOPER)
+            self.assertEqual(event["stage"], LABEL_IMPLEMENTING)
             self.assertEqual(event["review_round"], 2)
             self.assertEqual(event["retry_count"], 1)
         # The baseline audit lifecycle events still fire alongside.
         kinds = {event["event"] for event in gh.recorded_events}
-        self.assertIn("agent_spawn", kinds)
-        self.assertIn("agent_exit", kinds)
+        self.assertIn(EVENT_AGENT_SPAWN, kinds)
+        self.assertIn(EVENT_AGENT_EXIT, kinds)
 
     def test_switch_off_emits_no_skill_events(self) -> None:
         # Default-off: a skill-bearing stream produces the lifecycle events
@@ -1015,7 +1036,7 @@ class SkillTriggeredEventTest(unittest.TestCase):
         )
         self.assertEqual(self._skill_events(gh), [])
         self.assertIn(
-            "agent_exit", {event["event"] for event in gh.recorded_events},
+            EVENT_AGENT_EXIT, {event["event"] for event in gh.recorded_events},
         )
 
     def test_no_triggers_emits_no_skill_events(self) -> None:
@@ -1057,9 +1078,9 @@ class SkillTriggeredEventTest(unittest.TestCase):
             )
             workflow._run_agent_tracked(
                 gh, 202,
-                agent_role="reviewer",
-                stage="validating",
-                backend="codex",
+                agent_role=ROLE_REVIEWER,
+                stage=LABEL_VALIDATING,
+                backend=BACKEND_CODEX,
                 prompt="ignored",
                 cwd=_FAKE_WT,
             )
@@ -1074,7 +1095,7 @@ class SkillTriggeredEventTest(unittest.TestCase):
         # and `_run_agent_tracked` still returns the AgentResult.
         class _RaisingOnSkillGH(FakeGitHubClient):
             def emit_event(self, event, **kwargs):
-                if event == "skill_triggered":
+                if event == EVENT_SKILL_TRIGGERED:
                     raise RuntimeError("emit boom")
                 return super().emit_event(event, **kwargs)
 
@@ -1089,4 +1110,4 @@ class SkillTriggeredEventTest(unittest.TestCase):
         # The raising path emitted no skill event, but the lifecycle events
         # (which do not raise) still landed.
         self.assertEqual(self._skill_events(gh), [])
-        self.assertIn("agent_exit", {event["event"] for event in gh.recorded_events})
+        self.assertIn(EVENT_AGENT_EXIT, {event["event"] for event in gh.recorded_events})

--- a/tests/test_workflow_drain_terminals.py
+++ b/tests/test_workflow_drain_terminals.py
@@ -21,10 +21,24 @@ from tests.fakes import (
     make_issue,
 )
 from tests.workflow_helpers import (
+    EVENT_PR_CLOSED_WITHOUT_MERGE,
+    EVENT_PR_MERGED,
+    LABEL_DONE,
+    LABEL_FIXING,
+    LABEL_IN_REVIEW,
+    LABEL_REJECTED,
+    LABEL_RESOLVING_CONFLICT,
+    STATE_CLOSED,
+    STATE_OPEN,
     _PatchedWorkflowMixin,
     _TEST_SPEC,
     _agent,
+    _issue_branch,
 )
+
+
+DEFAULT_HEAD_SHA = "cafe1234"
+MERGE_METHOD_EXTERNAL = "external"
 
 
 class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
@@ -54,14 +68,14 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
         # down the fixing body). No label change, no state writes, no
         # cleanup, no events.
         gh = FakeGitHubClient()
-        issue = make_issue(310, label="fixing")
+        issue = make_issue(310, label=LABEL_FIXING)
         gh.add_issue(issue)
         state = self._state_with_pr_number(gh, 310, 31000)
 
         result = self._run(
             lambda: self.assertFalse(
                 workflow._drain_review_pr_terminals(
-                    gh, _TEST_SPEC, issue, state, None, stage="fixing",
+                    gh, _TEST_SPEC, issue, state, None, stage=LABEL_FIXING,
                 )
             ),
             run_agent=_agent(),
@@ -77,12 +91,12 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
         # the helper returning False for a "nothing terminal" state so
         # the caller can continue with the same `pr`.
         gh = FakeGitHubClient()
-        issue = make_issue(311, label="in_review")
+        issue = make_issue(311, label=LABEL_IN_REVIEW)
         gh.add_issue(issue)
         pr = FakePR(
-            number=31100, head_branch="orchestrator/geserdugarov__agent-orchestrator/issue-311",
-            head=FakePRRef(sha="cafe1234"),
-            merged=False, state="open",
+            number=31100, head_branch=_issue_branch(311),
+            head=FakePRRef(sha=DEFAULT_HEAD_SHA),
+            merged=False, state=STATE_OPEN,
         )
         gh.add_pr(pr)
         state = self._state_with_pr_number(gh, 311, 31100)
@@ -90,7 +104,7 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
         result = self._run(
             lambda: self.assertFalse(
                 workflow._drain_review_pr_terminals(
-                    gh, _TEST_SPEC, issue, state, pr, stage="in_review",
+                    gh, _TEST_SPEC, issue, state, pr, stage=LABEL_IN_REVIEW,
                 )
             ),
             run_agent=_agent(),
@@ -106,44 +120,45 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
         # `pr_merged` with `merge_method="external"` and the supplied
         # stage, close the issue if still open, and run branch cleanup.
         gh = FakeGitHubClient()
-        issue = make_issue(312, label="fixing")
+        issue = make_issue(312, label=LABEL_FIXING)
         gh.add_issue(issue)
         pr = FakePR(
-            number=31200, head_branch="orchestrator/geserdugarov__agent-orchestrator/issue-312",
-            head=FakePRRef(sha="cafe1234"),
-            merged=True, state="closed",
+            number=31200, head_branch=_issue_branch(312),
+            head=FakePRRef(sha=DEFAULT_HEAD_SHA),
+            merged=True, state=STATE_CLOSED,
         )
         gh.add_pr(pr)
         state = self._state_with_pr_number(
             gh, 312, 31200, review_round=2, conflict_round=0,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-312",
+            branch=_issue_branch(312),
         )
 
         result = self._run(
             lambda: self.assertTrue(
                 workflow._drain_review_pr_terminals(
-                    gh, _TEST_SPEC, issue, state, pr, stage="fixing",
+                    gh, _TEST_SPEC, issue, state, pr, stage=LABEL_FIXING,
                 )
             ),
             run_agent=_agent(),
         )
 
-        self.assertIn((312, "done"), gh.label_history)
+        self.assertIn((312, LABEL_DONE), gh.label_history)
         self.assertIn("merged_at", state.data)
         self.assertTrue(issue.closed)
         result["_cleanup_terminal_branch"].assert_called_once_with(
             gh, _TEST_SPEC, 312,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-312",
+            branch=_issue_branch(312),
         )
         merged_events = [
-            event for event in gh.recorded_events if event["event"] == "pr_merged"
+            event for event in gh.recorded_events
+            if event["event"] == EVENT_PR_MERGED
         ]
         self.assertEqual(len(merged_events), 1)
         event = merged_events[0]
-        self.assertEqual(event["stage"], "fixing")
+        self.assertEqual(event["stage"], LABEL_FIXING)
         self.assertEqual(event["pr_number"], 31200)
-        self.assertEqual(event["merge_method"], "external")
-        self.assertEqual(event["sha"], "cafe1234")
+        self.assertEqual(event["merge_method"], MERGE_METHOD_EXTERNAL)
+        self.assertEqual(event["sha"], DEFAULT_HEAD_SHA)
         self.assertEqual(event["review_round"], 2)
 
     def test_closed_unmerged_pr_finalizes_to_rejected(
@@ -155,43 +170,43 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
         # The branch is dead weight once the PR is gone, mirroring the
         # merged-PR cleanup order.
         gh = FakeGitHubClient()
-        issue = make_issue(313, label="resolving_conflict")
+        issue = make_issue(313, label=LABEL_RESOLVING_CONFLICT)
         gh.add_issue(issue)
         pr = FakePR(
-            number=31300, head_branch="orchestrator/geserdugarov__agent-orchestrator/issue-313",
+            number=31300, head_branch=_issue_branch(313),
             head=FakePRRef(sha="dead0001"),
-            merged=False, state="closed",
+            merged=False, state=STATE_CLOSED,
         )
         gh.add_pr(pr)
         state = self._state_with_pr_number(
             gh, 313, 31300, review_round=3, conflict_round=2,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-313",
+            branch=_issue_branch(313),
         )
 
         result = self._run(
             lambda: self.assertTrue(
                 workflow._drain_review_pr_terminals(
                     gh, _TEST_SPEC, issue, state, pr,
-                    stage="resolving_conflict",
+                    stage=LABEL_RESOLVING_CONFLICT,
                 )
             ),
             run_agent=_agent(),
         )
 
-        self.assertIn((313, "rejected"), gh.label_history)
+        self.assertIn((313, LABEL_REJECTED), gh.label_history)
         self.assertIn("closed_without_merge_at", state.data)
         self.assertTrue(issue.closed)
         result["_cleanup_terminal_branch"].assert_called_once_with(
             gh, _TEST_SPEC, 313,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-313",
+            branch=_issue_branch(313),
         )
         closed_events = [
             event for event in gh.recorded_events
-            if event["event"] == "pr_closed_without_merge"
+            if event["event"] == EVENT_PR_CLOSED_WITHOUT_MERGE
         ]
         self.assertEqual(len(closed_events), 1)
         event = closed_events[0]
-        self.assertEqual(event["stage"], "resolving_conflict")
+        self.assertEqual(event["stage"], LABEL_RESOLVING_CONFLICT)
         self.assertEqual(event["pr_number"], 31300)
         self.assertEqual(event["sha"], "dead0001")
         self.assertEqual(event["review_round"], 3)
@@ -208,13 +223,13 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
         # emit either -- `pr_closed_without_merge` is reserved for the
         # genuine closed-PR arc above.
         gh = FakeGitHubClient()
-        issue = make_issue(314, label="in_review")
+        issue = make_issue(314, label=LABEL_IN_REVIEW)
         issue.closed = True
         gh.add_issue(issue)
         pr = FakePR(
-            number=31400, head_branch="orchestrator/geserdugarov__agent-orchestrator/issue-314",
-            head=FakePRRef(sha="cafe1234"),
-            merged=False, state="open",
+            number=31400, head_branch=_issue_branch(314),
+            head=FakePRRef(sha=DEFAULT_HEAD_SHA),
+            merged=False, state=STATE_OPEN,
         )
         gh.add_pr(pr)
         state = self._state_with_pr_number(gh, 314, 31400)
@@ -222,13 +237,13 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
         result = self._run(
             lambda: self.assertTrue(
                 workflow._drain_review_pr_terminals(
-                    gh, _TEST_SPEC, issue, state, pr, stage="in_review",
+                    gh, _TEST_SPEC, issue, state, pr, stage=LABEL_IN_REVIEW,
                 )
             ),
             run_agent=_agent(),
         )
 
-        self.assertIn((314, "rejected"), gh.label_history)
+        self.assertIn((314, LABEL_REJECTED), gh.label_history)
         self.assertIn("closed_without_merge_at", state.data)
         # The PR is still open and may be reopened / salvaged, so the
         # branch must survive this exit.
@@ -236,11 +251,14 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
         # No `pr_closed_without_merge` emit for the open-PR case.
         self.assertEqual(
             [event for event in gh.recorded_events
-             if event["event"] == "pr_closed_without_merge"],
+             if event["event"] == EVENT_PR_CLOSED_WITHOUT_MERGE],
             [],
         )
         self.assertEqual(
-            [event for event in gh.recorded_events if event["event"] == "pr_merged"],
+            [
+                event for event in gh.recorded_events
+                if event["event"] == EVENT_PR_MERGED
+            ],
             [],
         )
 
@@ -258,12 +276,12 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
         # silently lose `conflict_round` from `pr_merged` /
         # `pr_closed_without_merge` events.
         gh = FakeGitHubClient()
-        issue = make_issue(316, label="resolving_conflict")
+        issue = make_issue(316, label=LABEL_RESOLVING_CONFLICT)
         gh.add_issue(issue)
         pr = FakePR(
-            number=31600, head_branch="orchestrator/geserdugarov__agent-orchestrator/issue-316",
+            number=31600, head_branch=_issue_branch(316),
             head=FakePRRef(sha="feed1234"),
-            merged=True, state="closed",
+            merged=True, state=STATE_CLOSED,
         )
         gh.add_pr(pr)
         # Deliberately omit `conflict_round` from the pinned state.
@@ -273,30 +291,31 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
             lambda: self.assertTrue(
                 workflow._drain_review_pr_terminals(
                     gh, _TEST_SPEC, issue, state, pr,
-                    stage="resolving_conflict",
+                    stage=LABEL_RESOLVING_CONFLICT,
                 )
             ),
             run_agent=_agent(),
         )
 
         merged_events = [
-            event for event in gh.recorded_events if event["event"] == "pr_merged"
+            event for event in gh.recorded_events
+            if event["event"] == EVENT_PR_MERGED
         ]
         self.assertEqual(len(merged_events), 1)
         merged_event = merged_events[0]
-        self.assertEqual(merged_event["stage"], "resolving_conflict")
+        self.assertEqual(merged_event["stage"], LABEL_RESOLVING_CONFLICT)
         # Field must be present (build_event_record drops None), and
         # the coerced default must be 0.
         self.assertIn("conflict_round", merged_event)
         self.assertEqual(merged_event["conflict_round"], 0)
 
         # Same coercion for the closed-without-merge arc.
-        issue2 = make_issue(317, label="resolving_conflict")
+        issue2 = make_issue(317, label=LABEL_RESOLVING_CONFLICT)
         gh.add_issue(issue2)
         pr2 = FakePR(
-            number=31700, head_branch="orchestrator/geserdugarov__agent-orchestrator/issue-317",
+            number=31700, head_branch=_issue_branch(317),
             head=FakePRRef(sha="feed5678"),
-            merged=False, state="closed",
+            merged=False, state=STATE_CLOSED,
         )
         gh.add_pr(pr2)
         state2 = self._state_with_pr_number(gh, 317, 31700)
@@ -305,7 +324,7 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
             lambda: self.assertTrue(
                 workflow._drain_review_pr_terminals(
                     gh, _TEST_SPEC, issue2, state2, pr2,
-                    stage="resolving_conflict",
+                    stage=LABEL_RESOLVING_CONFLICT,
                 )
             ),
             run_agent=_agent(),
@@ -313,7 +332,7 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
 
         closed_events = [
             event for event in gh.recorded_events
-            if event["event"] == "pr_closed_without_merge"
+            if event["event"] == EVENT_PR_CLOSED_WITHOUT_MERGE
         ]
         self.assertEqual(len(closed_events), 1)
         closed_event = closed_events[0]
@@ -328,12 +347,12 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
         # `in_review` / `fixing` and start emitting a `conflict_round=0`
         # field on states that never had the counter.
         gh = FakeGitHubClient()
-        issue = make_issue(318, label="in_review")
+        issue = make_issue(318, label=LABEL_IN_REVIEW)
         gh.add_issue(issue)
         pr = FakePR(
-            number=31800, head_branch="orchestrator/geserdugarov__agent-orchestrator/issue-318",
+            number=31800, head_branch=_issue_branch(318),
             head=FakePRRef(sha="cafe5678"),
-            merged=True, state="closed",
+            merged=True, state=STATE_CLOSED,
         )
         gh.add_pr(pr)
         state = self._state_with_pr_number(gh, 318, 31800)
@@ -341,14 +360,15 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
         self._run(
             lambda: self.assertTrue(
                 workflow._drain_review_pr_terminals(
-                    gh, _TEST_SPEC, issue, state, pr, stage="in_review",
+                    gh, _TEST_SPEC, issue, state, pr, stage=LABEL_IN_REVIEW,
                 )
             ),
             run_agent=_agent(),
         )
 
         merged_events = [
-            event for event in gh.recorded_events if event["event"] == "pr_merged"
+            event for event in gh.recorded_events
+            if event["event"] == EVENT_PR_MERGED
         ]
         self.assertEqual(len(merged_events), 1)
         self.assertNotIn("conflict_round", merged_events[0])
@@ -362,13 +382,13 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
         # finalizes the label, but must not crash trying to re-close
         # what GitHub already closed.
         gh = FakeGitHubClient()
-        issue = make_issue(315, label="fixing")
+        issue = make_issue(315, label=LABEL_FIXING)
         issue.closed = True
         gh.add_issue(issue)
         pr = FakePR(
-            number=31500, head_branch="orchestrator/geserdugarov__agent-orchestrator/issue-315",
+            number=31500, head_branch=_issue_branch(315),
             head=FakePRRef(sha="feed0001"),
-            merged=True, state="closed",
+            merged=True, state=STATE_CLOSED,
         )
         gh.add_pr(pr)
         state = self._state_with_pr_number(gh, 315, 31500)
@@ -376,19 +396,20 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
         self._run(
             lambda: self.assertTrue(
                 workflow._drain_review_pr_terminals(
-                    gh, _TEST_SPEC, issue, state, pr, stage="fixing",
+                    gh, _TEST_SPEC, issue, state, pr, stage=LABEL_FIXING,
                 )
             ),
             run_agent=_agent(),
         )
 
-        self.assertIn((315, "done"), gh.label_history)
+        self.assertIn((315, LABEL_DONE), gh.label_history)
         self.assertTrue(issue.closed)
         merged_events = [
-            event for event in gh.recorded_events if event["event"] == "pr_merged"
+            event for event in gh.recorded_events
+            if event["event"] == EVENT_PR_MERGED
         ]
         self.assertEqual(len(merged_events), 1)
-        self.assertEqual(merged_events[0]["stage"], "fixing")
+        self.assertEqual(merged_events[0]["stage"], LABEL_FIXING)
 
     def test_each_terminal_arc_posts_tracked_usage_verdict(self) -> None:
         # All three terminal arcs -- merged -> done, closed -> rejected, and
@@ -397,9 +418,16 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
         # arc's `write_pinned_state`, so its id rides the persisted state.
         cases = [
             # (issue, pr, merged, pr_state, issue_closed, stage)
-            (320, 32000, True, "closed", False, "in_review"),
-            (321, 32100, False, "closed", False, "fixing"),
-            (322, 32200, False, "open", True, "resolving_conflict"),
+            (320, 32000, True, STATE_CLOSED, False, LABEL_IN_REVIEW),
+            (321, 32100, False, STATE_CLOSED, False, LABEL_FIXING),
+            (
+                322,
+                32200,
+                False,
+                STATE_OPEN,
+                True,
+                LABEL_RESOLVING_CONFLICT,
+            ),
         ]
         for n, prn, merged, pr_state, issue_closed, stage in cases:
             with self.subTest(stage=stage):
@@ -409,8 +437,8 @@ class DrainReviewPrTerminalsTest(unittest.TestCase, _PatchedWorkflowMixin):
                 gh.add_issue(issue)
                 pr = FakePR(
                     number=prn,
-                    head_branch=f"orchestrator/geserdugarov__agent-orchestrator/issue-{n}",
-                    head=FakePRRef(sha="cafe1234"),
+                    head_branch=_issue_branch(n),
+                    head=FakePRRef(sha=DEFAULT_HEAD_SHA),
                     merged=merged, state=pr_state,
                 )
                 gh.add_pr(pr)

--- a/tests/test_workflow_event_emission.py
+++ b/tests/test_workflow_event_emission.py
@@ -21,7 +21,23 @@ from tests.fakes import (
     FakePR,
     make_issue,
 )
-from tests.workflow_helpers import _PatchedWorkflowMixin, _TEST_SPEC, _agent
+from tests.workflow_helpers import (
+    EVENT_AGENT_EXIT,
+    EVENT_AGENT_SPAWN,
+    EVENT_STAGE_ENTER,
+    LABEL_DECOMPOSING,
+    LABEL_DOCUMENTING,
+    LABEL_IMPLEMENTING,
+    LABEL_VALIDATING,
+    REVIEW_APPROVED_MESSAGE,
+    ROLE_DEVELOPER,
+    ROLE_REVIEWER,
+    TEST_BASE_BRANCH,
+    TEST_REPO_SLUG,
+    _PatchedWorkflowMixin,
+    _TEST_SPEC,
+    _agent,
+)
 
 
 class StageEventEmissionTest(unittest.TestCase, _PatchedWorkflowMixin):
@@ -35,13 +51,13 @@ class StageEventEmissionTest(unittest.TestCase, _PatchedWorkflowMixin):
         gh = FakeGitHubClient()
         issue = make_issue(1)
         gh.add_issue(issue)
-        gh.set_workflow_label(issue, "implementing")
+        gh.set_workflow_label(issue, LABEL_IMPLEMENTING)
         self.assertEqual(len(gh.recorded_events), 1)
         event = gh.recorded_events[0]
-        self.assertEqual(event["event"], "stage_enter")
-        self.assertEqual(event["stage"], "implementing")
+        self.assertEqual(event["event"], EVENT_STAGE_ENTER)
+        self.assertEqual(event["stage"], LABEL_IMPLEMENTING)
         self.assertEqual(event["issue"], 1)
-        self.assertEqual(event["repo"], "geserdugarov/agent-orchestrator")
+        self.assertEqual(event["repo"], TEST_REPO_SLUG)
         self.assertIn("ts", event)
         # UTC timestamp, ISO 8601 with offset.
         datetime.fromisoformat(event["ts"])
@@ -51,7 +67,7 @@ class StageEventEmissionTest(unittest.TestCase, _PatchedWorkflowMixin):
         # short-circuit so downstream consumers don't see a phantom
         # `stage_enter` with stage=None.
         gh = FakeGitHubClient()
-        issue = make_issue(1, label="implementing")
+        issue = make_issue(1, label=LABEL_IMPLEMENTING)
         gh.add_issue(issue)
         gh.set_workflow_label(issue, None)
         self.assertEqual(gh.recorded_events, [])
@@ -71,9 +87,9 @@ class StageEventEmissionTest(unittest.TestCase, _PatchedWorkflowMixin):
             )
         stages = [
             event["stage"] for event in gh.recorded_events
-            if event["event"] == "stage_enter"
+            if event["event"] == EVENT_STAGE_ENTER
         ]
-        self.assertIn("decomposing", stages)
+        self.assertIn(LABEL_DECOMPOSING, stages)
 
     def test_event_log_path_writes_one_jsonl_object_per_line(self) -> None:
         # End-to-end: a configured EVENT_LOG_PATH receives one parseable
@@ -87,21 +103,21 @@ class StageEventEmissionTest(unittest.TestCase, _PatchedWorkflowMixin):
                 # A legal forward path (implementing -> validating ->
                 # documenting) so the sequence emits three stage_enter events
                 # without tripping the transition guard under `enforce`.
-                gh.set_workflow_label(issue, "implementing")
-                gh.set_workflow_label(issue, "validating")
-                gh.set_workflow_label(issue, "documenting")
+                gh.set_workflow_label(issue, LABEL_IMPLEMENTING)
+                gh.set_workflow_label(issue, LABEL_VALIDATING)
+                gh.set_workflow_label(issue, LABEL_DOCUMENTING)
             # File closed on context exit -- read it back, parse line by line.
             lines = path.read_text(encoding="utf-8").splitlines()
             self.assertEqual(len(lines), 3)
             records = [json.loads(line) for line in lines]
             self.assertEqual(
                 [record["stage"] for record in records],
-                ["implementing", "validating", "documenting"],
+                [LABEL_IMPLEMENTING, LABEL_VALIDATING, LABEL_DOCUMENTING],
             )
             for record in records:
-                self.assertEqual(record["event"], "stage_enter")
+                self.assertEqual(record["event"], EVENT_STAGE_ENTER)
                 self.assertEqual(record["issue"], 7)
-                self.assertEqual(record["repo"], "geserdugarov/agent-orchestrator")
+                self.assertEqual(record["repo"], TEST_REPO_SLUG)
                 # ts must be a valid ISO-8601 UTC timestamp.
                 ts = datetime.fromisoformat(record["ts"])
                 self.assertEqual(ts.tzinfo, timezone.utc)
@@ -119,7 +135,7 @@ class StageEventEmissionTest(unittest.TestCase, _PatchedWorkflowMixin):
                 gh = FakeGitHubClient()
                 issue = make_issue(1)
                 gh.add_issue(issue)
-                gh.set_workflow_label(issue, "implementing")
+                gh.set_workflow_label(issue, LABEL_IMPLEMENTING)
             self.assertFalse(sentinel.exists())
             # In-memory capture still works even with the file sink disabled,
             # so tests don't need a temp file to inspect transitions.
@@ -143,21 +159,21 @@ class AgentLifecycleEventEmissionTest(unittest.TestCase, _PatchedWorkflowMixin):
 
     def test_fresh_developer_spawn_emits_paired_events(self) -> None:
         gh = FakeGitHubClient()
-        issue = make_issue(1, label="implementing")
+        issue = make_issue(1, label=LABEL_IMPLEMENTING)
         gh.add_issue(issue)
         self._run(
             lambda: workflow._handle_implementing(gh, _TEST_SPEC, issue),
             run_agent=_agent(session_id="sess-dev", last_message="q?"),
             has_new_commits=False,
         )
-        spawns = self._events(gh, "agent_spawn")
-        exits = self._events(gh, "agent_exit")
+        spawns = self._events(gh, EVENT_AGENT_SPAWN)
+        exits = self._events(gh, EVENT_AGENT_EXIT)
         self.assertEqual(len(spawns), 1)
         self.assertEqual(len(exits), 1)
         spawn = spawns[0]
         exit_event = exits[0]
-        self.assertEqual(spawn["stage"], "implementing")
-        self.assertEqual(spawn["agent_role"], "developer")
+        self.assertEqual(spawn["stage"], LABEL_IMPLEMENTING)
+        self.assertEqual(spawn["agent_role"], ROLE_DEVELOPER)
         self.assertEqual(spawn["agent"], config.DEV_AGENT)
         self.assertNotIn("session_id", spawn)  # fresh spawn -- no resume id
         self.assertEqual(exit_event["session_id"], "sess-dev")
@@ -172,12 +188,12 @@ class AgentLifecycleEventEmissionTest(unittest.TestCase, _PatchedWorkflowMixin):
 
     def test_reviewer_spawn_carries_review_round_and_retry_count(self) -> None:
         gh = FakeGitHubClient()
-        issue = make_issue(2, label="validating")
+        issue = make_issue(2, label=LABEL_VALIDATING)
         gh.add_issue(issue)
         pr = FakePR(
             number=42,
             head_branch="orchestrator/geserdugarov__agent-orchestrator/issue-2",
-            base_branch="main",
+            base_branch=TEST_BASE_BRANCH,
             mergeable=True,
             check_state="success",
             approved=False,
@@ -193,17 +209,22 @@ class AgentLifecycleEventEmissionTest(unittest.TestCase, _PatchedWorkflowMixin):
             self._run(
                 lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
                 run_agent=_agent(
-                    session_id="sess-review", last_message="VERDICT: APPROVED",
+                    session_id="sess-review",
+                    last_message=REVIEW_APPROVED_MESSAGE,
                 ),
                 head_shas=[pr.head.sha, pr.head.sha],
             )
-        spawns = self._events(gh, "agent_spawn")
-        exits = self._events(gh, "agent_exit")
-        reviewer_spawns = [event for event in spawns if event["agent_role"] == "reviewer"]
-        reviewer_exits = [event for event in exits if event["agent_role"] == "reviewer"]
+        spawns = self._events(gh, EVENT_AGENT_SPAWN)
+        exits = self._events(gh, EVENT_AGENT_EXIT)
+        reviewer_spawns = [
+            event for event in spawns if event["agent_role"] == ROLE_REVIEWER
+        ]
+        reviewer_exits = [
+            event for event in exits if event["agent_role"] == ROLE_REVIEWER
+        ]
         self.assertEqual(len(reviewer_spawns), 1)
         self.assertEqual(len(reviewer_exits), 1)
-        self.assertEqual(reviewer_spawns[0]["stage"], "validating")
+        self.assertEqual(reviewer_spawns[0]["stage"], LABEL_VALIDATING)
         self.assertEqual(reviewer_spawns[0]["agent"], config.REVIEW_AGENT)
         self.assertEqual(reviewer_spawns[0]["review_round"], 1)
         self.assertEqual(reviewer_spawns[0]["retry_count"], 2)
@@ -215,7 +236,7 @@ class AgentLifecycleEventEmissionTest(unittest.TestCase, _PatchedWorkflowMixin):
         # A resume hands the spawn event the existing session id; the exit
         # event records the (same) live id from the AgentResult.
         gh = FakeGitHubClient()
-        issue = make_issue(3, label="implementing")
+        issue = make_issue(3, label=LABEL_IMPLEMENTING)
         issue.comments.append(FakeComment(id=2000, body="please retry"))
         gh.add_issue(issue)
         gh.seed_state(
@@ -227,14 +248,14 @@ class AgentLifecycleEventEmissionTest(unittest.TestCase, _PatchedWorkflowMixin):
             run_agent=_agent(session_id="sess-resume", last_message="q?"),
             has_new_commits=False,
         )
-        spawns = self._events(gh, "agent_spawn")
+        spawns = self._events(gh, EVENT_AGENT_SPAWN)
         self.assertEqual(len(spawns), 1)
-        self.assertEqual(spawns[0]["agent_role"], "developer")
+        self.assertEqual(spawns[0]["agent_role"], ROLE_DEVELOPER)
         self.assertEqual(spawns[0]["session_id"], "sess-resume")
 
     def test_timeout_records_timed_out_flag_on_exit(self) -> None:
         gh = FakeGitHubClient()
-        issue = make_issue(4, label="implementing")
+        issue = make_issue(4, label=LABEL_IMPLEMENTING)
         gh.add_issue(issue)
         self._run(
             lambda: workflow._handle_implementing(gh, _TEST_SPEC, issue),
@@ -244,7 +265,7 @@ class AgentLifecycleEventEmissionTest(unittest.TestCase, _PatchedWorkflowMixin):
             # the issue parks (the disposition reads HEAD twice now).
             head_shas=("sha-pre", "sha-pre"),
         )
-        exits = self._events(gh, "agent_exit")
+        exits = self._events(gh, EVENT_AGENT_EXIT)
         self.assertEqual(len(exits), 1)
         self.assertTrue(exits[0]["timed_out"])
         self.assertEqual(exits[0]["exit_code"], -1)

--- a/tests/test_workflow_implementing_full_spec.py
+++ b/tests/test_workflow_implementing_full_spec.py
@@ -18,10 +18,15 @@ from tests.fakes import (
     make_issue,
 )
 from tests.workflow_helpers import (
+    LABEL_IMPLEMENTING,
+    LABEL_VALIDATING,
+    REVIEW_APPROVED_MESSAGE,
+    REVIEW_CHANGES_REQUESTED_MESSAGE,
     _FAKE_WT,
     _PatchedWorkflowMixin,
     _TEST_SPEC,
     _agent,
+    _issue_branch,
 )
 
 
@@ -76,7 +81,7 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
 
     def test_fresh_dev_spawn_stores_full_spec_with_args(self) -> None:
         gh = FakeGitHubClient()
-        issue = make_issue(67001, label="implementing")
+        issue = make_issue(67001, label=LABEL_IMPLEMENTING)
         gh.add_issue(issue)
 
         self._enter(self._patch_dev_config(
@@ -108,12 +113,12 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
         # flags, and silently dropping them on a resume changes what
         # the agent actually sees mid-flight.
         gh = FakeGitHubClient()
-        issue = make_issue(67002, label="validating")
+        issue = make_issue(67002, label=LABEL_VALIDATING)
         gh.add_issue(issue)
         gh.seed_state(
             67002,
             pr_number=67002,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-67002",
+            branch=_issue_branch(67002),
             dev_agent=self._CODEX_SPEC,
             dev_session_id="dev-67002",
             review_round=0,
@@ -125,7 +130,7 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
 
         review = _agent(
             session_id="rev-67002",
-            last_message="1. Tighten\n\nVERDICT: CHANGES_REQUESTED",
+            last_message=REVIEW_CHANGES_REQUESTED_MESSAGE,
         )
         dev_fix = _agent(session_id="dev-67002", last_message="fixed")
 
@@ -151,7 +156,7 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
         # must still resume on codex with no args -- that is what those
         # deployments had at the time the session was spawned.
         gh = FakeGitHubClient()
-        issue = make_issue(67003, label="implementing")
+        issue = make_issue(67003, label=LABEL_IMPLEMENTING)
         issue.comments.append(
             FakeComment(id=2100, body="please retry", user=FakeUser("alice"))
         )
@@ -162,7 +167,7 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
             last_action_comment_id=2000,
             dev_agent="codex",  # legacy bare-backend pinned form.
             dev_session_id="dev-legacy-spec",
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-67003",
+            branch=_issue_branch(67003),
         )
 
         # Flip current config to a spec with args -- which the resume must IGNORE.
@@ -190,7 +195,7 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
         # use codex regardless of any current config flip, and MUST pass
         # no args (the spec at the time was bare codex).
         gh = FakeGitHubClient()
-        issue = make_issue(67004, label="implementing")
+        issue = make_issue(67004, label=LABEL_IMPLEMENTING)
         issue.comments.append(
             FakeComment(id=2200, body="retry", user=FakeUser("alice"))
         )
@@ -200,7 +205,7 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
             awaiting_human=True,
             last_action_comment_id=2100,
             codex_session_id="sess-legacy-67004",
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-67004",
+            branch=_issue_branch(67004),
         )
 
         self._enter(self._patch_dev_config(
@@ -227,7 +232,7 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
         # backend+args (a poisoned session is a transcript problem,
         # not a backend-selection problem).
         gh = FakeGitHubClient()
-        issue = make_issue(67005, label="implementing")
+        issue = make_issue(67005, label=LABEL_IMPLEMENTING)
         gh.add_issue(issue)
         gh.seed_state(
             67005,
@@ -263,7 +268,7 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
         # so a subsequent env flip to claude cannot retroactively switch
         # the backend.
         gh = FakeGitHubClient()
-        issue = make_issue(67006, label="implementing")
+        issue = make_issue(67006, label=LABEL_IMPLEMENTING)
         gh.add_issue(issue)
         gh.seed_state(
             67006,
@@ -300,12 +305,12 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
 
     def test_fresh_reviewer_spawn_stores_full_spec(self) -> None:
         gh = FakeGitHubClient()
-        issue = make_issue(67010, label="validating")
+        issue = make_issue(67010, label=LABEL_VALIDATING)
         gh.add_issue(issue)
         gh.seed_state(
             67010,
             pr_number=67010,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-67010",
+            branch=_issue_branch(67010),
             dev_agent="claude",
             dev_session_id="dev-67010",
             review_round=0,
@@ -319,7 +324,7 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
             lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
             run_agent=_agent(
                 session_id="rev-67010",
-                last_message="LGTM\n\nVERDICT: APPROVED",
+                last_message=REVIEW_APPROVED_MESSAGE,
             ),
         )
 
@@ -338,12 +343,12 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
         # comments must say so. We test both approval and CHANGES_REQUESTED
         # paths since both posted hardcoded text before the fix.
         gh = FakeGitHubClient()
-        issue = make_issue(67011, label="validating")
+        issue = make_issue(67011, label=LABEL_VALIDATING)
         gh.add_issue(issue)
         gh.seed_state(
             67011,
             pr_number=67011,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-67011",
+            branch=_issue_branch(67011),
             dev_agent="codex",
             dev_session_id="dev-67011",
             review_round=0,
@@ -355,7 +360,7 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
             lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
             run_agent=_agent(
                 session_id="rev-67011",
-                last_message="LGTM\n\nVERDICT: APPROVED",
+                last_message=REVIEW_APPROVED_MESSAGE,
             ),
         )
 
@@ -369,12 +374,12 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
 
     def test_changes_requested_pr_comment_uses_configured_backend(self) -> None:
         gh = FakeGitHubClient()
-        issue = make_issue(67012, label="validating")
+        issue = make_issue(67012, label=LABEL_VALIDATING)
         gh.add_issue(issue)
         gh.seed_state(
             67012,
             pr_number=67012,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-67012",
+            branch=_issue_branch(67012),
             dev_agent="codex",
             dev_session_id="dev-67012",
             review_round=0,
@@ -384,7 +389,7 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
 
         review = _agent(
             session_id="rev-67012",
-            last_message="1. tighten\n\nVERDICT: CHANGES_REQUESTED",
+            last_message=REVIEW_CHANGES_REQUESTED_MESSAGE,
         )
         dev_fix = _agent(session_id="dev-67012", last_message="fixed")
 
@@ -558,7 +563,7 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
         # would silently retarget the next validating dev-fix resume
         # at a backend that never ran on this issue.
         gh = FakeGitHubClient()
-        issue = make_issue(67030, label="implementing")
+        issue = make_issue(67030, label=LABEL_IMPLEMENTING)
         gh.add_issue(issue)
 
         self._enter(self._patch_dev_config(
@@ -589,7 +594,7 @@ class FullSpecPersistenceTest(unittest.TestCase, _PatchedWorkflowMixin):
         # ticks. The next resume MUST stick with the spec that was
         # actually running, not retarget at the new config.
         gh = FakeGitHubClient()
-        issue = make_issue(67031, label="implementing")
+        issue = make_issue(67031, label=LABEL_IMPLEMENTING)
         gh.add_issue(issue)
 
         # First tick: codex spawn, no session id, agent question -> park

--- a/tests/test_workflow_stage_analytics.py
+++ b/tests/test_workflow_stage_analytics.py
@@ -18,7 +18,14 @@ from orchestrator import analytics, workflow
 from orchestrator.github import BACKLOG_LABEL, PAUSED_LABEL
 
 from tests.fakes import FakeGitHubClient, FakeLabel, make_issue
-from tests.workflow_helpers import _TEST_SPEC
+from tests.workflow_helpers import (
+    EVENT_STAGE_ENTER,
+    EVENT_STAGE_EVALUATION,
+    LABEL_IMPLEMENTING,
+    LABEL_VALIDATING,
+    TEST_REPO_SLUG,
+    _TEST_SPEC,
+)
 
 
 class StageEvaluationAnalyticsTest(unittest.TestCase):
@@ -47,20 +54,20 @@ class StageEvaluationAnalyticsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory(prefix="analytics-stageval-") as td:
             path = Path(td) / "analytics.jsonl"
             gh = FakeGitHubClient()
-            issue = make_issue(8001, label="implementing")
+            issue = make_issue(8001, label=LABEL_IMPLEMENTING)
             gh.add_issue(issue)
             with patch.object(analytics, "ANALYTICS_LOG_PATH", path), \
                  patch.object(workflow, "_handle_implementing"):
                 workflow._process_issue(gh, _TEST_SPEC, issue)
             records = [
                 record for record in self._records(path)
-                if record.get("event") == "stage_evaluation"
+                if record.get("event") == EVENT_STAGE_EVALUATION
                 and record.get("issue") == 8001
             ]
         self.assertEqual(len(records), 1)
         rec = records[0]
-        self.assertEqual(rec["repo"], "geserdugarov/agent-orchestrator")
-        self.assertEqual(rec["stage"], "implementing")
+        self.assertEqual(rec["repo"], TEST_REPO_SLUG)
+        self.assertEqual(rec["stage"], LABEL_IMPLEMENTING)
         self.assertEqual(rec["result"], "ok")
         self.assertIn("duration_s", rec)
         self.assertGreaterEqual(rec["duration_s"], 0)
@@ -84,7 +91,7 @@ class StageEvaluationAnalyticsTest(unittest.TestCase):
                 workflow._process_issue(gh, _TEST_SPEC, issue)
             records = [
                 record for record in self._records(path)
-                if record.get("event") == "stage_evaluation"
+                if record.get("event") == EVENT_STAGE_EVALUATION
                 and record.get("issue") == 8002
             ]
         self.assertEqual(len(records), 1)
@@ -104,7 +111,7 @@ class StageEvaluationAnalyticsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory(prefix="analytics-err-") as td:
             path = Path(td) / "analytics.jsonl"
             gh = FakeGitHubClient()
-            issue = make_issue(8003, label="validating")
+            issue = make_issue(8003, label=LABEL_VALIDATING)
             gh.add_issue(issue)
             with patch.object(analytics, "ANALYTICS_LOG_PATH", path), \
                  patch.object(
@@ -115,12 +122,12 @@ class StageEvaluationAnalyticsTest(unittest.TestCase):
                 self.assertIs(ctx.exception, sentinel)
             records = [
                 record for record in self._records(path)
-                if record.get("event") == "stage_evaluation"
+                if record.get("event") == EVENT_STAGE_EVALUATION
                 and record.get("issue") == 8003
             ]
         self.assertEqual(len(records), 1)
         rec = records[0]
-        self.assertEqual(rec["stage"], "validating")
+        self.assertEqual(rec["stage"], LABEL_VALIDATING)
         self.assertEqual(rec["result"], "error")
         self.assertIn("duration_s", rec)
 
@@ -135,7 +142,7 @@ class StageEvaluationAnalyticsTest(unittest.TestCase):
                 with tempfile.TemporaryDirectory(prefix="analytics-skip-") as td:
                     path = Path(td) / "analytics.jsonl"
                     gh = FakeGitHubClient()
-                    issue = make_issue(8004, label="implementing")
+                    issue = make_issue(8004, label=LABEL_IMPLEMENTING)
                     issue.labels.append(FakeLabel(skip_label))
                     gh.add_issue(issue)
                     with patch.object(analytics, "ANALYTICS_LOG_PATH", path), \
@@ -151,7 +158,7 @@ class StageEvaluationAnalyticsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory(prefix="analytics-off-") as td:
             sentinel = Path(td) / "must-not-be-created.jsonl"
             gh = FakeGitHubClient()
-            issue = make_issue(8005, label="implementing")
+            issue = make_issue(8005, label=LABEL_IMPLEMENTING)
             gh.add_issue(issue)
             with patch.object(analytics, "ANALYTICS_LOG_PATH", None), \
                  patch.object(workflow, "_handle_implementing"):
@@ -185,18 +192,18 @@ class StageEnterAnalyticsRecordTest(unittest.TestCase):
                 gh = FakeGitHubClient()
                 issue = make_issue(8101)
                 gh.add_issue(issue)
-                gh.set_workflow_label(issue, "implementing")
-                gh.set_workflow_label(issue, "validating")
+                gh.set_workflow_label(issue, LABEL_IMPLEMENTING)
+                gh.set_workflow_label(issue, LABEL_VALIDATING)
             records = self._records(path)
         self.assertEqual(len(records), 2)
         self.assertEqual(
             [record["stage"] for record in records],
-            ["implementing", "validating"],
+            [LABEL_IMPLEMENTING, LABEL_VALIDATING],
         )
         for record in records:
-            self.assertEqual(record["event"], "stage_enter")
+            self.assertEqual(record["event"], EVENT_STAGE_ENTER)
             self.assertEqual(record["issue"], 8101)
-            self.assertEqual(record["repo"], "geserdugarov/agent-orchestrator")
+            self.assertEqual(record["repo"], TEST_REPO_SLUG)
             datetime.fromisoformat(record["ts"])
 
     def test_label_cleared_to_none_does_not_emit_record(self) -> None:
@@ -207,7 +214,7 @@ class StageEnterAnalyticsRecordTest(unittest.TestCase):
             path = Path(td) / "analytics.jsonl"
             with patch.object(analytics, "ANALYTICS_LOG_PATH", path):
                 gh = FakeGitHubClient()
-                issue = make_issue(8102, label="implementing")
+                issue = make_issue(8102, label=LABEL_IMPLEMENTING)
                 gh.add_issue(issue)
                 gh.set_workflow_label(issue, None)
         self.assertEqual(self._records(path), [])

--- a/tests/test_workflow_validating_review.py
+++ b/tests/test_workflow_validating_review.py
@@ -16,20 +16,30 @@ from tests.fakes import (
     make_issue,
 )
 from tests.workflow_helpers import (
+    EVENT_AGENT_SPAWN,
+    LABEL_DOCUMENTING,
+    LABEL_FIXING,
+    LABEL_IN_REVIEW,
+    LABEL_VALIDATING,
+    REVIEW_APPROVED_MESSAGE,
+    REVIEW_CHANGES_REQUESTED_MESSAGE,
+    ROLE_DEVELOPER,
+    ROLE_REVIEWER,
     _PatchedWorkflowMixin,
     _TEST_SPEC,
     _agent,
+    _issue_branch,
 )
 
 
 class HandleValidatingFreshReviewTest(unittest.TestCase, _PatchedWorkflowMixin):
     def _seeded(self, **state):
         gh = FakeGitHubClient()
-        issue = make_issue(5, label="validating")
+        issue = make_issue(5, label=LABEL_VALIDATING)
         gh.add_issue(issue)
         defaults = dict(
             pr_number=11,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-5",
+            branch=_issue_branch(5),
             codex_session_id="dev-sess",
             review_round=0,
         )
@@ -41,14 +51,14 @@ class HandleValidatingFreshReviewTest(unittest.TestCase, _PatchedWorkflowMixin):
         gh, issue = self._seeded()
         mocks = self._run(
             lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
-            run_agent=_agent(last_message="LGTM\n\nVERDICT: APPROVED"),
+            run_agent=_agent(last_message=REVIEW_APPROVED_MESSAGE),
         )
 
         self.assertEqual(mocks["run_agent"].call_count, 1)
         # Approval routes through `documenting` for the final docs pass
         # before in_review picks up.
-        self.assertIn((5, "documenting"), gh.label_history)
-        self.assertNotIn((5, "in_review"), gh.label_history)
+        self.assertIn((5, LABEL_DOCUMENTING), gh.label_history)
+        self.assertNotIn((5, LABEL_IN_REVIEW), gh.label_history)
         self.assertTrue(any(
             ":white_check_mark: codex review approved" in body
             for _, body in gh.posted_pr_comments
@@ -58,7 +68,7 @@ class HandleValidatingFreshReviewTest(unittest.TestCase, _PatchedWorkflowMixin):
         gh, issue = self._seeded()
         review = _agent(
             session_id="rev-sess",
-            last_message="1. Fix typo\n\nVERDICT: CHANGES_REQUESTED",
+            last_message=REVIEW_CHANGES_REQUESTED_MESSAGE,
         )
         dev_fix = _agent(session_id="dev-sess", last_message="fixed")
 
@@ -89,18 +99,18 @@ class HandleValidatingFreshReviewTest(unittest.TestCase, _PatchedWorkflowMixin):
         # back to `validating` so the reviewer re-evaluates the new head
         # on the next tick. No documenting hop -- the docs pass only runs
         # as the final-docs handoff after approval.
-        self.assertIn((5, "fixing"), gh.label_history)
+        self.assertIn((5, LABEL_FIXING), gh.label_history)
         # The trailing label entry must be `validating` so the next tick
         # picks up via `_handle_validating`.
-        self.assertEqual(gh.label_history[-1], (5, "validating"))
+        self.assertEqual(gh.label_history[-1], (5, LABEL_VALIDATING))
         # The `fixing` flip happens BEFORE the `validating` flip so an
         # external observer sees the active work labeled `fixing` for the
         # duration of the dev subprocess.
-        fixing_idx = gh.label_history.index((5, "fixing"))
-        validating_idx = gh.label_history.index((5, "validating"))
+        fixing_idx = gh.label_history.index((5, LABEL_FIXING))
+        validating_idx = gh.label_history.index((5, LABEL_VALIDATING))
         self.assertLess(fixing_idx, validating_idx)
-        self.assertNotIn((5, "documenting"), gh.label_history)
-        self.assertNotIn((5, "in_review"), gh.label_history)
+        self.assertNotIn((5, LABEL_DOCUMENTING), gh.label_history)
+        self.assertNotIn((5, LABEL_IN_REVIEW), gh.label_history)
 
     def test_unknown_verdict_parks_with_quoted_message(self) -> None:
         gh, issue = self._seeded()
@@ -120,7 +130,7 @@ class HandleValidatingFreshReviewTest(unittest.TestCase, _PatchedWorkflowMixin):
         # subprocess stderr in addition -- skip the diagnostic block.
         self.assertNotIn("Reviewer stderr", last_comment)
         # Label stays validating: no in_review transition.
-        self.assertNotIn((5, "in_review"), gh.label_history)
+        self.assertNotIn((5, LABEL_IN_REVIEW), gh.label_history)
 
     def test_empty_review_park_surfaces_stderr_and_exit_code(self) -> None:
         # Codex hit a Cloudflare interstitial: the agent exited with
@@ -199,7 +209,7 @@ class HandleValidatingFreshReviewTest(unittest.TestCase, _PatchedWorkflowMixin):
         self.assertEqual(state.get("park_reason"), "reviewer_timeout")
         last_comment = gh.posted_comments[-1][1]
         self.assertIn("reviewer timed out", last_comment)
-        self.assertNotIn((5, "in_review"), gh.label_history)
+        self.assertNotIn((5, LABEL_IN_REVIEW), gh.label_history)
 
     def test_reviewer_silent_crash_parks_reviewer_failed(self) -> None:
         # The reviewer agent crashed (e.g. codex returned `Error: No such
@@ -252,11 +262,11 @@ class HandleValidatingFreshReviewTest(unittest.TestCase, _PatchedWorkflowMixin):
 class HandleValidatingFixLoopEdgeCasesTest(unittest.TestCase, _PatchedWorkflowMixin):
     def _seeded(self, **state):
         gh = FakeGitHubClient()
-        issue = make_issue(6, label="validating")
+        issue = make_issue(6, label=LABEL_VALIDATING)
         gh.add_issue(issue)
         defaults = dict(
             pr_number=12,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-6",
+            branch=_issue_branch(6),
             codex_session_id="dev-sess",
             review_round=0,
         )
@@ -267,7 +277,7 @@ class HandleValidatingFixLoopEdgeCasesTest(unittest.TestCase, _PatchedWorkflowMi
     def _changes_requested_review(self):
         return _agent(
             session_id="rev-sess",
-            last_message="1. Fix typo\n\nVERDICT: CHANGES_REQUESTED",
+            last_message=REVIEW_CHANGES_REQUESTED_MESSAGE,
         )
 
     def test_dev_fix_timeout_parks_agent_timeout(self) -> None:
@@ -302,8 +312,8 @@ class HandleValidatingFixLoopEdgeCasesTest(unittest.TestCase, _PatchedWorkflowMi
         # spawn so a parked subprocess leaves the active job labeled
         # `fixing` (the fixing handler then owns the awaiting-human
         # rescan + dev resume cycle on subsequent ticks).
-        self.assertIn((6, "fixing"), gh.label_history)
-        self.assertNotIn((6, "validating"), gh.label_history)
+        self.assertIn((6, LABEL_FIXING), gh.label_history)
+        self.assertNotIn((6, LABEL_VALIDATING), gh.label_history)
 
     def test_dev_fix_no_new_commit_parks_round_unchanged(self) -> None:
         gh, issue = self._seeded()
@@ -327,8 +337,8 @@ class HandleValidatingFixLoopEdgeCasesTest(unittest.TestCase, _PatchedWorkflowMi
         # The pre-spawn label flip is observed even on the no-commit park
         # path (the fixing handler then handles the awaiting-human rescan
         # on the next tick).
-        self.assertIn((6, "fixing"), gh.label_history)
-        self.assertNotIn((6, "validating"), gh.label_history)
+        self.assertIn((6, LABEL_FIXING), gh.label_history)
+        self.assertNotIn((6, LABEL_VALIDATING), gh.label_history)
 
     def test_dev_fix_dirty_parks_round_unchanged(self) -> None:
         gh, issue = self._seeded()
@@ -349,8 +359,8 @@ class HandleValidatingFixLoopEdgeCasesTest(unittest.TestCase, _PatchedWorkflowMi
         last_comment = gh.posted_comments[-1][1]
         self.assertIn("uncommitted change", last_comment)
         self.assertIn("leftover.py", last_comment)
-        self.assertIn((6, "fixing"), gh.label_history)
-        self.assertNotIn((6, "validating"), gh.label_history)
+        self.assertIn((6, LABEL_FIXING), gh.label_history)
+        self.assertNotIn((6, LABEL_VALIDATING), gh.label_history)
 
     def test_dev_fix_push_fail_parks_round_unchanged(self) -> None:
         gh, issue = self._seeded()
@@ -374,8 +384,8 @@ class HandleValidatingFixLoopEdgeCasesTest(unittest.TestCase, _PatchedWorkflowMi
         self.assertEqual(state.get("park_reason"), "push_failed")
         last_comment = gh.posted_comments[-1][1]
         self.assertIn("git push failed", last_comment)
-        self.assertIn((6, "fixing"), gh.label_history)
-        self.assertNotIn((6, "validating"), gh.label_history)
+        self.assertIn((6, LABEL_FIXING), gh.label_history)
+        self.assertNotIn((6, LABEL_VALIDATING), gh.label_history)
 
     def test_review_round_at_cap_parks_without_spawning_reviewer(self) -> None:
         gh, issue = self._seeded(review_round=config.MAX_REVIEW_ROUNDS)
@@ -411,21 +421,21 @@ class HandleValidatingFixLoopEdgeCasesTest(unittest.TestCase, _PatchedWorkflowMi
 
         # Both flips landed in order: first `fixing` (pre-spawn), then
         # `validating` (post-push) so the reviewer reruns on the next tick.
-        self.assertIn((6, "fixing"), gh.label_history)
-        self.assertIn((6, "validating"), gh.label_history)
-        fixing_idx = gh.label_history.index((6, "fixing"))
-        validating_idx = gh.label_history.index((6, "validating"))
+        self.assertIn((6, LABEL_FIXING), gh.label_history)
+        self.assertIn((6, LABEL_VALIDATING), gh.label_history)
+        fixing_idx = gh.label_history.index((6, LABEL_FIXING))
+        validating_idx = gh.label_history.index((6, LABEL_VALIDATING))
         self.assertLess(fixing_idx, validating_idx)
         # The dev work is tagged with `stage="fixing"` for analytics so
         # spend on a CHANGES_REQUESTED fix is not double-counted against
         # the validating bucket alongside the reviewer/verify spend.
         dev_spawns = [
             e for e in gh.recorded_events
-            if e["event"] == "agent_spawn"
-            and e.get("agent_role") == "developer"
+            if e["event"] == EVENT_AGENT_SPAWN
+            and e.get("agent_role") == ROLE_DEVELOPER
         ]
         self.assertEqual(len(dev_spawns), 1)
-        self.assertEqual(dev_spawns[0]["stage"], "fixing")
+        self.assertEqual(dev_spawns[0]["stage"], LABEL_FIXING)
 
     def test_dev_fix_interrupted_skips_write_and_does_not_push(self) -> None:
         # A shutdown-killed CHANGES_REQUESTED dev resume is ignored: the
@@ -456,8 +466,8 @@ class HandleValidatingFixLoopEdgeCasesTest(unittest.TestCase, _PatchedWorkflowMi
         mocks["_push_branch"].assert_not_called()
         # Pre-spawn flip landed; the issue did NOT bounce to validating this
         # tick (that happens on a later tick after a clean re-review).
-        self.assertIn((6, "fixing"), gh.label_history)
-        self.assertNotIn((6, "validating"), gh.label_history)
+        self.assertIn((6, LABEL_FIXING), gh.label_history)
+        self.assertNotIn((6, LABEL_VALIDATING), gh.label_history)
         state = gh.pinned_data(6)
         # Post-spawn write skipped: the resume-budget charge from
         # `_resume_dev_with_text` never persisted.
@@ -492,7 +502,7 @@ class HandleValidatingFixLoopEdgeCasesTest(unittest.TestCase, _PatchedWorkflowMi
         self.assertIsNotNone(state.get("pending_fix_reviewer_comment_id"))
         # The in_review-route discriminator is NOT set on this route.
         self.assertIsNone(state.get("pending_fix_at"))
-        self.assertIn((6, "fixing"), gh.label_history)
+        self.assertIn((6, LABEL_FIXING), gh.label_history)
 
     def test_changes_requested_pushed_fix_clears_reviewer_anchor(self) -> None:
         # On a pushed inline fix this reviewer round is addressed, so the
@@ -513,13 +523,13 @@ class HandleValidatingFixLoopEdgeCasesTest(unittest.TestCase, _PatchedWorkflowMi
         state = gh.pinned_data(6)
         self.assertIsNone(state.get("pending_fix_reviewer_comment_id"))
         self.assertEqual(state.get("review_round"), 3)
-        self.assertEqual(gh.label_history[-1], (6, "validating"))
+        self.assertEqual(gh.label_history[-1], (6, LABEL_VALIDATING))
 
 
 class HandleValidatingAwaitingHumanResumeTest(unittest.TestCase, _PatchedWorkflowMixin):
     def test_human_reply_bumps_round_without_reviewer(self) -> None:
         gh = FakeGitHubClient()
-        issue = make_issue(7, label="validating")
+        issue = make_issue(7, label=LABEL_VALIDATING)
         issue.comments.append(
             FakeComment(id=1100, body="use sqlite please", user=FakeUser("alice"))
         )
@@ -531,7 +541,7 @@ class HandleValidatingAwaitingHumanResumeTest(unittest.TestCase, _PatchedWorkflo
             codex_session_id="dev-sess",
             review_round=1,
             pr_number=13,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-7",
+            branch=_issue_branch(7),
         )
 
         mocks = self._run(
@@ -557,8 +567,8 @@ class HandleValidatingAwaitingHumanResumeTest(unittest.TestCase, _PatchedWorkflo
         # A successful awaiting-human resume stays on `validating` (no
         # documenting hop) so the reviewer re-runs against the new head
         # on the next tick.
-        self.assertNotIn((7, "documenting"), gh.label_history)
-        self.assertNotIn((7, "in_review"), gh.label_history)
+        self.assertNotIn((7, LABEL_DOCUMENTING), gh.label_history)
+        self.assertNotIn((7, LABEL_IN_REVIEW), gh.label_history)
 
     def test_successful_dev_fix_resets_silent_park_streak(self) -> None:
         # The validating / in_review fix paths exit on `_handle_dev_fix_result`
@@ -568,7 +578,7 @@ class HandleValidatingAwaitingHumanResumeTest(unittest.TestCase, _PatchedWorkflo
         # resume could tip an otherwise-healthy session past the
         # fresh-session threshold.
         gh = FakeGitHubClient()
-        issue = make_issue(70, label="validating")
+        issue = make_issue(70, label=LABEL_VALIDATING)
         issue.comments.append(
             FakeComment(id=1100, body="please fix it", user=FakeUser("alice"))
         )
@@ -581,7 +591,7 @@ class HandleValidatingAwaitingHumanResumeTest(unittest.TestCase, _PatchedWorkflo
             dev_session_id="dev-sess",
             review_round=1,
             pr_number=14,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-70",
+            branch=_issue_branch(70),
             # Carryover from an earlier silent park; one short of the
             # fresh-session threshold.
             silent_park_count=1,
@@ -613,7 +623,7 @@ class HandleValidatingContinueCommandTest(
 
     def _seed(self, number, *, park_reason, command="/orchestrator continue"):
         gh = FakeGitHubClient()
-        issue = make_issue(number, label="validating", body="the requirements")
+        issue = make_issue(number, label=LABEL_VALIDATING, body="the requirements")
         issue.comments.append(
             FakeComment(id=1100, body=command, user=FakeUser("dave"))
         )
@@ -628,7 +638,7 @@ class HandleValidatingContinueCommandTest(
             silent_park_count=1,
             review_round=1,
             pr_number=13,
-            branch=f"orchestrator/geserdugarov__agent-orchestrator/issue-{number}",
+            branch=_issue_branch(number),
             # Current content hash so a bare continue (excluded from the hash)
             # does not fire drift: the continue gate, not drift, is under test.
             user_content_hash=workflow._compute_user_content_hash(issue, set()),
@@ -697,7 +707,7 @@ class HandleValidatingReviewCapAddRoundsCommandTest(
 
     def _seeded(self, *, comment_body: Optional[str] = None, **state):
         gh = FakeGitHubClient()
-        issue = make_issue(80, label="validating")
+        issue = make_issue(80, label=LABEL_VALIDATING)
         if comment_body is not None:
             issue.comments.append(
                 FakeComment(id=1100, body=comment_body, user=FakeUser("alice"))
@@ -711,7 +721,7 @@ class HandleValidatingReviewCapAddRoundsCommandTest(
             dev_session_id="dev-sess",
             dev_agent="codex",
             pr_number=15,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-80",
+            branch=_issue_branch(80),
         )
         defaults.update(state)
         gh.seed_state(80, **defaults)
@@ -730,7 +740,7 @@ class HandleValidatingReviewCapAddRoundsCommandTest(
         mocks = self._run(
             lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
             run_agent=_agent(
-                last_message="LGTM\n\nVERDICT: APPROVED",
+                last_message=REVIEW_APPROVED_MESSAGE,
             ),
             head_shas=["aaa"],
         )
@@ -749,8 +759,8 @@ class HandleValidatingReviewCapAddRoundsCommandTest(
         self.assertEqual(mocks["run_agent"].call_count, 1)
         reviewer_spawns = [
             e for e in gh.recorded_events
-            if e["event"] == "agent_spawn"
-            and e.get("agent_role") == "reviewer"
+            if e["event"] == EVENT_AGENT_SPAWN
+            and e.get("agent_role") == ROLE_REVIEWER
         ]
         self.assertEqual(len(reviewer_spawns), 1)
         self.assertEqual(
@@ -776,7 +786,7 @@ class HandleValidatingReviewCapAddRoundsCommandTest(
 
         self._run(
             lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
-            run_agent=_agent(last_message="LGTM\n\nVERDICT: APPROVED"),
+            run_agent=_agent(last_message=REVIEW_APPROVED_MESSAGE),
             head_shas=["aaa"],
         )
 
@@ -805,7 +815,7 @@ class HandleValidatingReviewCapAddRoundsCommandTest(
 
         self._run(
             lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
-            run_agent=_agent(last_message="LGTM\n\nVERDICT: APPROVED"),
+            run_agent=_agent(last_message=REVIEW_APPROVED_MESSAGE),
             head_shas=["aaa"],
         )
 
@@ -917,13 +927,13 @@ class HandleValidatingReviewCapAddRoundsCommandTest(
         # itself surfaces the command so an operator who has never seen
         # the syntax can copy/paste it from the issue thread.
         gh = FakeGitHubClient()
-        issue = make_issue(81, label="validating")
+        issue = make_issue(81, label=LABEL_VALIDATING)
         gh.add_issue(issue)
         gh.seed_state(
             81,
             review_round=config.MAX_REVIEW_ROUNDS,
             pr_number=16,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-81",
+            branch=_issue_branch(81),
         )
 
         self._run(
@@ -942,13 +952,13 @@ class HandleValidatingReviewCapAddRoundsCommandTest(
         # `/orchestrator add-review-rounds` parser never runs -- the
         # command would silently fall through to the dev-resume branch.
         gh = FakeGitHubClient()
-        issue = make_issue(82, label="validating")
+        issue = make_issue(82, label=LABEL_VALIDATING)
         gh.add_issue(issue)
         gh.seed_state(
             82,
             review_round=config.MAX_REVIEW_ROUNDS,
             pr_number=17,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-82",
+            branch=_issue_branch(82),
         )
 
         self._run(
@@ -970,13 +980,13 @@ class HandleValidatingReviewCapAddRoundsCommandTest(
         # resets. Pre-seeded tests above cover the command parser in
         # isolation; this one closes the loop on the production sequence.
         gh = FakeGitHubClient()
-        issue = make_issue(83, label="validating")
+        issue = make_issue(83, label=LABEL_VALIDATING)
         gh.add_issue(issue)
         gh.seed_state(
             83,
             review_round=config.MAX_REVIEW_ROUNDS,
             pr_number=18,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-83",
+            branch=_issue_branch(83),
             pickup_comment_id=900,
             dev_session_id="dev-sess",
             dev_agent="codex",
@@ -1012,7 +1022,7 @@ class HandleValidatingReviewCapAddRoundsCommandTest(
         # Tick 2: command processes through the cap-reset path.
         self._run(
             lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
-            run_agent=_agent(last_message="LGTM\n\nVERDICT: APPROVED"),
+            run_agent=_agent(last_message=REVIEW_APPROVED_MESSAGE),
             head_shas=["aaa"],
         )
         tick2 = gh.pinned_data(83)
@@ -1037,8 +1047,8 @@ class HandleValidatingReviewCapAddRoundsCommandTest(
         ))
         reviewer_spawns = [
             e for e in gh.recorded_events
-            if e["event"] == "agent_spawn"
-            and e.get("agent_role") == "reviewer"
+            if e["event"] == EVENT_AGENT_SPAWN
+            and e.get("agent_role") == ROLE_REVIEWER
         ]
         self.assertEqual(len(reviewer_spawns), 1)
         self.assertEqual(
@@ -1055,7 +1065,7 @@ class ValidatingDevFixInterruptedHelperTest(unittest.TestCase):
 
     def _seeded(self, **state):
         gh = FakeGitHubClient()
-        issue = make_issue(7, label="validating")
+        issue = make_issue(7, label=LABEL_VALIDATING)
         gh.add_issue(issue)
         gh.seed_state(7, **state)
         return gh, gh.read_pinned_state(issue), issue
@@ -1120,7 +1130,7 @@ class ValidatingInterruptedResumeHandlerTest(
         self,
     ) -> None:
         gh = FakeGitHubClient()
-        issue = make_issue(8, label="validating")
+        issue = make_issue(8, label=LABEL_VALIDATING)
         issue.comments.append(
             FakeComment(id=1200, body="tweak the wording", user=FakeUser("alice"))
         )
@@ -1135,7 +1145,7 @@ class ValidatingInterruptedResumeHandlerTest(
             dev_session_id="dev-sess",
             review_round=1,
             pr_number=18,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-8",
+            branch=_issue_branch(8),
         )
 
         mocks = self._run(
@@ -1162,7 +1172,7 @@ class ValidatingInterruptedResumeHandlerTest(
 
     def test_awaiting_human_interrupted_resume_does_not_persist(self) -> None:
         gh = FakeGitHubClient()
-        issue = make_issue(9, label="validating")
+        issue = make_issue(9, label=LABEL_VALIDATING)
         issue.comments.append(
             FakeComment(id=1300, body="please retry", user=FakeUser("alice"))
         )
@@ -1180,7 +1190,7 @@ class ValidatingInterruptedResumeHandlerTest(
             dev_session_id="dev-sess",
             review_round=1,
             pr_number=19,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-9",
+            branch=_issue_branch(9),
         )
 
         mocks = self._run(
@@ -1216,7 +1226,7 @@ class HandleValidatingResumeTrustFilterTest(
     _ALLOWLIST = ("geserdugarov",)
 
     def _seed_cap_park(self, gh, *, author, body):
-        issue = make_issue(90, label="validating")
+        issue = make_issue(90, label=LABEL_VALIDATING)
         issue.comments.append(
             FakeComment(id=1100, body=body, user=FakeUser(author))
         )
@@ -1230,12 +1240,12 @@ class HandleValidatingResumeTrustFilterTest(
             dev_session_id="dev-sess",
             dev_agent="codex",
             pr_number=17,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-90",
+            branch=_issue_branch(90),
         )
         return issue
 
     def _seed_reviewer_timeout_park(self, gh, *, author):
-        issue = make_issue(91, label="validating")
+        issue = make_issue(91, label=LABEL_VALIDATING)
         issue.comments.append(
             FakeComment(id=1200, body="please retry", user=FakeUser(author))
         )
@@ -1249,7 +1259,7 @@ class HandleValidatingResumeTrustFilterTest(
             dev_session_id="dev-sess",
             dev_agent="codex",
             pr_number=18,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-91",
+            branch=_issue_branch(91),
         )
         return issue
 
@@ -1288,7 +1298,7 @@ class HandleValidatingResumeTrustFilterTest(
         with patch.object(config, "ALLOWED_ISSUE_AUTHORS", self._ALLOWLIST):
             mocks = self._run(
                 lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
-                run_agent=_agent(last_message="LGTM\n\nVERDICT: APPROVED"),
+                run_agent=_agent(last_message=REVIEW_APPROVED_MESSAGE),
                 head_shas=["aaa"],
             )
         # A trusted operator's command resets the cap and reruns the reviewer
@@ -1326,7 +1336,7 @@ class HandleValidatingResumeTrustFilterTest(
         with patch.object(config, "ALLOWED_ISSUE_AUTHORS", self._ALLOWLIST):
             mocks = self._run(
                 lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
-                run_agent=_agent(last_message="LGTM\n\nVERDICT: APPROVED"),
+                run_agent=_agent(last_message=REVIEW_APPROVED_MESSAGE),
                 head_shas=["aaa"],
             )
         # The trusted nudge re-spawns the reviewer this tick and advances the
@@ -1334,8 +1344,8 @@ class HandleValidatingResumeTrustFilterTest(
         self.assertEqual(mocks["run_agent"].call_count, 1)
         reviewer_spawns = [
             e for e in gh.recorded_events
-            if e["event"] == "agent_spawn"
-            and e.get("agent_role") == "reviewer"
+            if e["event"] == EVENT_AGENT_SPAWN
+            and e.get("agent_role") == ROLE_REVIEWER
         ]
         self.assertEqual(len(reviewer_spawns), 1)
         self.assertEqual(gh.pinned_data(91).get("last_action_comment_id"), 1200)

--- a/tests/test_workflow_validating_verify.py
+++ b/tests/test_workflow_validating_verify.py
@@ -17,10 +17,34 @@ from tests.fakes import (
     make_issue,
 )
 from tests.workflow_helpers import (
+    LABEL_DOCUMENTING,
+    LABEL_IN_REVIEW,
+    LABEL_VALIDATING,
+    REVIEW_APPROVED_MESSAGE,
+    REVIEW_CHANGES_REQUESTED_MESSAGE,
+    TEST_BASE_BRANCH,
     _PatchedWorkflowMixin,
     _TEST_SPEC,
     _agent,
+    _issue_branch,
 )
+
+
+ISSUE = 7
+PR_NUMBER = 21
+DEV_SESSION = "dev-sess"
+REVIEW_SHA = "rev-sha"
+VERIFY_PYTEST = "pytest -q"
+VERIFY_SLOW = "pytest --slow"
+VERIFY_FAILED = "failed"
+VERIFY_TIMEOUT = "timeout"
+VERIFY_HEAD_CHANGED = "head_changed"
+VERIFY_DIRTY = "dirty"
+VERIFY_OK = "ok"
+PARK_VERIFY_FAILED = "verify_failed"
+PARK_VERIFY_TIMEOUT = "verify_timeout"
+PARK_VERIFY_HEAD_CHANGED = "verify_head_changed"
+PARK_VERIFY_DIRTY = "verify_dirty"
 
 
 def shutil_quote(s: str) -> str:
@@ -41,16 +65,16 @@ class HandleValidatingVerifyGateTest(unittest.TestCase, _PatchedWorkflowMixin):
 
     def _seeded(self, **state):
         gh = FakeGitHubClient()
-        issue = make_issue(7, label="validating")
+        issue = make_issue(ISSUE, label=LABEL_VALIDATING)
         gh.add_issue(issue)
         defaults = dict(
-            pr_number=21,
-            branch="orchestrator/geserdugarov__agent-orchestrator/issue-7",
-            codex_session_id="dev-sess",
+            pr_number=PR_NUMBER,
+            branch=_issue_branch(ISSUE),
+            codex_session_id=DEV_SESSION,
             review_round=0,
         )
         defaults.update(state)
-        gh.seed_state(7, **defaults)
+        gh.seed_state(ISSUE, **defaults)
         return gh, issue
 
     def test_default_empty_verify_is_a_noop_on_approval(self) -> None:
@@ -61,8 +85,8 @@ class HandleValidatingVerifyGateTest(unittest.TestCase, _PatchedWorkflowMixin):
         gh, issue = self._seeded()
         mocks = self._run(
             lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
-            run_agent=_agent(last_message="LGTM\n\nVERDICT: APPROVED"),
-            head_shas=("rev-sha",),
+            run_agent=_agent(last_message=REVIEW_APPROVED_MESSAGE),
+            head_shas=(REVIEW_SHA,),
         )
 
         self.assertEqual(mocks["_run_verify_commands"].call_count, 1)
@@ -72,8 +96,8 @@ class HandleValidatingVerifyGateTest(unittest.TestCase, _PatchedWorkflowMixin):
         self.assertEqual(call.args[1], config.VERIFY_COMMANDS)
         self.assertEqual(config.VERIFY_COMMANDS, ())
         # Handoff completed normally through the final-docs hop.
-        self.assertIn((7, "documenting"), gh.label_history)
-        state = gh.pinned_data(7)
+        self.assertIn((ISSUE, LABEL_DOCUMENTING), gh.label_history)
+        state = gh.pinned_data(ISSUE)
         self.assertFalse(state.get("awaiting_human"))
         self.assertIsNone(state.get("park_reason"))
 
@@ -85,27 +109,27 @@ class HandleValidatingVerifyGateTest(unittest.TestCase, _PatchedWorkflowMixin):
 
         self.assertEqual(_parse_verify_commands(""), ())
         self.assertEqual(
-            _parse_verify_commands("pytest -q;ruff check ."),
-            ("pytest -q", "ruff check ."),
+            _parse_verify_commands(f"{VERIFY_PYTEST};ruff check ."),
+            (VERIFY_PYTEST, "ruff check ."),
         )
         self.assertEqual(
-            _parse_verify_commands("pytest -q\nruff check .\n"),
-            ("pytest -q", "ruff check ."),
+            _parse_verify_commands(f"{VERIFY_PYTEST}\nruff check .\n"),
+            (VERIFY_PYTEST, "ruff check ."),
         )
         self.assertEqual(
-            _parse_verify_commands("\n#comment\npytest -q\n\n"),
-            ("pytest -q",),
+            _parse_verify_commands(f"\n#comment\n{VERIFY_PYTEST}\n\n"),
+            (VERIFY_PYTEST,),
         )
 
     def test_verify_success_keeps_approval_flow(self) -> None:
         gh, issue = self._seeded()
         from orchestrator.worktrees import VerifyResult
-        with patch.object(config, "VERIFY_COMMANDS", ("pytest -q",)):
+        with patch.object(config, "VERIFY_COMMANDS", (VERIFY_PYTEST,)):
             mocks = self._run(
                 lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
-                run_agent=_agent(last_message="LGTM\n\nVERDICT: APPROVED"),
-                head_shas=("rev-sha",),
-                verify_result=VerifyResult(status="ok"),
+                run_agent=_agent(last_message=REVIEW_APPROVED_MESSAGE),
+                head_shas=(REVIEW_SHA,),
+                verify_result=VerifyResult(status=VERIFY_OK),
             )
 
         mocks["_run_verify_commands"].assert_called_once()
@@ -115,34 +139,34 @@ class HandleValidatingVerifyGateTest(unittest.TestCase, _PatchedWorkflowMixin):
             ":white_check_mark:" in body
             for _, body in gh.posted_pr_comments
         ))
-        self.assertIn((7, "documenting"), gh.label_history)
-        state = gh.pinned_data(7)
+        self.assertIn((ISSUE, LABEL_DOCUMENTING), gh.label_history)
+        state = gh.pinned_data(ISSUE)
         self.assertFalse(state.get("awaiting_human"))
 
     def test_verify_failed_parks(self) -> None:
         gh, issue = self._seeded()
         from orchestrator.worktrees import VerifyResult
         run = VerifyResult(
-            status="failed",
-            command="pytest -q",
+            status=VERIFY_FAILED,
+            command=VERIFY_PYTEST,
             exit_code=2,
             output="E   AssertionError: bad\nTAIL_MARKER",
         )
-        with patch.object(config, "VERIFY_COMMANDS", ("pytest -q",)):
+        with patch.object(config, "VERIFY_COMMANDS", (VERIFY_PYTEST,)):
             self._run(
                 lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
-                run_agent=_agent(last_message="LGTM\n\nVERDICT: APPROVED"),
-                head_shas=("rev-sha",),
+                run_agent=_agent(last_message=REVIEW_APPROVED_MESSAGE),
+                head_shas=(REVIEW_SHA,),
                 verify_result=run,
             )
 
-        state = gh.pinned_data(7)
+        state = gh.pinned_data(ISSUE)
         self.assertTrue(state.get("awaiting_human"))
-        self.assertEqual(state.get("park_reason"), "verify_failed")
+        self.assertEqual(state.get("park_reason"), PARK_VERIFY_FAILED)
         # No in_review or documenting handoff -- the verify gate fires
         # BEFORE the approval / squash / final-docs route is reached.
-        self.assertNotIn((7, "in_review"), gh.label_history)
-        self.assertNotIn((7, "documenting"), gh.label_history)
+        self.assertNotIn((ISSUE, LABEL_IN_REVIEW), gh.label_history)
+        self.assertNotIn((ISSUE, LABEL_DOCUMENTING), gh.label_history)
         # No approval comment (gate fires BEFORE the approval post).
         self.assertFalse(any(
             ":white_check_mark:" in body
@@ -150,7 +174,7 @@ class HandleValidatingVerifyGateTest(unittest.TestCase, _PatchedWorkflowMixin):
         ))
         last_comment = gh.posted_comments[-1][1]
         self.assertIn("local verification failed", last_comment)
-        self.assertIn("pytest -q", last_comment)
+        self.assertIn(VERIFY_PYTEST, last_comment)
         self.assertIn("exited with code 2", last_comment)
         self.assertIn("TAIL_MARKER", last_comment)
 
@@ -158,27 +182,27 @@ class HandleValidatingVerifyGateTest(unittest.TestCase, _PatchedWorkflowMixin):
         gh, issue = self._seeded()
         from orchestrator.worktrees import VerifyResult
         run = VerifyResult(
-            status="timeout",
-            command="pytest --slow",
+            status=VERIFY_TIMEOUT,
+            command=VERIFY_SLOW,
             exit_code=None,
             output="hanging...",
         )
-        with patch.object(config, "VERIFY_COMMANDS", ("pytest --slow",)), \
+        with patch.object(config, "VERIFY_COMMANDS", (VERIFY_SLOW,)), \
              patch.object(config, "VERIFY_TIMEOUT", 123):
             self._run(
                 lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
-                run_agent=_agent(last_message="LGTM\n\nVERDICT: APPROVED"),
-                head_shas=("rev-sha",),
+                run_agent=_agent(last_message=REVIEW_APPROVED_MESSAGE),
+                head_shas=(REVIEW_SHA,),
                 verify_result=run,
             )
 
-        state = gh.pinned_data(7)
+        state = gh.pinned_data(ISSUE)
         self.assertTrue(state.get("awaiting_human"))
-        self.assertEqual(state.get("park_reason"), "verify_timeout")
-        self.assertNotIn((7, "in_review"), gh.label_history)
-        self.assertNotIn((7, "documenting"), gh.label_history)
+        self.assertEqual(state.get("park_reason"), PARK_VERIFY_TIMEOUT)
+        self.assertNotIn((ISSUE, LABEL_IN_REVIEW), gh.label_history)
+        self.assertNotIn((ISSUE, LABEL_DOCUMENTING), gh.label_history)
         last_comment = gh.posted_comments[-1][1]
-        self.assertIn("pytest --slow", last_comment)
+        self.assertIn(VERIFY_SLOW, last_comment)
         self.assertIn("timed out after 123s", last_comment)
 
     def test_verify_head_changed_parks(self) -> None:
@@ -190,7 +214,7 @@ class HandleValidatingVerifyGateTest(unittest.TestCase, _PatchedWorkflowMixin):
         gh, issue = self._seeded()
         from orchestrator.worktrees import VerifyResult
         run = VerifyResult(
-            status="head_changed",
+            status=VERIFY_HEAD_CHANGED,
             command="sh -c 'git commit -am autofix'",
             exit_code=0,
             output="",
@@ -200,18 +224,18 @@ class HandleValidatingVerifyGateTest(unittest.TestCase, _PatchedWorkflowMixin):
         with patch.object(config, "VERIFY_COMMANDS", ("sh -c 'git commit -am autofix'",)):
             self._run(
                 lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
-                run_agent=_agent(last_message="LGTM\n\nVERDICT: APPROVED"),
-                head_shas=("rev-sha",),
+                run_agent=_agent(last_message=REVIEW_APPROVED_MESSAGE),
+                head_shas=(REVIEW_SHA,),
                 verify_result=run,
             )
 
-        state = gh.pinned_data(7)
+        state = gh.pinned_data(ISSUE)
         self.assertTrue(state.get("awaiting_human"))
-        self.assertEqual(state.get("park_reason"), "verify_head_changed")
+        self.assertEqual(state.get("park_reason"), PARK_VERIFY_HEAD_CHANGED)
         # No in_review / documenting handoff and no approval / squash
         # side effects.
-        self.assertNotIn((7, "in_review"), gh.label_history)
-        self.assertNotIn((7, "documenting"), gh.label_history)
+        self.assertNotIn((ISSUE, LABEL_IN_REVIEW), gh.label_history)
+        self.assertNotIn((ISSUE, LABEL_DOCUMENTING), gh.label_history)
         self.assertFalse(any(
             ":white_check_mark:" in body
             for _, body in gh.posted_pr_comments
@@ -226,24 +250,24 @@ class HandleValidatingVerifyGateTest(unittest.TestCase, _PatchedWorkflowMixin):
         gh, issue = self._seeded()
         from orchestrator.worktrees import VerifyResult
         run = VerifyResult(
-            status="dirty",
-            command="pytest -q",
+            status=VERIFY_DIRTY,
+            command=VERIFY_PYTEST,
             exit_code=0,
             dirty_files=("build/artifact.bin", "tests/cache"),
         )
-        with patch.object(config, "VERIFY_COMMANDS", ("pytest -q",)):
+        with patch.object(config, "VERIFY_COMMANDS", (VERIFY_PYTEST,)):
             self._run(
                 lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
-                run_agent=_agent(last_message="LGTM\n\nVERDICT: APPROVED"),
-                head_shas=("rev-sha",),
+                run_agent=_agent(last_message=REVIEW_APPROVED_MESSAGE),
+                head_shas=(REVIEW_SHA,),
                 verify_result=run,
             )
 
-        state = gh.pinned_data(7)
+        state = gh.pinned_data(ISSUE)
         self.assertTrue(state.get("awaiting_human"))
-        self.assertEqual(state.get("park_reason"), "verify_dirty")
-        self.assertNotIn((7, "in_review"), gh.label_history)
-        self.assertNotIn((7, "documenting"), gh.label_history)
+        self.assertEqual(state.get("park_reason"), PARK_VERIFY_DIRTY)
+        self.assertNotIn((ISSUE, LABEL_IN_REVIEW), gh.label_history)
+        self.assertNotIn((ISSUE, LABEL_DOCUMENTING), gh.label_history)
         last_comment = gh.posted_comments[-1][1]
         self.assertIn("build/artifact.bin", last_comment)
 
@@ -252,15 +276,15 @@ class HandleValidatingVerifyGateTest(unittest.TestCase, _PatchedWorkflowMixin):
         from orchestrator.worktrees import VerifyResult
         review = _agent(
             session_id="rev-sess",
-            last_message="1. Fix typo\n\nVERDICT: CHANGES_REQUESTED",
+            last_message=REVIEW_CHANGES_REQUESTED_MESSAGE,
         )
-        dev_fix = _agent(session_id="dev-sess", last_message="fixed")
+        dev_fix = _agent(session_id=DEV_SESSION, last_message="fixed")
         # The verify mock should not be called -- assert by setting a
         # failing result that would otherwise park the issue.
         verify_fail = VerifyResult(
-            status="failed", command="pytest -q", exit_code=1, output="bad",
+            status=VERIFY_FAILED, command=VERIFY_PYTEST, exit_code=1, output="bad",
         )
-        with patch.object(config, "VERIFY_COMMANDS", ("pytest -q",)):
+        with patch.object(config, "VERIFY_COMMANDS", (VERIFY_PYTEST,)):
             mocks = self._run(
                 lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
                 run_agent=[review, dev_fix],
@@ -273,17 +297,17 @@ class HandleValidatingVerifyGateTest(unittest.TestCase, _PatchedWorkflowMixin):
         mocks["_run_verify_commands"].assert_not_called()
         # Standard CHANGES_REQUESTED handling: PR review comment + dev resume.
         self.assertEqual(mocks["run_agent"].call_count, 2)
-        self.assertEqual(gh.pinned_data(7).get("review_round"), 1)
-        state = gh.pinned_data(7)
+        self.assertEqual(gh.pinned_data(ISSUE).get("review_round"), 1)
+        state = gh.pinned_data(ISSUE)
         self.assertFalse(state.get("awaiting_human"))
 
     def test_unknown_verdict_does_not_run_verify(self) -> None:
         gh, issue = self._seeded()
         from orchestrator.worktrees import VerifyResult
         verify_fail = VerifyResult(
-            status="failed", command="pytest -q", exit_code=1, output="bad",
+            status=VERIFY_FAILED, command=VERIFY_PYTEST, exit_code=1, output="bad",
         )
-        with patch.object(config, "VERIFY_COMMANDS", ("pytest -q",)):
+        with patch.object(config, "VERIFY_COMMANDS", (VERIFY_PYTEST,)):
             mocks = self._run(
                 lambda: workflow._handle_validating(gh, _TEST_SPEC, issue),
                 run_agent=_agent(
@@ -293,13 +317,16 @@ class HandleValidatingVerifyGateTest(unittest.TestCase, _PatchedWorkflowMixin):
             )
 
         mocks["_run_verify_commands"].assert_not_called()
-        state = gh.pinned_data(7)
+        state = gh.pinned_data(ISSUE)
         # Park comes from the unknown-verdict path, NOT the verify gate;
         # confirm by checking the comment text (the unknown-verdict park
         # does not persist `park_reason` to pinned state for the
         # non-silent-crash case).
         self.assertTrue(state.get("awaiting_human"))
-        self.assertNotIn(state.get("park_reason"), ("verify_failed", "verify_timeout", "verify_dirty"))
+        self.assertNotIn(
+            state.get("park_reason"),
+            (PARK_VERIFY_FAILED, PARK_VERIFY_TIMEOUT, PARK_VERIFY_DIRTY),
+        )
         self.assertIn("did not emit a VERDICT line", gh.posted_comments[-1][1])
 
 
@@ -310,7 +337,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
         self.tmp = Path(tempfile.mkdtemp())
         # Initialize a git repo so the dirty-detection branch works.
         subprocess.run(
-            ["git", "init", "-q", "-b", "main", str(self.tmp)],
+            ["git", "init", "-q", "-b", TEST_BASE_BRANCH, str(self.tmp)],
             check=True,
         )
         subprocess.run(
@@ -335,14 +362,14 @@ class RunVerifyCommandsTest(unittest.TestCase):
 
     def test_empty_commands_short_circuits_to_ok(self) -> None:
         run = workflow._run_verify_commands(self.tmp, (), 60)
-        self.assertEqual(run.status, "ok")
+        self.assertEqual(run.status, VERIFY_OK)
         self.assertIsNone(run.command)
 
     def test_all_commands_pass_returns_ok(self) -> None:
         run = workflow._run_verify_commands(
             self.tmp, ("true", "echo hello"), 60,
         )
-        self.assertEqual(run.status, "ok")
+        self.assertEqual(run.status, VERIFY_OK)
 
     def test_non_zero_exit_names_first_failing_command(self) -> None:
         run = workflow._run_verify_commands(
@@ -350,7 +377,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
             ("true", "sh -c 'echo boom 1>&2; exit 3'", "true"),
             60,
         )
-        self.assertEqual(run.status, "failed")
+        self.assertEqual(run.status, VERIFY_FAILED)
         self.assertEqual(run.command, "sh -c 'echo boom 1>&2; exit 3'")
         self.assertEqual(run.exit_code, 3)
         self.assertIn("boom", run.output)
@@ -360,7 +387,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
         run = workflow._run_verify_commands(
             self.tmp, ("sleep 5",), timeout=1,
         )
-        self.assertEqual(run.status, "timeout")
+        self.assertEqual(run.status, VERIFY_TIMEOUT)
         self.assertEqual(run.command, "sleep 5")
         self.assertIsNone(run.exit_code)
 
@@ -385,7 +412,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
             f"(sleep 2 && touch {marker}) & sleep 10"
         )
         run = workflow._run_verify_commands(self.tmp, (cmd,), timeout=1)
-        self.assertEqual(run.status, "timeout")
+        self.assertEqual(run.status, VERIFY_TIMEOUT)
         # Wait well past when the background touch would have fired.
         # 3s gives the background its full 2s + 1s of slack.
         import time
@@ -400,7 +427,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
         run = workflow._run_verify_commands(
             self.tmp, ("sh -c 'echo leak > leftover.txt'",), 60,
         )
-        self.assertEqual(run.status, "dirty")
+        self.assertEqual(run.status, VERIFY_DIRTY)
         self.assertIn("leftover.txt", run.dirty_files)
 
     def test_output_truncated_to_budget(self) -> None:
@@ -410,7 +437,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
             (f"sh -c 'printf %s {shutil_quote(big)}; exit 1'",),
             60,
         )
-        self.assertEqual(run.status, "failed")
+        self.assertEqual(run.status, VERIFY_FAILED)
         # Tail preserved, leading bulk trimmed.
         self.assertIn("TAIL", run.output)
         self.assertLessEqual(len(run.output), 4096)
@@ -444,7 +471,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
         cmd = f"sh -c 'printf %s {shlex.quote(payload)}; exit 1'"
         with patch.dict(_os.environ, {"VERIFY_TEST_API_KEY": secret}):
             run = workflow._run_verify_commands(self.tmp, (cmd,), 60)
-        self.assertEqual(run.status, "failed")
+        self.assertEqual(run.status, VERIFY_FAILED)
         # The full secret must be gone -- baseline check.
         self.assertNotIn(secret, run.output)
         # And no 8+ char substring of the secret survives either.
@@ -481,7 +508,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
             {"GITHUB_TOKEN": "ghp_ORCHESTRATOR_PAT_SHOULD_NOT_LEAK"},
         ):
             run = workflow._run_verify_commands(self.tmp, (cmd,), 60)
-        self.assertEqual(run.status, "failed")
+        self.assertEqual(run.status, VERIFY_FAILED)
         # The verify environment must NOT carry GITHUB_TOKEN through.
         self.assertIn("TOKEN_PRESENT=NO", run.output)
         # And the original token value must not appear verbatim. (This
@@ -516,7 +543,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
             },
         ):
             run = workflow._run_verify_commands(self.tmp, (cmd,), 60)
-        self.assertEqual(run.status, "failed")
+        self.assertEqual(run.status, VERIFY_FAILED)
         self.assertIn("SSH_AUTH=NO", run.output)
         self.assertIn("SSH_ASK=NO", run.output)
         self.assertIn("GIT_ASK=NO", run.output)
@@ -554,7 +581,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
             },
         ):
             run = workflow._run_verify_commands(self.tmp, (cmd,), 60)
-        self.assertEqual(run.status, "failed")
+        self.assertEqual(run.status, VERIFY_FAILED)
         self.assertIn("ORCH_TF=NO", run.output)
         self.assertIn("GAC=NO", run.output)
         self.assertIn("AWS_SCF=NO", run.output)
@@ -598,7 +625,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
             },
         ):
             run = workflow._run_verify_commands(self.tmp, (cmd,), 60)
-        self.assertEqual(run.status, "failed")
+        self.assertEqual(run.status, VERIFY_FAILED)
         self.assertIn("STRIPE_PRESENT=NO", run.output)
         self.assertIn("DBPW_PRESENT=NO", run.output)
         self.assertIn("DEPLOY_PRESENT=NO", run.output)
@@ -638,7 +665,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
             "git commit -q -m \"chore: verify-time auto-fix\"'"
         )
         run = workflow._run_verify_commands(self.tmp, (cmd,), 60)
-        self.assertEqual(run.status, "head_changed")
+        self.assertEqual(run.status, VERIFY_HEAD_CHANGED)
         self.assertEqual(run.command, cmd)
         self.assertEqual(run.head_before, head_before)
         self.assertNotEqual(run.head_after, head_before)
@@ -658,7 +685,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
             "true",                                              # should never run
         )
         run = workflow._run_verify_commands(self.tmp, cmds, 60)
-        self.assertEqual(run.status, "dirty")
+        self.assertEqual(run.status, VERIFY_DIRTY)
         # Named command is the SECOND command (the one that left the
         # tree dirty), NOT `commands[-1]`.
         self.assertEqual(run.command, cmds[1])
@@ -694,7 +721,7 @@ class RunVerifyCommandsTest(unittest.TestCase):
              patch.object(verify, "_head_sha", return_value="sha"):
             run = verify._run_verify_commands(self.tmp, ("true",), 60)
 
-        self.assertEqual(run.status, "ok")
+        self.assertEqual(run.status, VERIFY_OK)
         self.assertTrue(
             seen.get("during"), "verify child not registered during the run",
         )

--- a/tests/test_workflow_verdict_parsing.py
+++ b/tests/test_workflow_verdict_parsing.py
@@ -17,44 +17,65 @@ from orchestrator.workflow_messages import (
     _parse_review_verdict,
 )
 
+from tests.workflow_helpers import (
+    VERDICT_APPROVED,
+    VERDICT_CHANGES_REQUESTED,
+    VERDICT_UNKNOWN,
+)
+
+
+REVIEW_APPROVED_BODY = "Looks good."
+REVIEW_APPROVED_MARKER = "VERDICT: APPROVED"
+REVIEW_CHANGES_REQUESTED_MARKER = "VERDICT: CHANGES_REQUESTED"
+DOCS_NO_CHANGE = "no_change"
+DOCS_NO_CHANGE_MARKER = "DOCS: NO_CHANGE"
+
 
 class ParseReviewVerdictTest(unittest.TestCase):
     def test_approved_alone_on_line(self) -> None:
         self.assertEqual(
-            _parse_review_verdict("Looks good.\n\nVERDICT: APPROVED"),
-            ("approved", "Looks good."),
+            _parse_review_verdict(
+                f"{REVIEW_APPROVED_BODY}\n\n{REVIEW_APPROVED_MARKER}"
+            ),
+            (VERDICT_APPROVED, REVIEW_APPROVED_BODY),
         )
 
     def test_changes_requested_with_numbered_list(self) -> None:
-        msg = "1. Fix typo in README\n2. Add a test for the empty case\n\nVERDICT: CHANGES_REQUESTED"
+        msg = (
+            "1. Fix typo in README\n2. Add a test for the empty case\n\n"
+            f"{REVIEW_CHANGES_REQUESTED_MARKER}"
+        )
         verdict, body = _parse_review_verdict(msg)
-        self.assertEqual(verdict, "changes_requested")
+        self.assertEqual(verdict, VERDICT_CHANGES_REQUESTED)
         self.assertIn("1. Fix typo in README", body)
         self.assertNotIn("VERDICT", body)
 
     def test_inline_marker_is_accepted(self) -> None:
         self.assertEqual(
-            _parse_review_verdict("All good. VERDICT: APPROVED"),
-            ("approved", "All good."),
+            _parse_review_verdict(f"All good. {REVIEW_APPROVED_MARKER}"),
+            (VERDICT_APPROVED, "All good."),
         )
 
     def test_case_insensitive(self) -> None:
         verdict, _ = _parse_review_verdict("verdict: approved")
-        self.assertEqual(verdict, "approved")
+        self.assertEqual(verdict, VERDICT_APPROVED)
 
     def test_last_marker_wins(self) -> None:
-        msg = "I considered VERDICT: APPROVED but a test fails.\nVERDICT: CHANGES_REQUESTED"
+        msg = (
+            f"I considered {REVIEW_APPROVED_MARKER} but a test fails.\n"
+            f"{REVIEW_CHANGES_REQUESTED_MARKER}"
+        )
         verdict, _ = _parse_review_verdict(msg)
-        self.assertEqual(verdict, "changes_requested")
+        self.assertEqual(verdict, VERDICT_CHANGES_REQUESTED)
 
     def test_no_marker_returns_unknown(self) -> None:
         self.assertEqual(
             _parse_review_verdict("looks fine to me"),
-            ("unknown", "looks fine to me"),
+            (VERDICT_UNKNOWN, "looks fine to me"),
         )
 
     def test_empty_message_returns_unknown(self) -> None:
-        self.assertEqual(_parse_review_verdict(""), ("unknown", ""))
+        self.assertEqual(_parse_review_verdict(""), (VERDICT_UNKNOWN, ""))
 
 
 class ParseDocumentationVerdictTest(unittest.TestCase):
@@ -74,25 +95,26 @@ class ParseDocumentationVerdictTest(unittest.TestCase):
     def test_no_change_marker_alone_on_line(self) -> None:
         self.assertEqual(
             _parse_documentation_verdict(
-                "Diff is internal-only; nothing user-visible changed.\n\nDOCS: NO_CHANGE"
+                "Diff is internal-only; nothing user-visible changed."
+                f"\n\n{DOCS_NO_CHANGE_MARKER}"
             ),
-            ("no_change", "Diff is internal-only; nothing user-visible changed."),
+            (DOCS_NO_CHANGE, "Diff is internal-only; nothing user-visible changed."),
         )
 
     def test_no_change_marker_case_insensitive(self) -> None:
         verdict, _ = _parse_documentation_verdict("docs: no_change")
-        self.assertEqual(verdict, "no_change")
+        self.assertEqual(verdict, DOCS_NO_CHANGE)
 
     def test_last_marker_wins(self) -> None:
         # Mirrors `_parse_review_verdict`'s "last marker wins" rule so a
         # template/sample reference earlier in the body loses to the
         # concluding line.
         msg = (
-            "I almost wrote DOCS: NO_CHANGE but actually the README is "
-            "stale, so I'll commit a fix.\n\nDOCS: NO_CHANGE"
+            f"I almost wrote {DOCS_NO_CHANGE_MARKER} but actually the README is "
+            f"stale, so I'll commit a fix.\n\n{DOCS_NO_CHANGE_MARKER}"
         )
         verdict, _ = _parse_documentation_verdict(msg)
-        self.assertEqual(verdict, "no_change")
+        self.assertEqual(verdict, DOCS_NO_CHANGE)
 
     def test_ambiguous_no_change_text_is_not_accepted(self) -> None:
         # Plain prose that sounds like a no-change result must NOT pass
@@ -101,7 +123,7 @@ class ParseDocumentationVerdictTest(unittest.TestCase):
         verdict, body = _parse_documentation_verdict(
             "Looks like no docs changes needed."
         )
-        self.assertEqual(verdict, "unknown")
+        self.assertEqual(verdict, VERDICT_UNKNOWN)
         self.assertIn("no docs changes needed", body)
 
     def test_update_description_without_marker_is_unknown(self) -> None:
@@ -112,7 +134,7 @@ class ParseDocumentationVerdictTest(unittest.TestCase):
         verdict, _ = _parse_documentation_verdict(
             "Updated README.md with the new flag."
         )
-        self.assertEqual(verdict, "unknown")
+        self.assertEqual(verdict, VERDICT_UNKNOWN)
 
     def test_inline_marker_in_prose_is_unknown(self) -> None:
         # The marker must start its own line. An inline reference
@@ -120,29 +142,31 @@ class ParseDocumentationVerdictTest(unittest.TestCase):
         # NO_CHANGE because the README is stale" -- is exactly the kind
         # of ambiguous no-commit text the issue forbids accepting.
         verdict, _ = _parse_documentation_verdict(
-            "I cannot conclude DOCS: NO_CHANGE because README is stale."
+            f"I cannot conclude {DOCS_NO_CHANGE_MARKER} because README is stale."
         )
-        self.assertEqual(verdict, "unknown")
+        self.assertEqual(verdict, VERDICT_UNKNOWN)
 
     def test_non_final_marker_followed_by_text_is_unknown(self) -> None:
         # The marker must be the FINAL non-whitespace content. A marker
         # line followed by an unresolved question must be rejected so an
         # agent's follow-up clarification can't silently close the stage.
         verdict, _ = _parse_documentation_verdict(
-            "DOCS: NO_CHANGE\nBut I have a question about the API."
+            f"{DOCS_NO_CHANGE_MARKER}\nBut I have a question about the API."
         )
-        self.assertEqual(verdict, "unknown")
+        self.assertEqual(verdict, VERDICT_UNKNOWN)
 
     def test_marker_with_trailing_punctuation_is_unknown(self) -> None:
         # `DOCS: NO_CHANGE.` (trailing punctuation) is rejected; the
         # contract is a machine-readable marker, not a sentence. Without
         # this, a markdown-trained agent's habit of ending sentences
         # with periods would silently mask the stricter rule.
-        verdict, _ = _parse_documentation_verdict("All clear.\n\nDOCS: NO_CHANGE.")
-        self.assertEqual(verdict, "unknown")
+        verdict, _ = _parse_documentation_verdict(
+            f"All clear.\n\n{DOCS_NO_CHANGE_MARKER}."
+        )
+        self.assertEqual(verdict, VERDICT_UNKNOWN)
 
     def test_empty_message_returns_unknown(self) -> None:
-        self.assertEqual(_parse_documentation_verdict(""), ("unknown", ""))
+        self.assertEqual(_parse_documentation_verdict(""), (VERDICT_UNKNOWN, ""))
 
 
 class VerdictParserReexportTest(unittest.TestCase):

--- a/tests/workflow_helpers.py
+++ b/tests/workflow_helpers.py
@@ -33,15 +33,57 @@ def _manifest(payload: str) -> str:
     return f"```orchestrator-manifest\n{payload}\n```"
 
 
+TEST_REPO_SLUG = "geserdugarov/agent-orchestrator"
+TEST_BASE_BRANCH = "main"
+
+LABEL_DECOMPOSING = "decomposing"
+LABEL_DOCUMENTING = "documenting"
+LABEL_DONE = "done"
+LABEL_FIXING = "fixing"
+LABEL_IMPLEMENTING = "implementing"
+LABEL_IN_REVIEW = "in_review"
+LABEL_REJECTED = "rejected"
+LABEL_RESOLVING_CONFLICT = "resolving_conflict"
+LABEL_VALIDATING = "validating"
+
+STATE_CLOSED = "closed"
+STATE_OPEN = "open"
+
+BACKEND_CLAUDE = "claude"
+BACKEND_CODEX = "codex"
+
+ROLE_DEVELOPER = "developer"
+ROLE_REVIEWER = "reviewer"
+
+EVENT_AGENT_EXIT = "agent_exit"
+EVENT_AGENT_SPAWN = "agent_spawn"
+EVENT_AGENT_TRAJECTORY = "agent_trajectory"
+EVENT_PR_CLOSED_WITHOUT_MERGE = "pr_closed_without_merge"
+EVENT_PR_MERGED = "pr_merged"
+EVENT_SKILL_TRIGGERED = "skill_triggered"
+EVENT_STAGE_ENTER = "stage_enter"
+EVENT_STAGE_EVALUATION = "stage_evaluation"
+
+VERDICT_APPROVED = "approved"
+VERDICT_CHANGES_REQUESTED = "changes_requested"
+VERDICT_UNKNOWN = "unknown"
+REVIEW_APPROVED_MESSAGE = "LGTM\n\nVERDICT: APPROVED"
+REVIEW_CHANGES_REQUESTED_MESSAGE = "1. Fix typo\n\nVERDICT: CHANGES_REQUESTED"
+
+
+def _issue_branch(issue_number: int, slug: str = TEST_REPO_SLUG) -> str:
+    return f"orchestrator/{slug.replace('/', '__')}/issue-{issue_number}"
+
+
 _FAKE_WT = Path("/tmp/orchestrator-test-wt-doesnt-matter")
 # Tests don't shell out (the worktree/git helpers are mocked), so the values
 # only need to be plausible -- the slug/base reach `_build_review_prompt`,
 # `_push_branch`, and the `find_open_pr` / `open_pr` call sites and are
 # inspected by some assertions; nothing else cares.
 _TEST_SPEC = config.RepoSpec(
-    slug="geserdugarov/agent-orchestrator",
+    slug=TEST_REPO_SLUG,
     target_root=Path("/tmp/orchestrator-test-target-root"),
-    base_branch="main",
+    base_branch=TEST_BASE_BRANCH,
 )
 
 
@@ -287,7 +329,7 @@ class _ResolvingConflictMixin(_PatchedWorkflowMixin):
     happens.
     """
 
-    BRANCH = "orchestrator/geserdugarov__agent-orchestrator/issue-200"
+    BRANCH = _issue_branch(200)
     PR_NUMBER = 800
 
     def _seed(
@@ -298,12 +340,12 @@ class _ResolvingConflictMixin(_PatchedWorkflowMixin):
         head_shas=("before", "after"),
         push_branch: bool = True,
         run_agent_result=None,
-        pr_state: str = "open",
+        pr_state: str = STATE_OPEN,
         pr_merged: bool = False,
         extra_state=None,
     ):
         gh = FakeGitHubClient()
-        issue = make_issue(200, label="resolving_conflict")
+        issue = make_issue(200, label=LABEL_RESOLVING_CONFLICT)
         gh.add_issue(issue)
         pr = FakePR(
             number=self.PR_NUMBER, head_branch=self.BRANCH,
@@ -314,7 +356,7 @@ class _ResolvingConflictMixin(_PatchedWorkflowMixin):
         gh.add_pr(pr)
         state = dict(
             pr_number=self.PR_NUMBER, branch=self.BRANCH,
-            dev_agent="claude", dev_session_id="dev-sess",
+            dev_agent=BACKEND_CLAUDE, dev_session_id="dev-sess",
             review_round=2,
             conflict_round=0,
         )


### PR DESCRIPTION
Resolves #771 

Implemented the test-string consolidation across workflow/analytics tests.

What changed:

- Added shared workflow test constants and `_issue_branch()` in `tests/workflow_helpers.py`.
- Replaced repeated labels, event names, roles, repo/base values, review messages, PR states, and branch strings in the touched workflow/analytics tests.
- Kept parser/verify-specific concepts local in their test files.
