### PR TITLE
refactor: flatten dashboard helpers

### DIFF
--- a/orchestrator/analytics/read_dashboard.py
+++ b/orchestrator/analytics/read_dashboard.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
+from functools import partial
 from typing import Any, Callable, Optional, Sequence
 
 from .connection import _default_connect
@@ -63,6 +64,30 @@ def _as_skill_names(value: Any) -> list[str]:
     if not isinstance(value, (list, tuple)):
         return []
     return [s for s in value if isinstance(s, str)]
+
+
+def _label_or_unknown(value: Any) -> str:
+    if value is None:
+        return "unknown"
+    return str(value)
+
+
+def _row_label(row: Sequence[Any], index: int) -> str:
+    if len(row) <= index:
+        return "unknown"
+    return _label_or_unknown(row[index])
+
+
+def _skill_matrix_order_key(
+    key: tuple[str, str, str, str],
+    *,
+    counts: dict[tuple[str, str, str, str], int],
+    cohort_runs: dict[tuple[str, str, str], int],
+) -> tuple:
+    repo, role, backend, skill = key
+    skill_runs = counts.get(key, 0)
+    total = cohort_runs.get((repo, role, backend), 0)
+    return (-skill_runs, -total, repo, role, backend, skill)
 
 
 # Default cap on the rows `get_skill_trigger_matrix` returns. The
@@ -311,8 +336,8 @@ def get_skill_trigger_rates(
         total_triggers = row[4] if len(row) > 4 else 0
         out.append(
             SkillTriggerRateRow(
-                agent_role=str(role) if role is not None else "unknown",
-                backend=str(backend) if backend is not None else "unknown",
+                agent_role=_label_or_unknown(role),
+                backend=_label_or_unknown(backend),
                 runs=int(runs or 0),
                 skill_runs=int(skill_runs or 0),
                 total_triggers=int(total_triggers or 0),
@@ -433,13 +458,9 @@ def get_skill_trigger_matrix(
     cohort_runs: dict[tuple[str, str, str], int] = {}
     counts: dict[tuple[str, str, str, str], int] = {}
     for row in run_rows:
-        r_repo = str(row[0]) if row[0] is not None else "unknown"
-        role = (
-            str(row[1]) if len(row) > 1 and row[1] is not None else "unknown"
-        )
-        backend = (
-            str(row[2]) if len(row) > 2 and row[2] is not None else "unknown"
-        )
+        r_repo = _label_or_unknown(row[0])
+        role = _row_label(row, 1)
+        backend = _row_label(row, 2)
         cohort = (r_repo, role, backend)
         # One agent-exit row == one run in the cohort, regardless of how
         # many (or whether any) skills it fired.
@@ -455,33 +476,33 @@ def get_skill_trigger_matrix(
     #    the catalog is missing, so the fall-back path emits only the
     #    observed-trigger cells.
     keys: set[tuple[str, str, str, str]] = set(counts)
-    for (c_repo, role, backend) in cohort_runs:
-        for skill in catalog.get(c_repo, ()):
-            keys.add((c_repo, role, backend, skill))
+    for (catalog_repo, catalog_role, catalog_backend) in cohort_runs:
+        for catalog_skill in catalog.get(catalog_repo, ()):
+            keys.add((catalog_repo, catalog_role, catalog_backend, catalog_skill))
 
-    def _order(key: tuple[str, str, str, str]) -> tuple:
-        k_repo, role, backend, skill = key
-        skill_runs = counts.get(key, 0)
-        total = cohort_runs.get((k_repo, role, backend), 0)
-        # Runs-with-skill DESC, then cohort runs DESC (negated for the
-        # ascending sort), then a stable repo / role / backend / skill
-        # tiebreak so equal-weight rows keep a deterministic order.
-        return (-skill_runs, -total, k_repo, role, backend, skill)
-
-    ordered = sorted(keys, key=_order)
+    ordered = sorted(
+        keys,
+        key=partial(
+            _skill_matrix_order_key,
+            counts=counts,
+            cohort_runs=cohort_runs,
+        ),
+    )
     if limit > 0:
         ordered = ordered[:limit]
 
     out: list[SkillTriggerMatrixRow] = []
     for key in ordered:
-        k_repo, role, backend, skill = key
+        matrix_repo, matrix_role, matrix_backend, matrix_skill = key
         out.append(
             SkillTriggerMatrixRow(
-                repo=k_repo,
-                skill=skill,
-                agent_role=role,
-                backend=backend,
-                runs=cohort_runs.get((k_repo, role, backend), 0),
+                repo=matrix_repo,
+                skill=matrix_skill,
+                agent_role=matrix_role,
+                backend=matrix_backend,
+                runs=cohort_runs.get(
+                    (matrix_repo, matrix_role, matrix_backend), 0
+                ),
                 skill_runs=counts.get(key, 0),
             )
         )

--- a/orchestrator/analytics/read_raw.py
+++ b/orchestrator/analytics/read_raw.py
@@ -40,6 +40,30 @@ _FILTER_OPTION_COLUMNS: tuple[str, ...] = (
 )
 
 
+def _int_or_none(raw: Any) -> Optional[int]:
+    if raw is None:
+        return None
+    return int(raw)
+
+
+def _float_or_none(raw: Any) -> Optional[float]:
+    if raw is None:
+        return None
+    return float(raw)
+
+
+def _bool_or_none(raw: Any) -> Optional[bool]:
+    if raw is None:
+        return None
+    return bool(raw)
+
+
+def _empty_filter_selected(values: Optional[Sequence[str]]) -> bool:
+    if values is None:
+        return False
+    return len(values) == 0
+
+
 def get_filter_options(
     *,
     db_url: Optional[str] = None,
@@ -254,22 +278,14 @@ def get_recent_agent_exits(
                 stage=stage,
                 agent_role=agent_role,
                 backend=backend,
-                duration_s=float(duration_s) if duration_s is not None else None,
-                exit_code=int(exit_code) if exit_code is not None else None,
-                timed_out=bool(timed_out) if timed_out is not None else None,
-                review_round=(
-                    int(review_round) if review_round is not None else None
-                ),
-                retry_count=(
-                    int(retry_count) if retry_count is not None else None
-                ),
-                input_tokens=(
-                    int(input_tokens) if input_tokens is not None else None
-                ),
-                output_tokens=(
-                    int(output_tokens) if output_tokens is not None else None
-                ),
-                cost_usd=float(cost_usd) if cost_usd is not None else None,
+                duration_s=_float_or_none(duration_s),
+                exit_code=_int_or_none(exit_code),
+                timed_out=_bool_or_none(timed_out),
+                review_round=_int_or_none(review_round),
+                retry_count=_int_or_none(retry_count),
+                input_tokens=_int_or_none(input_tokens),
+                output_tokens=_int_or_none(output_tokens),
+                cost_usd=_float_or_none(cost_usd),
                 cost_source=cost_source,
             )
         )
@@ -415,24 +431,12 @@ def get_issues(
                 last_seen=last_seen,
                 latest_stage=latest_stage,
                 agent_exits=int(agent_exits or 0),
-                total_cost_usd=(
-                    float(total_cost_usd)
-                    if total_cost_usd is not None
-                    else None
-                ),
+                total_cost_usd=_float_or_none(total_cost_usd),
                 total_input_tokens=int(total_input_tokens or 0),
                 total_output_tokens=int(total_output_tokens or 0),
-                max_review_round=(
-                    int(max_review_round)
-                    if max_review_round is not None
-                    else None
-                ),
+                max_review_round=_int_or_none(max_review_round),
                 failed_agent_runs=int(failed_agent_runs or 0),
-                max_retry_count=(
-                    int(max_retry_count)
-                    if max_retry_count is not None
-                    else None
-                ),
+                max_retry_count=_int_or_none(max_retry_count),
             )
         )
     return out
@@ -464,9 +468,9 @@ def get_issue_events(
     url = _resolve_db_url(db_url)
     if conn is None and not url:
         return []
-    if events is not None and not events:
+    if _empty_filter_selected(events):
         return []
-    if stages is not None and not stages:
+    if _empty_filter_selected(stages):
         return []
     connect_fn = connect or _default_connect
     conditions = ["repo = %s", "issue = %s"]
@@ -511,12 +515,12 @@ def get_issue_events(
                 ts=ts,
                 event=event,
                 stage=stage,
-                duration_s=float(duration_s) if duration_s is not None else None,
+                duration_s=_float_or_none(duration_s),
                 result=result,
                 agent_role=agent_role,
                 backend=backend,
-                exit_code=int(exit_code) if exit_code is not None else None,
-                cost_usd=float(cost_usd) if cost_usd is not None else None,
+                exit_code=_int_or_none(exit_code),
+                cost_usd=_float_or_none(cost_usd),
             )
         )
     return out

--- a/orchestrator/dashboard.py
+++ b/orchestrator/dashboard.py
@@ -378,9 +378,9 @@ def main() -> None:
 
     repo_filter = None if repo_choice == "All" else repo_choice
     issue_input_parsed = parse_issue_number(issue_input)
-    issue_filter = (
-        issue_input_parsed if repo_filter is not None else None
-    )
+    issue_filter = None
+    if repo_filter:
+        issue_filter = issue_input_parsed
     event_filter = list(event_choice)
     stage_filter = resolve_stage_filter(stage_choice, options.stages)
 
@@ -577,7 +577,9 @@ def _filter_list(values_t: Optional[Sequence[str]]) -> Optional[list[str]]:
     -- `None` means "no filter", an empty selection means "show
     nothing", and the two must stay distinct at the read layer.
     """
-    return list(values_t) if values_t is not None else None
+    if values_t is None:
+        return None
+    return list(values_t)
 
 
 def _scoped_read(getter: Callable[..., Any], /, **filters: Any) -> Any:
@@ -595,6 +597,14 @@ def _scoped_read(getter: Callable[..., Any], /, **filters: Any) -> Any:
         return getter(conn=conn, **filters)
 
 
+def _read_data_extent():
+    return _scoped_read(analytics_read.get_data_extent)
+
+
+def _read_filter_options():
+    return _scoped_read(analytics_read.get_filter_options)
+
+
 def _read_static_metadata(*, st: Any):
     """Read the data extent + filter options through cached wrappers.
 
@@ -605,16 +615,15 @@ def _read_static_metadata(*, st: Any):
     topbar round-trip on every rerun. Returns `(extent, options)`; a read
     error is surfaced as one `st.error` and stops the app.
     """
-    @st.cache_data(show_spinner=False, ttl=STATIC_METADATA_TTL_SECONDS)
-    def _read_data_extent():
-        return _scoped_read(analytics_read.get_data_extent)
-
-    @st.cache_data(show_spinner=False, ttl=STATIC_METADATA_TTL_SECONDS)
-    def _read_filter_options():
-        return _scoped_read(analytics_read.get_filter_options)
+    read_data_extent = st.cache_data(
+        show_spinner=False, ttl=STATIC_METADATA_TTL_SECONDS,
+    )(_read_data_extent)
+    read_filter_options = st.cache_data(
+        show_spinner=False, ttl=STATIC_METADATA_TTL_SECONDS,
+    )(_read_filter_options)
 
     try:
-        return _read_data_extent(), _read_filter_options()
+        return read_data_extent(), read_filter_options()
     except analytics_read.AnalyticsReadError as e:
         st.error(
             "Could not load analytics filter options: "
@@ -646,6 +655,153 @@ def _render_no_data(*, st: Any, extent: DataExtent, theme: Any) -> None:
     st.stop()
 
 
+def _read_summary(start, end, repo, events_t, stages_t, issue):
+    return _scoped_read(
+        analytics_read.get_summary,
+        start=start, end=end, repo=repo,
+        events=_filter_list(events_t), stages=_filter_list(stages_t),
+        issue=issue,
+    )
+
+
+def _read_prev_kpi(start, end, repo, events_t, stages_t, issue):
+    # Previous-window read for the KPI delta pills and cost-trend
+    # banner only. The full `get_summary` shape is never read off
+    # `prev_summary`, so a thinner reader saves a `GROUP BY` follow-up
+    # while leaving the cache key identical to `_read_summary`.
+    return _scoped_read(
+        analytics_read.get_kpi_prev,
+        start=start, end=end, repo=repo,
+        events=_filter_list(events_t), stages=_filter_list(stages_t),
+        issue=issue,
+    )
+
+
+def _read_time_series(start, end, repo, events_t, stages_t, issue):
+    return _scoped_read(
+        analytics_read.get_time_series,
+        start=start, end=end, repo=repo,
+        events=_filter_list(events_t), stages=_filter_list(stages_t),
+        issue=issue,
+    )
+
+
+def _read_stage_breakdown(start, end, repo, events_t, stages_t, issue):
+    return _scoped_read(
+        analytics_read.get_stage_breakdown,
+        start=start, end=end, repo=repo,
+        events=_filter_list(events_t), stages=_filter_list(stages_t),
+        issue=issue,
+    )
+
+
+def _read_recent_agent_exits(start, end, repo, events_t, stages_t, issue):
+    return _scoped_read(
+        analytics_read.get_recent_agent_exits,
+        limit=DEFAULT_RECENT_AGENT_EXITS,
+        start=start, end=end, repo=repo,
+        events=_filter_list(events_t), stages=_filter_list(stages_t),
+        issue=issue,
+    )
+
+
+def _read_top_cost_issues(start, end, repo, events_t, stages_t, issue):
+    # Ask the database for the top-cost issues directly. Reading the
+    # latest N issues by `last_seen` and re-sorting in Python silently
+    # drops older high-cost issues that fall outside the truncated set.
+    return _scoped_read(
+        analytics_read.get_issues,
+        limit=DEFAULT_EXPENSIVE_LIMIT,
+        sort_by=analytics_read.SORT_BY_COST,
+        start=start, end=end, repo=repo,
+        events=_filter_list(events_t), stages=_filter_list(stages_t),
+        issue=issue,
+    )
+
+
+def _read_review_round(start, end, repo, events_t, stages_t, issue):
+    return _scoped_read(
+        analytics_read.get_review_round_breakdown,
+        start=start, end=end, repo=repo,
+        events=_filter_list(events_t), stages=_filter_list(stages_t),
+        issue=issue,
+    )
+
+
+def _read_backend_efficiency(start, end, repo, events_t, stages_t, issue):
+    return _scoped_read(
+        analytics_read.get_backend_efficiency,
+        start=start, end=end, repo=repo,
+        events=_filter_list(events_t), stages=_filter_list(stages_t),
+        issue=issue,
+    )
+
+
+def _read_repo_breakdown(start, end, repo, events_t, stages_t, issue):
+    return _scoped_read(
+        analytics_read.get_repo_breakdown,
+        start=start, end=end, repo=repo,
+        events=_filter_list(events_t), stages=_filter_list(stages_t),
+        issue=issue,
+    )
+
+
+def _read_cost_coverage(start, end, repo, events_t, stages_t, issue):
+    return _scoped_read(
+        analytics_read.get_cost_coverage,
+        start=start, end=end, repo=repo,
+        events=_filter_list(events_t), stages=_filter_list(stages_t),
+        issue=issue,
+    )
+
+
+def _read_hourly_heatmap(
+    start, end, repo, events_t, stages_t, issue, tz_offset_hours,
+):
+    return _scoped_read(
+        analytics_read.get_hourly_heatmap,
+        start=start, end=end, repo=repo,
+        events=_filter_list(events_t), stages=_filter_list(stages_t),
+        issue=issue, tz_offset_hours=tz_offset_hours,
+    )
+
+
+def _read_throughput(start, end, repo, events_t, stages_t, issue):
+    return _scoped_read(
+        analytics_read.get_throughput_breakdown,
+        start=start, end=end, repo=repo,
+        events=_filter_list(events_t), stages=_filter_list(stages_t),
+        issue=issue,
+    )
+
+
+def _read_backend_daily_tokens(start, end, repo, events_t, stages_t, issue):
+    return _scoped_read(
+        analytics_read.get_backend_daily_tokens,
+        start=start, end=end, repo=repo,
+        events=_filter_list(events_t), stages=_filter_list(stages_t),
+        issue=issue,
+    )
+
+
+def _read_skill_trigger_rates(start, end, repo, events_t, stages_t, issue):
+    return _scoped_read(
+        analytics_read.get_skill_trigger_rates,
+        start=start, end=end, repo=repo,
+        events=_filter_list(events_t), stages=_filter_list(stages_t),
+        issue=issue,
+    )
+
+
+def _read_skill_trigger_matrix(start, end, repo, events_t, stages_t, issue):
+    return _scoped_read(
+        analytics_read.get_skill_trigger_matrix,
+        start=start, end=end, repo=repo,
+        events=_filter_list(events_t), stages=_filter_list(stages_t),
+        issue=issue,
+    )
+
+
 def _widget_readers(*, st: Any, key, prev_key, tz_offset_choice: int):
     """Define the cached per-filter read wrappers and stage them.
 
@@ -672,167 +828,43 @@ def _widget_readers(*, st: Any, key, prev_key, tz_offset_choice: int):
     worker threads only return data -- every `st.*` write happens on the
     caller's render thread between the waves.
     """
-    @st.cache_data(show_spinner=False, ttl=60)
-    def _read_summary(start, end, repo, events_t, stages_t, issue):
-        return _scoped_read(
-            analytics_read.get_summary,
-            start=start, end=end, repo=repo,
-            events=_filter_list(events_t), stages=_filter_list(stages_t),
-            issue=issue,
-        )
-
-    @st.cache_data(show_spinner=False, ttl=60)
-    def _read_prev_kpi(start, end, repo, events_t, stages_t, issue):
-        # Previous-window read for the KPI delta pills and cost-trend
-        # banner only. The full `get_summary` shape (per-event / per-stage
-        # breakdowns, distinct-issue / distinct-repo counts, failure /
-        # timeout counters) is never read off `prev_summary`, so a thinner
-        # reader saves a `GROUP BY` follow-up plus a couple of
-        # `COUNT(DISTINCT)`s on every cold load while leaving the cached
-        # wrapper shape (and cache key) identical to `_read_summary`.
-        return _scoped_read(
-            analytics_read.get_kpi_prev,
-            start=start, end=end, repo=repo,
-            events=_filter_list(events_t), stages=_filter_list(stages_t),
-            issue=issue,
-        )
-
-    @st.cache_data(show_spinner=False, ttl=60)
-    def _read_time_series(start, end, repo, events_t, stages_t, issue):
-        return _scoped_read(
-            analytics_read.get_time_series,
-            start=start, end=end, repo=repo,
-            events=_filter_list(events_t), stages=_filter_list(stages_t),
-            issue=issue,
-        )
-
-    @st.cache_data(show_spinner=False, ttl=60)
-    def _read_stage_breakdown(start, end, repo, events_t, stages_t, issue):
-        return _scoped_read(
-            analytics_read.get_stage_breakdown,
-            start=start, end=end, repo=repo,
-            events=_filter_list(events_t), stages=_filter_list(stages_t),
-            issue=issue,
-        )
-
-    @st.cache_data(show_spinner=False, ttl=60)
-    def _read_recent_agent_exits(
-        start, end, repo, events_t, stages_t, issue
-    ):
-        return _scoped_read(
-            analytics_read.get_recent_agent_exits,
-            limit=DEFAULT_RECENT_AGENT_EXITS,
-            start=start, end=end, repo=repo,
-            events=_filter_list(events_t), stages=_filter_list(stages_t),
-            issue=issue,
-        )
-
-    @st.cache_data(show_spinner=False, ttl=60)
-    def _read_top_cost_issues(start, end, repo, events_t, stages_t, issue):
-        # Ask the database for the top-cost issues directly. Reading
-        # the latest N issues by `last_seen` and re-sorting in Python
-        # silently drops older high-cost issues that fall outside the
-        # truncated set, so the redesigned "Most expensive issues"
-        # panel must be cost-ordered at the SQL layer.
-        return _scoped_read(
-            analytics_read.get_issues,
-            limit=DEFAULT_EXPENSIVE_LIMIT,
-            sort_by=analytics_read.SORT_BY_COST,
-            start=start, end=end, repo=repo,
-            events=_filter_list(events_t), stages=_filter_list(stages_t),
-            issue=issue,
-        )
-
-    @st.cache_data(show_spinner=False, ttl=60)
-    def _read_review_round(start, end, repo, events_t, stages_t, issue):
-        return _scoped_read(
-            analytics_read.get_review_round_breakdown,
-            start=start, end=end, repo=repo,
-            events=_filter_list(events_t), stages=_filter_list(stages_t),
-            issue=issue,
-        )
-
-    @st.cache_data(show_spinner=False, ttl=60)
-    def _read_backend_efficiency(
-        start, end, repo, events_t, stages_t, issue
-    ):
-        return _scoped_read(
-            analytics_read.get_backend_efficiency,
-            start=start, end=end, repo=repo,
-            events=_filter_list(events_t), stages=_filter_list(stages_t),
-            issue=issue,
-        )
-
-    @st.cache_data(show_spinner=False, ttl=60)
-    def _read_repo_breakdown(start, end, repo, events_t, stages_t, issue):
-        return _scoped_read(
-            analytics_read.get_repo_breakdown,
-            start=start, end=end, repo=repo,
-            events=_filter_list(events_t), stages=_filter_list(stages_t),
-            issue=issue,
-        )
-
-    @st.cache_data(show_spinner=False, ttl=60)
-    def _read_cost_coverage(start, end, repo, events_t, stages_t, issue):
-        return _scoped_read(
-            analytics_read.get_cost_coverage,
-            start=start, end=end, repo=repo,
-            events=_filter_list(events_t), stages=_filter_list(stages_t),
-            issue=issue,
-        )
-
-    @st.cache_data(show_spinner=False, ttl=60)
-    def _read_hourly_heatmap(
-        start, end, repo, events_t, stages_t, issue, tz_offset_hours,
-    ):
-        return _scoped_read(
-            analytics_read.get_hourly_heatmap,
-            start=start, end=end, repo=repo,
-            events=_filter_list(events_t), stages=_filter_list(stages_t),
-            issue=issue, tz_offset_hours=tz_offset_hours,
-        )
-
-    @st.cache_data(show_spinner=False, ttl=60)
-    def _read_throughput(start, end, repo, events_t, stages_t, issue):
-        return _scoped_read(
-            analytics_read.get_throughput_breakdown,
-            start=start, end=end, repo=repo,
-            events=_filter_list(events_t), stages=_filter_list(stages_t),
-            issue=issue,
-        )
-
-    @st.cache_data(show_spinner=False, ttl=60)
-    def _read_backend_daily_tokens(
-        start, end, repo, events_t, stages_t, issue
-    ):
-        return _scoped_read(
-            analytics_read.get_backend_daily_tokens,
-            start=start, end=end, repo=repo,
-            events=_filter_list(events_t), stages=_filter_list(stages_t),
-            issue=issue,
-        )
-
-    @st.cache_data(show_spinner=False, ttl=60)
-    def _read_skill_trigger_rates(
-        start, end, repo, events_t, stages_t, issue
-    ):
-        return _scoped_read(
-            analytics_read.get_skill_trigger_rates,
-            start=start, end=end, repo=repo,
-            events=_filter_list(events_t), stages=_filter_list(stages_t),
-            issue=issue,
-        )
-
-    @st.cache_data(show_spinner=False, ttl=60)
-    def _read_skill_trigger_matrix(
-        start, end, repo, events_t, stages_t, issue
-    ):
-        return _scoped_read(
-            analytics_read.get_skill_trigger_matrix,
-            start=start, end=end, repo=repo,
-            events=_filter_list(events_t), stages=_filter_list(stages_t),
-            issue=issue,
-        )
+    read_summary = st.cache_data(show_spinner=False, ttl=60)(_read_summary)
+    read_prev_kpi = st.cache_data(show_spinner=False, ttl=60)(_read_prev_kpi)
+    read_time_series = st.cache_data(show_spinner=False, ttl=60)(_read_time_series)
+    read_stage_breakdown = st.cache_data(
+        show_spinner=False, ttl=60,
+    )(_read_stage_breakdown)
+    read_recent_agent_exits = st.cache_data(
+        show_spinner=False, ttl=60,
+    )(_read_recent_agent_exits)
+    read_top_cost_issues = st.cache_data(
+        show_spinner=False, ttl=60,
+    )(_read_top_cost_issues)
+    read_review_round = st.cache_data(
+        show_spinner=False, ttl=60,
+    )(_read_review_round)
+    read_backend_efficiency = st.cache_data(
+        show_spinner=False, ttl=60,
+    )(_read_backend_efficiency)
+    read_repo_breakdown = st.cache_data(
+        show_spinner=False, ttl=60,
+    )(_read_repo_breakdown)
+    read_cost_coverage = st.cache_data(
+        show_spinner=False, ttl=60,
+    )(_read_cost_coverage)
+    read_hourly_heatmap = st.cache_data(
+        show_spinner=False, ttl=60,
+    )(_read_hourly_heatmap)
+    read_throughput = st.cache_data(show_spinner=False, ttl=60)(_read_throughput)
+    read_backend_daily_tokens = st.cache_data(
+        show_spinner=False, ttl=60,
+    )(_read_backend_daily_tokens)
+    read_skill_trigger_rates = st.cache_data(
+        show_spinner=False, ttl=60,
+    )(_read_skill_trigger_rates)
+    read_skill_trigger_matrix = st.cache_data(
+        show_spinner=False, ttl=60,
+    )(_read_skill_trigger_matrix)
 
     # Read fan-out. Each entry is `(name, zero-arg callable)` so
     # `_fan_out_reads` can dispatch them across worker threads when
@@ -851,25 +883,25 @@ def _widget_readers(*, st: Any, key, prev_key, tz_offset_choice: int):
     # data back to this render thread -- every `st.*` / placeholder
     # write happens on the main thread between waves.
     first_wave_readers: list[tuple[str, Callable[[], Any]]] = [
-        ("summary", lambda: _read_summary(*key)),
-        ("prev_summary", lambda: _read_prev_kpi(*prev_key)),
-        ("ts_points", lambda: _read_time_series(*key)),
-        ("review_round_rows", lambda: _read_review_round(*key)),
-        ("throughput_rows", lambda: _read_throughput(*key)),
-        ("cost_coverage_rows", lambda: _read_cost_coverage(*key)),
+        ("summary", lambda: read_summary(*key)),
+        ("prev_summary", lambda: read_prev_kpi(*prev_key)),
+        ("ts_points", lambda: read_time_series(*key)),
+        ("review_round_rows", lambda: read_review_round(*key)),
+        ("throughput_rows", lambda: read_throughput(*key)),
+        ("cost_coverage_rows", lambda: read_cost_coverage(*key)),
     ]
     second_wave_readers: list[tuple[str, Callable[[], Any]]] = [
-        ("stage_rows", lambda: _read_stage_breakdown(*key)),
-        ("agent_exits", lambda: _read_recent_agent_exits(*key)),
-        ("issues_rows", lambda: _read_top_cost_issues(*key)),
-        ("backend_rows", lambda: _read_backend_efficiency(*key)),
-        ("repo_rows", lambda: _read_repo_breakdown(*key)),
-        ("heatmap_rows", lambda: _read_hourly_heatmap(
+        ("stage_rows", lambda: read_stage_breakdown(*key)),
+        ("agent_exits", lambda: read_recent_agent_exits(*key)),
+        ("issues_rows", lambda: read_top_cost_issues(*key)),
+        ("backend_rows", lambda: read_backend_efficiency(*key)),
+        ("repo_rows", lambda: read_repo_breakdown(*key)),
+        ("heatmap_rows", lambda: read_hourly_heatmap(
             *key, int(tz_offset_choice),
         )),
-        ("backend_daily_rows", lambda: _read_backend_daily_tokens(*key)),
-        ("skill_rows", lambda: _read_skill_trigger_rates(*key)),
-        ("skill_matrix_rows", lambda: _read_skill_trigger_matrix(*key)),
+        ("backend_daily_rows", lambda: read_backend_daily_tokens(*key)),
+        ("skill_rows", lambda: read_skill_trigger_rates(*key)),
+        ("skill_matrix_rows", lambda: read_skill_trigger_matrix(*key)),
     ]
     return first_wave_readers, second_wave_readers
 

--- a/orchestrator/dashboard_html.py
+++ b/orchestrator/dashboard_html.py
@@ -86,6 +86,28 @@ def _short_repo_name(repo: str) -> str:
     return repo.split("/")[-1] if "/" in repo else repo
 
 
+def _sparkline_y(value: float, *, lo: float, span: float, pad: int, h: int) -> float:
+    return pad + (1 - (value - lo) / span) * (h - pad * 2)
+
+
+def _int_or_zero(raw: object) -> int:
+    if raw is None:
+        return 0
+    return int(raw)
+
+
+def _money_or_dash(raw: object) -> str:
+    if raw is None:
+        return "—"
+    return f"${raw:,.2f}"
+
+
+def _plural_s(count: int) -> str:
+    if count == 1:
+        return ""
+    return "s"
+
+
 def _sparkline_svg(
     values: Sequence[float], *, color: str, w: int = 96, h: int = 26
 ) -> str:
@@ -97,17 +119,19 @@ def _sparkline_svg(
     so the layout slot stays consistent across KPIs.
     """
     nums = [float(v or 0) for v in values]
-    if not nums or max(nums) == min(nums) == 0:
+    if len(nums) == 0 or max(nums) == min(nums) == 0:
         return f'<svg width="{w}" height="{h}" viewBox="0 0 {w} {h}"></svg>'
     lo, hi = min(nums), max(nums)
     span = max(hi - lo, 1e-9)
     pad = 2
     step = (w - pad * 2) / max(len(nums) - 1, 1)
-
-    def y(v: float) -> float:
-        return pad + (1 - (v - lo) / span) * (h - pad * 2)
-
-    points = [(pad + i * step, y(v)) for i, v in enumerate(nums)]
+    points = [
+        (
+            pad + i * step,
+            _sparkline_y(v, lo=lo, span=span, pad=pad, h=h),
+        )
+        for i, v in enumerate(nums)
+    ]
     poly = " ".join(f"{x:.1f},{yv:.1f}" for x, yv in points)
     area_path = (
         "M" + f"{points[0][0]:.1f},{h - pad:.1f}"
@@ -146,10 +170,10 @@ def _delta_pill(value: Optional[float], *, invert: bool = False) -> str:
         return ""
     pct_str = f"{abs(value) * 100:.1f}%"
     if value > 0:
-        cls = "up" if not invert else "down"
+        cls = "down" if invert else "up"
         arrow = "▲"
     else:
-        cls = "down" if not invert else "up"
+        cls = "up" if invert else "down"
         arrow = "▼"
     return f'<span class="orch-delta {cls}">{arrow} {pct_str}</span>'
 
@@ -176,7 +200,7 @@ def _topbar_html(
         )
     sub = (
         f"{html.escape(range_label)} · "
-        f"{distinct_repos} repo{'s' if distinct_repos != 1 else ''} · "
+        f"{distinct_repos} repo{_plural_s(distinct_repos)} · "
         f"{fmt_num(total_events)} events"
     )
     return (
@@ -201,7 +225,7 @@ def _filter_meta_html(
     return (
         '<div class="orch-filter-meta">'
         f'{from_d.isoformat()} → {to_d.isoformat()} · '
-        f'{days} day{"s" if days != 1 else ""} · '
+        f'{days} day{_plural_s(days)} · '
         f'{fmt_num(runs)} runs'
         '</div>'
     )
@@ -285,21 +309,9 @@ def _issue_table_row_html(row: IssueSummaryRow, *, max_cost: float) -> str:
     short = _short_repo_name(row.repo)
     cost = float(row.total_cost_usd or 0.0)
     bar_pct = _relative_width_pct(cost, max_cost)
-    cost_text = (
-        f"${row.total_cost_usd:,.2f}"
-        if row.total_cost_usd is not None
-        else "—"
-    )
-    review_rounds = (
-        int(row.max_review_round)
-        if row.max_review_round is not None
-        else 0
-    )
-    retries = (
-        int(row.max_retry_count)
-        if row.max_retry_count is not None
-        else 0
-    )
+    cost_text = _money_or_dash(row.total_cost_usd)
+    review_rounds = _int_or_zero(row.max_review_round)
+    retries = _int_or_zero(row.max_retry_count)
     failed = int(row.failed_agent_runs or 0)
     return (
         "<tr>"
@@ -643,7 +655,7 @@ def _skill_matrix_html(
     the local CSS sits inline next to the table and reuses the shared
     `var(--orch-*)` theme tokens.
     """
-    if not rows:
+    if len(rows) == 0:
         # Self-contained inline style so the notice still reads as muted
         # body copy without the table's `<style>` block (skipped on this
         # early-return path).
@@ -654,11 +666,10 @@ def _skill_matrix_html(
             f"{html.escape(SKILL_MATRIX_EMPTY_MESSAGE)}"
             "</div>"
         )
-    rows = (
-        _sort_skill_matrix_rows(rows, sort_key, descending)
-        if sort_key is not None
-        else _default_sort_skill_matrix_rows(rows)
-    )
+    if sort_key is None:
+        rows = _default_sort_skill_matrix_rows(rows)
+    else:
+        rows = _sort_skill_matrix_rows(rows, sort_key, descending)
     return _table_html(
         table_class="orch-skillmatrix",
         css=_table_css(

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 import os
 import sys
 import unittest
+from contextlib import ExitStack
 from datetime import date, datetime, timezone
+from functools import partial
 from unittest.mock import patch
 
 
@@ -131,6 +133,27 @@ SECOND_WAVE_READER_NAMES = (
     "backend_rows", "repo_rows", "heatmap_rows",
     "backend_daily_rows", "skill_rows", "skill_matrix_rows",
 )
+STATIC_METADATA_READER_NAMES = (
+    "_read_data_extent",
+    "_read_filter_options",
+)
+WIDGET_READER_WRAPPER_NAMES = (
+    "_read_summary",
+    "_read_prev_kpi",
+    "_read_time_series",
+    "_read_stage_breakdown",
+    "_read_recent_agent_exits",
+    "_read_top_cost_issues",
+    "_read_review_round",
+    "_read_backend_efficiency",
+    "_read_repo_breakdown",
+    "_read_cost_coverage",
+    "_read_hourly_heatmap",
+    "_read_throughput",
+    "_read_backend_daily_tokens",
+    "_read_skill_trigger_rates",
+    "_read_skill_trigger_matrix",
+)
 
 # Canonical drill-down issue number, shared by the parse + cache-key tests.
 ISSUE_NUMBER = 42
@@ -156,6 +179,83 @@ SORT_DESC = "desc"
 MTX_SORT_KEYS = (
     "repo", "role", "backend", "skill", "runs", "skill_runs", "rate",
 )
+
+
+def _is_orchestrator_module(name: str) -> bool:
+    return name == "orchestrator" or name.startswith("orchestrator.")
+
+
+def _is_orchestrator_launch_module(name: str) -> bool:
+    return (
+        _is_orchestrator_module(name)
+        or name == "script_launch"
+    )
+
+
+def _is_dashboard_script_launch_module(name: str) -> bool:
+    return name in (
+        "orchestrator.dashboard",
+        "orchestrator.script_launch",
+        "script_launch",
+    )
+
+
+def _clear_modules(predicate) -> None:
+    for name in list(sys.modules):
+        if predicate(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_sys_path(path_entries: list[str]) -> None:
+    sys.path[:] = path_entries
+
+
+def _record_reader_call(name: str, value: int, calls: list[str]) -> int:
+    calls.append(name)
+    return value
+
+
+def _raise_read_error(
+    message: str,
+    calls: list[str] | None = None,
+    call_name: str | None = None,
+) -> None:
+    from orchestrator.analytics.read import AnalyticsReadError
+
+    if calls is None or call_name is None:
+        raise AnalyticsReadError(message)
+    calls.append(call_name)
+    raise AnalyticsReadError(message)
+
+
+def _increment_reader_count(name: str, counts: dict[str, int]) -> str:
+    counts[name] = counts.get(name, 0) + 1
+    return name
+
+
+def _return_value(value: int) -> int:
+    return value
+
+
+def _record_threaded_reader(
+    name: str,
+    calls: dict[str, int],
+    threads: set[int],
+    lock,
+) -> str:
+    import threading
+
+    with lock:
+        calls[name] = calls.get(name, 0) + 1
+        threads.add(threading.get_ident())
+    return name
+
+
+def _sleep_then_return(delay: float, value: str) -> str:
+    import time
+
+    time.sleep(delay)
+    return value
 
 
 class _MainSourceTest(unittest.TestCase):
@@ -353,9 +453,12 @@ class ScriptPathLaunchTest(unittest.TestCase):
         # test session with a half-initialised package.
         saved_modules = {
             module_name: module for module_name, module in sys.modules.items()
-            if module_name == "orchestrator" or module_name.startswith("orchestrator.")
+            if _is_orchestrator_module(module_name)
         }
-        try:
+        with ExitStack() as cleanup:
+            cleanup.callback(sys.modules.update, saved_modules)
+            cleanup.callback(_clear_modules, _is_orchestrator_module)
+            cleanup.callback(_restore_sys_path, original_path)
             # Match Streamlit's launch shape: only the script's
             # directory is on sys.path, the repo root is not.
             resolved_root = repo_root.resolve()
@@ -364,9 +467,7 @@ class ScriptPathLaunchTest(unittest.TestCase):
                 if not p or Path(p).resolve() != resolved_root
             ]
             sys.path.insert(0, str(script_dir))
-            for module_name in list(sys.modules):
-                if module_name == "orchestrator" or module_name.startswith("orchestrator."):
-                    del sys.modules[module_name]
+            _clear_modules(_is_orchestrator_module)
 
             # `run_name="not_main"` keeps the `if __name__ == "__main__":`
             # block from firing, so the test does not require Streamlit
@@ -377,12 +478,6 @@ class ScriptPathLaunchTest(unittest.TestCase):
             )
             self.assertIn("main", namespace)
             self.assertIn("analytics_read", namespace)
-        finally:
-            sys.path[:] = original_path
-            for module_name in list(sys.modules):
-                if module_name == "orchestrator" or module_name.startswith("orchestrator."):
-                    del sys.modules[module_name]
-            sys.modules.update(saved_modules)
 
     def test_stale_parent_package_does_not_shadow_repo_root(self) -> None:
         # Script-launch mode carries only `orchestrator/` on `sys.path`, so
@@ -400,54 +495,42 @@ class ScriptPathLaunchTest(unittest.TestCase):
         dashboard_path = repo_root / "orchestrator" / "dashboard.py"
         script_dir = dashboard_path.parent
 
-        def _is_launch_module(name: str) -> bool:
-            return (
-                name == "orchestrator"
-                or name.startswith("orchestrator.")
-                or name == "script_launch"
-            )
-
         original_path = list(sys.path)
         saved_modules = {
             name: module for name, module in sys.modules.items()
-            if _is_launch_module(name)
+            if _is_orchestrator_launch_module(name)
         }
-        with tempfile.TemporaryDirectory() as decoy_root:
+        with ExitStack() as cleanup:
+            decoy_root = cleanup.enter_context(tempfile.TemporaryDirectory())
+            cleanup.callback(sys.modules.update, saved_modules)
+            cleanup.callback(_clear_modules, _is_orchestrator_launch_module)
+            cleanup.callback(_restore_sys_path, original_path)
             # A bare `orchestrator` package with none of the real submodules,
             # standing in for a stale install that shadows the repo root.
             decoy_pkg = Path(decoy_root) / "orchestrator"
             decoy_pkg.mkdir()
             (decoy_pkg / "__init__.py").write_text("")
-            try:
-                resolved_root = repo_root.resolve()
-                sys.path[:] = [
-                    p for p in sys.path
-                    if not p or Path(p).resolve() != resolved_root
-                ]
-                # Streamlit's shape (script's own dir first), with the decoy
-                # parent reachable just behind it.
-                sys.path.insert(0, decoy_root)
-                sys.path.insert(0, str(script_dir))
-                for name in list(sys.modules):
-                    if _is_launch_module(name):
-                        del sys.modules[name]
+            resolved_root = repo_root.resolve()
+            sys.path[:] = [
+                p for p in sys.path
+                if not p or Path(p).resolve() != resolved_root
+            ]
+            # Streamlit's shape (script's own dir first), with the decoy
+            # parent reachable just behind it.
+            sys.path.insert(0, decoy_root)
+            sys.path.insert(0, str(script_dir))
+            _clear_modules(_is_orchestrator_launch_module)
 
-                namespace = runpy.run_path(
-                    str(dashboard_path), run_name="not_main"
-                )
-                self.assertIn("main", namespace)
-                # The real read model landed -- not the decoy package (which
-                # has no `analytics` submodule and would raise on import).
-                self.assertEqual(
-                    namespace["analytics_read"].__name__,
-                    "orchestrator.analytics.read",
-                )
-            finally:
-                sys.path[:] = original_path
-                for name in list(sys.modules):
-                    if _is_launch_module(name):
-                        del sys.modules[name]
-                sys.modules.update(saved_modules)
+            namespace = runpy.run_path(
+                str(dashboard_path), run_name="not_main"
+            )
+            self.assertIn("main", namespace)
+            # The real read model landed -- not the decoy package (which
+            # has no `analytics` submodule and would raise on import).
+            self.assertEqual(
+                namespace["analytics_read"].__name__,
+                "orchestrator.analytics.read",
+            )
 
     def test_package_import_ignores_stray_top_level_script_launch(self) -> None:
         # A normal package import (`import orchestrator.dashboard`) must
@@ -459,41 +542,29 @@ class ScriptPathLaunchTest(unittest.TestCase):
         import tempfile
         from pathlib import Path
 
-        def _is_launch_module(name: str) -> bool:
-            return name in (
-                "orchestrator.dashboard",
-                "orchestrator.script_launch",
-                "script_launch",
-            )
-
         original_path = list(sys.path)
         saved_modules = {
             name: module for name, module in sys.modules.items()
-            if _is_launch_module(name)
+            if _is_dashboard_script_launch_module(name)
         }
-        with tempfile.TemporaryDirectory() as stray_dir:
+        with ExitStack() as cleanup:
+            stray_dir = cleanup.enter_context(tempfile.TemporaryDirectory())
+            cleanup.callback(sys.modules.update, saved_modules)
+            cleanup.callback(_clear_modules, _is_dashboard_script_launch_module)
+            cleanup.callback(_restore_sys_path, original_path)
             # A stray top-level `script_launch` that detonates on import, so a
             # bare `import script_launch` during the package import would fail
             # loudly instead of silently binding the wrong helper.
             (Path(stray_dir) / "script_launch.py").write_text(
                 "raise RuntimeError('stray script_launch must not be imported')\n"
             )
-            try:
-                sys.path.insert(0, stray_dir)
-                for name in list(sys.modules):
-                    if _is_launch_module(name):
-                        del sys.modules[name]
-                module = importlib.import_module("orchestrator.dashboard")
-                self.assertTrue(hasattr(module, "main"))
-                # The package path used `orchestrator.script_launch` and never
-                # probed the bare name, so the stray stayed unimported.
-                self.assertNotIn("script_launch", sys.modules)
-            finally:
-                sys.path[:] = original_path
-                for name in list(sys.modules):
-                    if _is_launch_module(name):
-                        del sys.modules[name]
-                sys.modules.update(saved_modules)
+            sys.path.insert(0, stray_dir)
+            _clear_modules(_is_dashboard_script_launch_module)
+            module = importlib.import_module("orchestrator.dashboard")
+            self.assertTrue(hasattr(module, "main"))
+            # The package path used `orchestrator.script_launch` and never
+            # probed the bare name, so the stray stayed unimported.
+            self.assertNotIn("script_launch", sys.modules)
 
 
 class ResolveStageFilterTest(unittest.TestCase):
@@ -1705,6 +1776,9 @@ class CachedReadConnectionScopingTest(_MainSourceTest):
     def _drilldown_source(self) -> str:
         return self._source_of("_render_drilldown")
 
+    def _combined_source(self, names) -> str:
+        return "\n\n".join(self._source_of(name) for name in names)
+
     def test_reads_scope_through_analytics_connection(self) -> None:
         # `_scoped_read` is the one place the per-thread persistent socket
         # is checked out via `analytics_connection`; the cached widget
@@ -1716,8 +1790,8 @@ class CachedReadConnectionScopingTest(_MainSourceTest):
             self._source_of("_scoped_read"),
         )
         for label, src in (
-            ("widget readers", self._readers_source()),
-            ("static metadata", self._metadata_source()),
+            ("widget readers", self._combined_source(WIDGET_READER_WRAPPER_NAMES)),
+            ("static metadata", self._combined_source(STATIC_METADATA_READER_NAMES)),
             ("drill-down", self._drilldown_source()),
         ):
             with self.subTest(source=label):
@@ -1729,33 +1803,13 @@ class CachedReadConnectionScopingTest(_MainSourceTest):
         # st.cache_data to hash a connection object, which crashes
         # on the unhashable psycopg.Connection and (with a stringy
         # fallback) treats every refreshed conn as a cache miss.
-        src = self._readers_source()
-        wrapper_names = [
-            "_read_summary",
-            "_read_prev_kpi",
-            "_read_time_series",
-            "_read_stage_breakdown",
-            "_read_recent_agent_exits",
-            "_read_top_cost_issues",
-            "_read_review_round",
-            "_read_backend_efficiency",
-            "_read_repo_breakdown",
-            "_read_cost_coverage",
-            "_read_hourly_heatmap",
-            "_read_throughput",
-            "_read_backend_daily_tokens",
-        ]
-        for name in wrapper_names:
+        for name in WIDGET_READER_WRAPPER_NAMES:
             with self.subTest(name=name):
-                # Each wrapper's signature line lives inside
-                # `_widget_readers`; check that none mention `conn` as
-                # a parameter (which would land in the cache key).
+                # Each wrapper's signature is the cache key; `conn`
+                # belongs inside `_scoped_read`, not in the parameter list.
+                src = self._source_of(name)
                 marker = f"def {name}("
                 self.assertIn(marker, src)
-                # Pull the def line(s) up to the closing paren so we
-                # can assert `conn` is not in the parameter list. The
-                # def signatures are short (one or two lines), so a
-                # narrow window around the marker is enough.
                 head = src.index(marker)
                 tail = src.index("):", head)
                 signature = src[head:tail]
@@ -1771,15 +1825,17 @@ class CachedReadConnectionScopingTest(_MainSourceTest):
         # otherwise a new socket would open per call (the very thing the
         # scoping is supposed to eliminate). The wrappers stay
         # connection-free so `conn` never lands in the cache key.
-        readers_src = self._readers_source()
-        # 15 cached widget wrappers each route through `_scoped_read`.
+        readers_src = self._combined_source(WIDGET_READER_WRAPPER_NAMES)
         self.assertGreaterEqual(
             readers_src.count("_scoped_read("), 15,
             "every widget read should route through `_scoped_read`",
         )
         # The two static-metadata reads route through it too.
         self.assertGreaterEqual(
-            self._metadata_source().count("_scoped_read("), 2,
+            self._combined_source(STATIC_METADATA_READER_NAMES).count(
+                "_scoped_read("
+            ),
+            2,
         )
         # And the per-issue drill-down runs its own scoped read.
         self.assertIn("_scoped_read(", self._drilldown_source())
@@ -1798,21 +1854,15 @@ class CachedReadConnectionScopingTest(_MainSourceTest):
         # `analytics_read.get_kpi_prev` rather than reusing the
         # full `get_summary` shape -- if it falls back to the heavy
         # path, the cold-load wins from Layer 3 evaporate.
-        src = self._readers_source()
-        marker = "def _read_prev_kpi("
-        self.assertIn(marker, src)
-        head = src.index(marker)
-        # The wrapper body is short; walk to the next `def` (which
-        # bounds the cached wrapper region) so the substring search
-        # below cannot accidentally catch a later wrapper.
-        body = src[head:src.index("\n    def ", head + 1)]
-        self.assertIn("analytics_read.get_kpi_prev", body)
-        self.assertNotIn("analytics_read.get_summary", body)
+        wrapper_src = self._source_of("_read_prev_kpi")
+        self.assertIn("analytics_read.get_kpi_prev", wrapper_src)
+        self.assertNotIn("analytics_read.get_summary", wrapper_src)
         # And the `prev_summary` entry in the reader fan-out must
         # dispatch through `_read_prev_kpi` so the lightweight path
         # is the one that actually fires when the dashboard renders.
+        src = self._readers_source()
         self.assertIn(
-            '("prev_summary", lambda: _read_prev_kpi(*prev_key))',
+            '("prev_summary", lambda: read_prev_kpi(*prev_key))',
             src,
         )
 
@@ -1934,16 +1984,10 @@ class FanOutReadsSequentialTest(unittest.TestCase):
         _, dashboard = _reload()
         order: list[str] = []
 
-        def _make(name: str, value: int):
-            def fn():
-                order.append(name)
-                return value
-            return fn
-
         readers = [
-            ("a", _make("a", 1)),
-            ("b", _make("b", 2)),
-            ("c", _make("c", 3)),
+            ("a", partial(_record_reader_call, "a", 1, order)),
+            ("b", partial(_record_reader_call, "b", 2, order)),
+            ("c", partial(_record_reader_call, "c", 3, order)),
         ]
         results = dashboard._fan_out_reads(readers, parallel=False)
         self.assertEqual(results, {"a": 1, "b": 2, "c": 3})
@@ -1959,19 +2003,11 @@ class FanOutReadsSequentialTest(unittest.TestCase):
         from orchestrator.analytics.read import AnalyticsReadError
         called: list[str] = []
 
-        def _ok():
-            called.append("ok")
-            return 1
-
-        def _boom():
-            called.append("boom")
-            raise AnalyticsReadError("connection refused")
-
-        def _never():
-            called.append("never")
-            return 2
-
-        readers = [("a", _ok), ("b", _boom), ("c", _never)]
+        readers = [
+            ("a", partial(_record_reader_call, "ok", 1, called)),
+            ("b", partial(_raise_read_error, "connection refused", called, "boom")),
+            ("c", partial(_record_reader_call, "never", 2, called)),
+        ]
         with self.assertRaises(AnalyticsReadError):
             dashboard._fan_out_reads(readers, parallel=False)
         self.assertEqual(called, ["ok", "boom"])
@@ -1980,13 +2016,10 @@ class FanOutReadsSequentialTest(unittest.TestCase):
         _, dashboard = _reload()
         counts = {"a": 0, "b": 0}
 
-        def _mk(name):
-            def fn():
-                counts[name] += 1
-                return name
-            return fn
-
-        readers = [("a", _mk("a")), ("b", _mk("b"))]
+        readers = [
+            ("a", partial(_increment_reader_count, "a", counts)),
+            ("b", partial(_increment_reader_count, "b", counts)),
+        ]
         dashboard._fan_out_reads(readers, parallel=False)
         self.assertEqual(counts, {"a": 1, "b": 1})
 
@@ -2001,12 +2034,7 @@ class FanOutReadsParallelTest(unittest.TestCase):
     def test_all_results_returned_keyed_by_name(self) -> None:
         _, dashboard = _reload()
 
-        def _mk(value):
-            def fn():
-                return value
-            return fn
-
-        readers = [(f"r{i}", _mk(i)) for i in range(5)]
+        readers = [(f"r{i}", partial(_return_value, i)) for i in range(5)]
         results = dashboard._fan_out_reads(
             readers, parallel=True, max_workers=4
         )
@@ -2027,15 +2055,10 @@ class FanOutReadsParallelTest(unittest.TestCase):
         threads: set[int] = set()
         lock = threading.Lock()
 
-        def _mk(name):
-            def fn():
-                with lock:
-                    calls[name] = calls.get(name, 0) + 1
-                    threads.add(threading.get_ident())
-                return name
-            return fn
-
-        readers = [(f"r{i}", _mk(f"r{i}")) for i in range(8)]
+        readers = [
+            (f"r{i}", partial(_record_threaded_reader, f"r{i}", calls, threads, lock))
+            for i in range(8)
+        ]
         dashboard._fan_out_reads(
             readers, parallel=True, max_workers=4
         )
@@ -2053,11 +2076,10 @@ class FanOutReadsParallelTest(unittest.TestCase):
         _, dashboard = _reload()
         delay = 0.08
 
-        def _slow():
-            time.sleep(delay)
-            return "ok"
-
-        readers = [(f"r{i}", _slow) for i in range(4)]
+        readers = [
+            (f"r{i}", partial(_sleep_then_return, delay, "ok"))
+            for i in range(4)
+        ]
         t0 = time.perf_counter()
         results = dashboard._fan_out_reads(
             readers, parallel=True, max_workers=4
@@ -2075,18 +2097,14 @@ class FanOutReadsParallelTest(unittest.TestCase):
         _, dashboard = _reload()
         from orchestrator.analytics.read import AnalyticsReadError
 
-        def _boom():
-            raise AnalyticsReadError("query failed")
-
-        def _ok():
-            return 1
-
-        readers = [("ok", _ok), ("boom", _boom)]
-        with self.assertRaises(AnalyticsReadError) as cm:
+        readers = [
+            ("ok", partial(_return_value, 1)),
+            ("boom", partial(_raise_read_error, "query failed")),
+        ]
+        with self.assertRaisesRegex(AnalyticsReadError, "query failed"):
             dashboard._fan_out_reads(
                 readers, parallel=True, max_workers=2
             )
-        self.assertIn("query failed", str(cm.exception))
 
 
 class MainRenderDispatchTest(_MainSourceTest):
@@ -2208,8 +2226,7 @@ class SkillMatrixWiringTest(_MainSourceTest):
     """
 
     def test_matrix_read_calls_matrix_read_model(self) -> None:
-        src = self._source_of("_widget_readers")
-        self.assertIn("def _read_skill_trigger_matrix(", src)
+        src = self._source_of("_read_skill_trigger_matrix")
         self.assertIn("analytics_read.get_skill_trigger_matrix", src)
 
     def test_matrix_read_forwards_scoped_connection(self) -> None:
@@ -2217,12 +2234,9 @@ class SkillMatrixWiringTest(_MainSourceTest):
         # `_scoped_read`, which checks out the scoped thread-local
         # connection and forwards it to the read helper, so the matrix
         # read shares the open socket rather than opening its own.
-        src = self._source_of("_widget_readers")
-        marker = "def _read_skill_trigger_matrix("
-        head = src.index(marker)
-        body = src[head:src.index("\n\n", head)]
-        self.assertIn("_scoped_read(", body)
-        self.assertIn("analytics_read.get_skill_trigger_matrix", body)
+        src = self._source_of("_read_skill_trigger_matrix")
+        self.assertIn("_scoped_read(", src)
+        self.assertIn("analytics_read.get_skill_trigger_matrix", src)
         scoped_src = self._source_of("_scoped_read")
         self.assertIn("analytics_read.analytics_connection()", scoped_src)
         self.assertIn("conn=conn", scoped_src)
@@ -2231,7 +2245,7 @@ class SkillMatrixWiringTest(_MainSourceTest):
         # `conn` must not appear in the wrapper's parameter list -- it
         # would land in the `st.cache_data` key and crash on the
         # unhashable psycopg connection.
-        src = self._source_of("_widget_readers")
+        src = self._source_of("_read_skill_trigger_matrix")
         marker = "def _read_skill_trigger_matrix("
         head = src.index(marker)
         tail = src.index("):", head)
@@ -2241,7 +2255,7 @@ class SkillMatrixWiringTest(_MainSourceTest):
         src = self._source_of("_widget_readers")
         self.assertIn(
             '("skill_matrix_rows", '
-            "lambda: _read_skill_trigger_matrix(*key))",
+            "lambda: read_skill_trigger_matrix(*key))",
             src,
         )
 
@@ -2304,15 +2318,12 @@ class StaticMetadataCacheTest(_MainSourceTest):
 
     def test_extent_reader_decorated_with_longer_ttl(self) -> None:
         src = self._metadata_source()
-        marker = "def _read_data_extent("
+        marker = "read_data_extent = st.cache_data("
         self.assertIn(marker, src)
-        # The cached wrapper must sit directly under
-        # `@st.cache_data(... ttl=STATIC_METADATA_TTL_SECONDS)` --
-        # not the 60 s TTL the per-filter wrappers use.
         head = src.index(marker)
-        # Look back to the decorator just above the def.
-        decorator_window = src[max(0, head - 200):head]
-        self.assertIn("@st.cache_data(", decorator_window)
+        tail = src.index(")(_read_data_extent)", head)
+        decorator_window = src[head:tail]
+        self.assertIn("st.cache_data(", decorator_window)
         self.assertIn(
             "ttl=STATIC_METADATA_TTL_SECONDS", decorator_window
         )
@@ -2320,11 +2331,12 @@ class StaticMetadataCacheTest(_MainSourceTest):
 
     def test_filter_options_reader_decorated_with_longer_ttl(self) -> None:
         src = self._metadata_source()
-        marker = "def _read_filter_options("
+        marker = "read_filter_options = st.cache_data("
         self.assertIn(marker, src)
         head = src.index(marker)
-        decorator_window = src[max(0, head - 200):head]
-        self.assertIn("@st.cache_data(", decorator_window)
+        tail = src.index(")(_read_filter_options)", head)
+        decorator_window = src[head:tail]
+        self.assertIn("st.cache_data(", decorator_window)
         self.assertIn(
             "ttl=STATIC_METADATA_TTL_SECONDS", decorator_window
         )
@@ -2338,9 +2350,10 @@ class StaticMetadataCacheTest(_MainSourceTest):
         # the empty signature so a future refactor cannot silently
         # re-introduce a parameter (e.g. a connection) that would
         # turn into part of the cache key.
-        src = self._metadata_source()
-        for marker in ("def _read_data_extent(", "def _read_filter_options("):
-            with self.subTest(marker=marker):
+        for name in STATIC_METADATA_READER_NAMES:
+            with self.subTest(name=name):
+                src = self._source_of(name)
+                marker = f"def {name}("
                 head = src.index(marker)
                 tail = src.index("):", head)
                 self.assertEqual(src[head:tail + 1], marker + ")")
@@ -2357,8 +2370,8 @@ class StaticMetadataCacheTest(_MainSourceTest):
         self.assertNotIn("get_filter_options(", main_src)
         # The helper itself dispatches through the cached wrappers.
         meta_src = self._metadata_source()
-        self.assertIn("_read_data_extent()", meta_src)
-        self.assertIn("_read_filter_options()", meta_src)
+        self.assertIn("read_data_extent()", meta_src)
+        self.assertIn("read_filter_options()", meta_src)
 
 
 class StagedRenderTest(_MainSourceTest):
@@ -2559,29 +2572,22 @@ class FanOutReadsErrorPropagationTest(unittest.TestCase):
         _, dashboard = _reload()
         from orchestrator.analytics.read import AnalyticsReadError
 
-        def _boom():
-            raise AnalyticsReadError("first wave dead")
-
-        with self.assertRaises(AnalyticsReadError) as cm:
+        with self.assertRaisesRegex(AnalyticsReadError, "first wave dead"):
             dashboard._fan_out_reads(
-                [("summary", _boom)], parallel=False
+                [("summary", partial(_raise_read_error, "first wave dead"))],
+                parallel=False,
             )
-        self.assertIn("first wave dead", str(cm.exception))
 
     def test_parallel_propagates_in_staged_call(self) -> None:
         _, dashboard = _reload()
         from orchestrator.analytics.read import AnalyticsReadError
 
-        def _boom():
-            raise AnalyticsReadError("second wave dead")
-
-        with self.assertRaises(AnalyticsReadError) as cm:
+        with self.assertRaisesRegex(AnalyticsReadError, "second wave dead"):
             dashboard._fan_out_reads(
-                [("repo_rows", _boom)],
+                [("repo_rows", partial(_raise_read_error, "second wave dead"))],
                 parallel=True,
                 max_workers=2,
             )
-        self.assertIn("second wave dead", str(cm.exception))
 
 
 class FormatTzOffsetTest(unittest.TestCase):


### PR DESCRIPTION
Resolves #777 

Implemented the cleanup across five files:

- Flattened dashboard cached read helpers in `orchestrator/dashboard.py`
- Updated source-inspection tests and flattened local test helpers in `tests/test_dashboard.py`
- Removed targeted negated/post-block patterns from `orchestrator/analytics/read_raw.py`, `orchestrator/analytics/read_dashboard.py`, and `orchestrator/dashboard_html.py`

The final wemake target-family scan shows none of the touched files still listed for `WPS420`, `WPS430`, `WPS431`,
`WPS441`, `WPS501`, or `WPS504`.