### PR TITLE
chore: complete stage 1 linter remediation

### DIFF
--- a/orchestrator/agents.py
+++ b/orchestrator/agents.py
@@ -171,6 +171,7 @@ def terminate_all_running(grace: float = 5.0) -> int:
         _sigkill_unless_group_gone(proc, remaining)
     return len(procs)
 
+
 _UUID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
     re.IGNORECASE,

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -120,6 +120,7 @@ def _parse_hitl_handles(raw: str) -> tuple[str, ...]:
         seen.add(handle)
     return tuple(handles)
 
+
 REPO: str = os.environ.get("REPO", "geserdugarov/agent-orchestrator")
 GITHUB_TOKEN: str = _resolve_github_token(REPO)
 POLL_INTERVAL: int = int(os.environ.get("POLL_INTERVAL", "60"))
@@ -601,6 +602,7 @@ def default_repo_specs() -> list[RepoSpec]:
     list copy so callers cannot mutate the cached result.
     """
     return list(_REPO_SPECS)
+
 
 # Base branch of the orchestrator's *own* repo (REPO_ROOT). Used only by the
 # self-update path: `_self_modifying_merge_happened` watches `origin/<this>`

--- a/orchestrator/dashboard_charts.py
+++ b/orchestrator/dashboard_charts.py
@@ -705,7 +705,7 @@ def _lighten_hex(hex_color: str, alpha: float) -> str:
     only emits 6-hex strings.
     """
     h = hex_color.lstrip("#")
-    r = int(h[0:2], 16)
+    r = int(h[:2], 16)
     g = int(h[2:4], 16)
     b = int(h[4:6], 16)
     return f"rgba({r},{g},{b},{alpha:.2f})"

--- a/orchestrator/dashboard_charts.py
+++ b/orchestrator/dashboard_charts.py
@@ -635,9 +635,11 @@ def cost_by_stage(
     totals = [
         float(r.total_cost_usd or 0.0) for r in ordered
     ]
-    for i, (nc, c, tot) in enumerate(zip(no_cache, cache, totals)):
-        if nc == 0.0 and c == 0.0 and tot > 0.0:
-            no_cache[i] = tot
+    for row_index, (no_cache_cost, cache_cost, total_cost) in enumerate(
+        zip(no_cache, cache, totals)
+    ):
+        if no_cache_cost == 0.0 and cache_cost == 0.0 and total_cost > 0.0:
+            no_cache[row_index] = total_cost
     colors = [
         theme.color_for(r.stage, explicit=theme.STAGE_COLORS)
         for r in ordered
@@ -645,7 +647,7 @@ def cost_by_stage(
     # 0.45 alpha keeps the cache segment legible on the page
     # background while leaving the no-cache portion as the dominant
     # stage color -- mirroring `cost_by_review_round`.
-    cache_colors = [_lighten_hex(c, 0.45) for c in colors]
+    cache_colors = [_lighten_hex(stage_color, 0.45) for stage_color in colors]
     # Plotly draws the first y-value at the bottom of a horizontal
     # bar chart; reverse so the largest cost sits at the top.
     (

--- a/orchestrator/github.py
+++ b/orchestrator/github.py
@@ -954,16 +954,16 @@ class GitHubClient:
         `pr_has_changes_requested` without ever reaching the dev agent.
         """
         out: list = []
-        for review in pr.get_reviews():
-            state = (review.state or "").upper()
+        for candidate_review in pr.get_reviews():
+            state = (candidate_review.state or "").upper()
             if state not in ("CHANGES_REQUESTED", "COMMENTED"):
                 continue
-            body = (review.body or "").strip()
+            body = (candidate_review.body or "").strip()
             if not body:
                 continue
-            if after_id is None or review.id > after_id:
-                out.append(review)
-        out.sort(key=lambda review: review.id)
+            if after_id is None or candidate_review.id > after_id:
+                out.append(candidate_review)
+        out.sort(key=lambda review_summary: review_summary.id)
         return out
 
     def ensure_workflow_labels(self) -> None:

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -29,7 +29,7 @@ log = logging.getLogger("orchestrator")
 
 _running = True
 _received_signal: Optional[int] = None
-_scheduler: Optional[IssueScheduler] = None
+active_scheduler: Optional[IssueScheduler] = None
 # Set once `main`'s shutdown drain has finished. The shutdown watchdog waits
 # on this with a timeout so it only force-exits when the drain genuinely
 # overran the grace window -- a clean fast drain sets it and the watchdog
@@ -63,7 +63,7 @@ def _shutdown(signum, _frame) -> None:
     _received_signal = signum
     log.info("signal %s received; will stop after this tick", signum)
     _running = False
-    sched = _scheduler
+    sched = active_scheduler
     if sched is not None:
         try:
             sched.shutdown(wait=False)
@@ -266,8 +266,8 @@ def main(argv: Optional[list[str]] = None) -> int:
     # `_running=False` but cannot close the scheduler -- that window is
     # the brief gap between scheduler construction and this line and is
     # acceptable because no tick has dispatched anything yet.
-    global _scheduler
-    _scheduler = scheduler
+    global active_scheduler
+    active_scheduler = scheduler
 
     try:
         if args.once:
@@ -306,7 +306,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             # watchdog's own sweep.
             agents.terminate_all_running()
         scheduler.shutdown(wait=True)
-        _scheduler = None
+        active_scheduler = None
         # Release the watchdog: the drain is done, so a clean exit must not
         # be pre-empted by a force-exit.
         _shutdown_complete.set()

--- a/orchestrator/skill_catalog.py
+++ b/orchestrator/skill_catalog.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import logging
 import os
+from contextlib import suppress
 from pathlib import Path
 from typing import Iterable, Optional
 
@@ -204,11 +205,9 @@ def _direct_skill_names(root: Path) -> list[str]:
     for entry in entries:
         if entry.name.startswith("."):
             continue
-        try:
+        with suppress(OSError):
             if entry.is_dir() and (Path(entry.path) / _SKILL_FILE).is_file():
                 names.append(entry.name)
-        except OSError:
-            continue
     return sorted(names)
 
 

--- a/orchestrator/state_machine.py
+++ b/orchestrator/state_machine.py
@@ -209,12 +209,16 @@ def _build_allowed() -> dict[Optional[WorkflowLabel], frozenset[WorkflowLabel]]:
     edge -- an unlabeled issue is never terminalized directly.
     """
     allowed: dict[Optional[WorkflowLabel], set[WorkflowLabel]] = {
-        src: set(forward) for src, forward in _FORWARD.items()
+        forward_source: set(forward_targets)
+        for forward_source, forward_targets in _FORWARD.items()
     }
     for target, sources in _INTERRUPT_SOURCES.items():
-        for src in sources:
-            allowed[src].add(target)
-    return {src: frozenset(edges) for src, edges in allowed.items()}
+        for interrupt_source in sources:
+            allowed[interrupt_source].add(target)
+    return {
+        allowed_source: frozenset(edges)
+        for allowed_source, edges in allowed.items()
+    }
 
 
 ALLOWED_TRANSITIONS: dict[Optional[WorkflowLabel], frozenset[WorkflowLabel]] = (

--- a/orchestrator/usage.py
+++ b/orchestrator/usage.py
@@ -578,11 +578,13 @@ def parse_claude_usage(stdout: str) -> UsageMetrics:
     records = _claude_usage_records(events)
     aggregate = _claude_aggregate_by_model(records)
     aggregate.apply_tokens(metrics)
-    metrics.cost_usd, metrics.cost_source = _select_cost(
+    selected_cost = _select_cost(
         _find_last_reported_cost(events),
         _claude_estimate_total(aggregate.per_model),
         bool(records),
     )
+    metrics.cost_usd = selected_cost[0]
+    metrics.cost_source = selected_cost[1]
     metrics.turns = _claude_turn_count(events, records)
     return metrics
 
@@ -855,11 +857,13 @@ class _CodexUsageSummary:
         metrics.output_tokens = self.usage["output"]
         if self.model is not None:
             metrics.models = (self.model,)
-        metrics.cost_usd, metrics.cost_source = _select_cost(
+        selected_cost = _select_cost(
             _find_last_reported_cost(self.events),
             _codex_estimate_cost(self.model or "unknown", self.usage),
             bool(self.usage_events),
         )
+        metrics.cost_usd = selected_cost[0]
+        metrics.cost_source = selected_cost[1]
         metrics.turns = _codex_turn_count(self.events)
 
 

--- a/plans/linter-remediation.md
+++ b/plans/linter-remediation.md
@@ -39,7 +39,7 @@ Do not mark a stage complete until its completion gate is satisfied.
 
 | Stage | Goal | Packages complete | Status |
 |---|---|---:|---:|
-| 1 | Concrete formatting and correctness cleanup | 5/9 | [ ] |
+| 1 | Concrete formatting and correctness cleanup | 6/9 | [ ] |
 | 2 | Extreme production complexity hotspots | 0/8 | [ ] |
 | 3 | Remaining production complexity | 0/6 | [ ] |
 | 4 | Remaining production style and structure | 0/5 | [ ] |
@@ -138,9 +138,9 @@ Goal: remove objective, low-risk findings before structural refactoring.
 
 ### Package 1.6 — Small redundant constructs
 
-- [ ] Simplify the redundant subscript slice in `orchestrator/dashboard_charts.py`.
-- [ ] Remove the useless terminal `continue` in `orchestrator/skill_catalog.py`.
-- [ ] Confirm that sequence boundaries and loop behavior remain unchanged.
+- [x] Simplify the redundant subscript slice in `orchestrator/dashboard_charts.py`.
+- [x] Remove the useless terminal `continue` in `orchestrator/skill_catalog.py`.
+- [x] Confirm that sequence boundaries and loop behavior remain unchanged.
 
 ### Package 1.7 — Incorrect unused-name marker
 
@@ -455,3 +455,4 @@ Add one row for every implementation session, including partial sessions.
 | 2026-07-11 | 1.3 | Complete | E127/E128, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.4 |
 | 2026-07-11 | 1.4 | Complete | E261, 41 tests, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.5 |
 | 2026-07-11 | 1.5 | Complete | 3 focused, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.6 |
+| 2026-07-11 | 1.6 | Complete | WPS327/349, Ruff, diff, 2093 passed, 3 skipped | None | Start Package 1.7 |

--- a/plans/linter-remediation.md
+++ b/plans/linter-remediation.md
@@ -39,7 +39,7 @@ Do not mark a stage complete until its completion gate is satisfied.
 
 | Stage | Goal | Packages complete | Status |
 |---|---|---:|---:|
-| 1 | Concrete formatting and correctness cleanup | 8/9 | [ ] |
+| 1 | Concrete formatting and correctness cleanup | 9/9 | [x] |
 | 2 | Extreme production complexity hotspots | 0/8 | [ ] |
 | 3 | Remaining production complexity | 0/6 | [ ] |
 | 4 | Remaining production style and structure | 0/5 | [ ] |
@@ -154,11 +154,11 @@ Goal: remove objective, low-risk findings before structural refactoring.
 
 ### Package 1.9 — Production control-variable reuse
 
-- [ ] Rename the reused variables in:
+- [x] Rename the reused variables in:
   - `orchestrator/dashboard_charts.py`
   - `orchestrator/github.py`
   - `orchestrator/state_machine.py`
-- [ ] Confirm that empty iterables cannot expose an unbound-variable path.
+- [x] Confirm that empty iterables cannot expose an unbound-variable path.
 
 Completion gate: all 29 standard `E...` findings and the concrete findings above are gone.
 
@@ -458,3 +458,4 @@ Add one row for every implementation session, including partial sessions.
 | 2026-07-11 | 1.6 | Complete | WPS327/349, Ruff, diff, 2093 passed, 3 skipped | None | Start Package 1.7 |
 | 2026-07-11 | 1.7 | Complete | WPS121, 31 focused, Ruff, diff, 2093 passed, 3 skipped | e2cae6d | Start Package 1.8 |
 | 2026-07-11 | 1.8 | Complete | WPS414, 90 focused, Ruff, diff, 2093 passed, 3 skipped | Not committed | Package 1.9 |
+| 2026-07-11 | 1.9 | Complete | WPS441, 77 focused, Ruff, diff, 2093 passed, 3 skipped | 403c4d6 | Start Package 2.1 |

--- a/plans/linter-remediation.md
+++ b/plans/linter-remediation.md
@@ -39,7 +39,7 @@ Do not mark a stage complete until its completion gate is satisfied.
 
 | Stage | Goal | Packages complete | Status |
 |---|---|---:|---:|
-| 1 | Concrete formatting and correctness cleanup | 7/9 | [ ] |
+| 1 | Concrete formatting and correctness cleanup | 8/9 | [ ] |
 | 2 | Extreme production complexity hotspots | 0/8 | [ ] |
 | 3 | Remaining production complexity | 0/6 | [ ] |
 | 4 | Remaining production style and structure | 0/5 | [ ] |
@@ -149,8 +149,8 @@ Goal: remove objective, low-risk findings before structural refactoring.
 
 ### Package 1.8 — Unpacking targets
 
-- [ ] Resolve the two unique production unpacking-target findings in `orchestrator/usage.py`.
-- [ ] Update the related parser tests and preserve all accepted provider payload shapes.
+- [x] Resolve the two unique production unpacking-target findings in `orchestrator/usage.py`.
+- [x] Update the related parser tests and preserve all accepted provider payload shapes.
 
 ### Package 1.9 — Production control-variable reuse
 
@@ -456,4 +456,5 @@ Add one row for every implementation session, including partial sessions.
 | 2026-07-11 | 1.4 | Complete | E261, 41 tests, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.5 |
 | 2026-07-11 | 1.5 | Complete | 3 focused, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.6 |
 | 2026-07-11 | 1.6 | Complete | WPS327/349, Ruff, diff, 2093 passed, 3 skipped | None | Start Package 1.7 |
-| 2026-07-11 | 1.7 | Complete | WPS121, 31 focused, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.8 |
+| 2026-07-11 | 1.7 | Complete | WPS121, 31 focused, Ruff, diff, 2093 passed, 3 skipped | e2cae6d | Start Package 1.8 |
+| 2026-07-11 | 1.8 | Complete | WPS414, 90 focused, Ruff, diff, 2093 passed, 3 skipped | Not committed | Package 1.9 |

--- a/plans/linter-remediation.md
+++ b/plans/linter-remediation.md
@@ -39,7 +39,7 @@ Do not mark a stage complete until its completion gate is satisfied.
 
 | Stage | Goal | Packages complete | Status |
 |---|---|---:|---:|
-| 1 | Concrete formatting and correctness cleanup | 1/9 | [ ] |
+| 1 | Concrete formatting and correctness cleanup | 2/9 | [ ] |
 | 2 | Extreme production complexity hotspots | 0/8 | [ ] |
 | 3 | Remaining production complexity | 0/6 | [ ] |
 | 4 | Remaining production style and structure | 0/5 | [ ] |
@@ -106,7 +106,7 @@ Goal: remove objective, low-risk findings before structural refactoring.
 
 ### Package 1.2 — Test blank-line findings
 
-- [ ] Correct `E303`, `E305`, and `E306` in:
+- [x] Correct `E303`, `E305`, and `E306` in:
   - `tests/test_analytics_read_conn_reuse.py`
   - `tests/test_workflow_decomposition_children.py`
   - `tests/test_workflow_drift.py`
@@ -451,3 +451,4 @@ Add one row for every implementation session, including partial sessions.
 | Date | Package | Result | Validation | PR or commit | Exact next action |
 |---|---|---|---|---|---|
 | 2026-07-11 | 1.1 | Complete | E305, Ruff, diff, 2093 passed | Not committed | Start Package 1.2 |
+| 2026-07-11 | 1.2 | Complete | E303/E305/E306, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.3 |

--- a/plans/linter-remediation.md
+++ b/plans/linter-remediation.md
@@ -39,7 +39,7 @@ Do not mark a stage complete until its completion gate is satisfied.
 
 | Stage | Goal | Packages complete | Status |
 |---|---|---:|---:|
-| 1 | Concrete formatting and correctness cleanup | 6/9 | [ ] |
+| 1 | Concrete formatting and correctness cleanup | 7/9 | [ ] |
 | 2 | Extreme production complexity hotspots | 0/8 | [ ] |
 | 3 | Remaining production complexity | 0/6 | [ ] |
 | 4 | Remaining production style and structure | 0/5 | [ ] |
@@ -144,8 +144,8 @@ Goal: remove objective, low-risk findings before structural refactoring.
 
 ### Package 1.7 — Incorrect unused-name marker
 
-- [ ] Rename or clarify `_scheduler` in `orchestrator/main.py` so a used value is not marked as unused.
-- [ ] Preserve shutdown ordering and the watchdog-release behavior.
+- [x] Rename or clarify `_scheduler` in `orchestrator/main.py` so a used value is not marked as unused.
+- [x] Preserve shutdown ordering and the watchdog-release behavior.
 
 ### Package 1.8 — Unpacking targets
 
@@ -456,3 +456,4 @@ Add one row for every implementation session, including partial sessions.
 | 2026-07-11 | 1.4 | Complete | E261, 41 tests, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.5 |
 | 2026-07-11 | 1.5 | Complete | 3 focused, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.6 |
 | 2026-07-11 | 1.6 | Complete | WPS327/349, Ruff, diff, 2093 passed, 3 skipped | None | Start Package 1.7 |
+| 2026-07-11 | 1.7 | Complete | WPS121, 31 focused, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.8 |

--- a/plans/linter-remediation.md
+++ b/plans/linter-remediation.md
@@ -39,7 +39,7 @@ Do not mark a stage complete until its completion gate is satisfied.
 
 | Stage | Goal | Packages complete | Status |
 |---|---|---:|---:|
-| 1 | Concrete formatting and correctness cleanup | 4/9 | [ ] |
+| 1 | Concrete formatting and correctness cleanup | 5/9 | [ ] |
 | 2 | Extreme production complexity hotspots | 0/8 | [ ] |
 | 3 | Remaining production complexity | 0/6 | [ ] |
 | 4 | Remaining production style and structure | 0/5 | [ ] |
@@ -132,9 +132,9 @@ Goal: remove objective, low-risk findings before structural refactoring.
 
 ### Package 1.5 — File resource handling
 
-- [ ] Replace the unscoped `open()` in `tests/test_reexport_surface.py` with `Path.read_text()` or a context
+- [x] Replace the unscoped `open()` in `tests/test_reexport_surface.py` with `Path.read_text()` or a context
   manager.
-- [ ] Preserve the parsed source and encoding behavior.
+- [x] Preserve the parsed source and encoding behavior.
 
 ### Package 1.6 — Small redundant constructs
 
@@ -453,4 +453,5 @@ Add one row for every implementation session, including partial sessions.
 | 2026-07-11 | 1.1 | Complete | E305, Ruff, diff, 2093 passed | Not committed | Start Package 1.2 |
 | 2026-07-11 | 1.2 | Complete | E303/E305/E306, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.3 |
 | 2026-07-11 | 1.3 | Complete | E127/E128, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.4 |
-| 2026-07-11 | 1.4 | Complete | E261, 41 focused, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.5 |
+| 2026-07-11 | 1.4 | Complete | E261, 41 tests, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.5 |
+| 2026-07-11 | 1.5 | Complete | 3 focused, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.6 |

--- a/plans/linter-remediation.md
+++ b/plans/linter-remediation.md
@@ -39,7 +39,7 @@ Do not mark a stage complete until its completion gate is satisfied.
 
 | Stage | Goal | Packages complete | Status |
 |---|---|---:|---:|
-| 1 | Concrete formatting and correctness cleanup | 2/9 | [ ] |
+| 1 | Concrete formatting and correctness cleanup | 3/9 | [ ] |
 | 2 | Extreme production complexity hotspots | 0/8 | [ ] |
 | 3 | Remaining production complexity | 0/6 | [ ] |
 | 4 | Remaining production style and structure | 0/5 | [ ] |
@@ -117,7 +117,7 @@ Goal: remove objective, low-risk findings before structural refactoring.
 
 ### Package 1.3 — Test continuation indentation
 
-- [ ] Correct `E127` and `E128` in:
+- [x] Correct `E127` and `E128` in:
   - `tests/test_dashboard.py`
   - `tests/test_main.py`
   - `tests/test_workflow_implementing_paused.py`
@@ -452,3 +452,4 @@ Add one row for every implementation session, including partial sessions.
 |---|---|---|---|---|---|
 | 2026-07-11 | 1.1 | Complete | E305, Ruff, diff, 2093 passed | Not committed | Start Package 1.2 |
 | 2026-07-11 | 1.2 | Complete | E303/E305/E306, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.3 |
+| 2026-07-11 | 1.3 | Complete | E127/E128, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.4 |

--- a/plans/linter-remediation.md
+++ b/plans/linter-remediation.md
@@ -39,7 +39,7 @@ Do not mark a stage complete until its completion gate is satisfied.
 
 | Stage | Goal | Packages complete | Status |
 |---|---|---:|---:|
-| 1 | Concrete formatting and correctness cleanup | 3/9 | [ ] |
+| 1 | Concrete formatting and correctness cleanup | 4/9 | [ ] |
 | 2 | Extreme production complexity hotspots | 0/8 | [ ] |
 | 3 | Remaining production complexity | 0/6 | [ ] |
 | 4 | Remaining production style and structure | 0/5 | [ ] |
@@ -128,7 +128,7 @@ Goal: remove objective, low-risk findings before structural refactoring.
 
 ### Package 1.4 — Inline-comment spacing
 
-- [ ] Correct `E261` in `tests/test_workflow_implementing_pr_reuse.py`.
+- [x] Correct `E261` in `tests/test_workflow_implementing_pr_reuse.py`.
 
 ### Package 1.5 — File resource handling
 
@@ -453,3 +453,4 @@ Add one row for every implementation session, including partial sessions.
 | 2026-07-11 | 1.1 | Complete | E305, Ruff, diff, 2093 passed | Not committed | Start Package 1.2 |
 | 2026-07-11 | 1.2 | Complete | E303/E305/E306, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.3 |
 | 2026-07-11 | 1.3 | Complete | E127/E128, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.4 |
+| 2026-07-11 | 1.4 | Complete | E261, 41 focused, Ruff, diff, 2093 passed, 3 skipped | Not committed | Start Package 1.5 |

--- a/plans/linter-remediation.md
+++ b/plans/linter-remediation.md
@@ -39,7 +39,7 @@ Do not mark a stage complete until its completion gate is satisfied.
 
 | Stage | Goal | Packages complete | Status |
 |---|---|---:|---:|
-| 1 | Concrete formatting and correctness cleanup | 0/9 | [ ] |
+| 1 | Concrete formatting and correctness cleanup | 1/9 | [ ] |
 | 2 | Extreme production complexity hotspots | 0/8 | [ ] |
 | 3 | Remaining production complexity | 0/6 | [ ] |
 | 4 | Remaining production style and structure | 0/5 | [ ] |
@@ -101,8 +101,8 @@ Goal: remove objective, low-risk findings before structural refactoring.
 
 ### Package 1.1 — Production blank-line findings
 
-- [ ] Correct the three production `E305` findings in `orchestrator/agents.py` and `orchestrator/config.py`.
-- [ ] Verify that only blank-line layout changes.
+- [x] Correct the three production `E305` findings in `orchestrator/agents.py` and `orchestrator/config.py`.
+- [x] Verify that only blank-line layout changes.
 
 ### Package 1.2 — Test blank-line findings
 
@@ -450,4 +450,4 @@ Add one row for every implementation session, including partial sessions.
 
 | Date | Package | Result | Validation | PR or commit | Exact next action |
 |---|---|---|---|---|---|
-| | | | | | |
+| 2026-07-11 | 1.1 | Complete | E305, Ruff, diff, 2093 passed | Not committed | Start Package 1.2 |

--- a/tests/test_analytics_read_conn_reuse.py
+++ b/tests/test_analytics_read_conn_reuse.py
@@ -109,6 +109,7 @@ class ConnReusePathTest(unittest.TestCase):
         # exercised: the only way it would land is if a helper
         # short-circuited on the unset URL and then tried to open
         # its own socket, which is the bug we are guarding against.
+
         def _never_called(_url: str) -> _FakeConnection:
             raise AssertionError(
                 "connect= must not be called when conn= is supplied"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1616,7 +1616,7 @@ class BuildReadKeysTest(unittest.TestCase):
         self.assertEqual(
             prev_key,
             (prev.start, prev.end, CACHE_REPO, EVENT_NAMES, None,
-            ISSUE_NUMBER),
+             ISSUE_NUMBER),
         )
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1198,16 +1198,18 @@ class ShutdownWatchdogTest(unittest.TestCase):
                 client.slug = repo_spec.slug
                 return client
 
-            with patch.object(main_mod, "_arm_shutdown_watchdog"), \
-                 patch.object(
-                     main_mod.agents, "terminate_all_running",
-                 ) as term, \
-                 patch.object(
-                     main_mod, "GitHubClient", side_effect=fake_client,
-                 ), \
-                 patch.object(
-                     main_mod.workflow, "tick", side_effect=fake_tick,
-                 ):
+            with (
+                patch.object(main_mod, "_arm_shutdown_watchdog"),
+                patch.object(
+                    main_mod.agents, "terminate_all_running",
+                ) as term,
+                patch.object(
+                    main_mod, "GitHubClient", side_effect=fake_client,
+                ),
+                patch.object(
+                    main_mod.workflow, "tick", side_effect=fake_tick,
+                ),
+            ):
                 rc = main_mod.main(["--once"])
 
             self.assertEqual(rc, 128 + signal.SIGTERM)
@@ -1227,15 +1229,17 @@ class ShutdownWatchdogTest(unittest.TestCase):
                 client.slug = repo_spec.slug
                 return client
 
-            with patch.object(
-                main_mod.agents, "terminate_all_running",
-            ) as term, \
-                 patch.object(
-                     main_mod, "GitHubClient", side_effect=fake_client,
-                 ), \
-                 patch.object(
-                     main_mod.workflow, "tick", side_effect=fake_tick,
-                 ):
+            with (
+                patch.object(
+                    main_mod.agents, "terminate_all_running",
+                ) as term,
+                patch.object(
+                    main_mod, "GitHubClient", side_effect=fake_client,
+                ),
+                patch.object(
+                    main_mod.workflow, "tick", side_effect=fake_tick,
+                ),
+            ):
                 rc = main_mod.main(["--once"])
 
             self.assertEqual(rc, 0)

--- a/tests/test_reexport_surface.py
+++ b/tests/test_reexport_surface.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import ast
 import unittest
+from pathlib import Path
 
 from orchestrator import dashboard, workflow, worktrees
 from orchestrator.analytics import read as analytics_read
@@ -25,7 +26,7 @@ def _reexport_names(module) -> set[str]:
     names the facade republishes, independent of the hand-maintained
     `__all__`.
     """
-    tree = ast.parse(open(module.__file__).read())
+    tree = ast.parse(Path(module.__file__).read_text(encoding="utf-8"))
     names: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):

--- a/tests/test_workflow_decomposition_children.py
+++ b/tests/test_workflow_decomposition_children.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import unittest
 
 
-
 class CreateChildIssueAlwaysUsesParentRepoTest(unittest.TestCase):
     """`create_child_issue` is structurally bound to `self.repo` so a
     misuse cannot accidentally file a child against a different repo

--- a/tests/test_workflow_drift.py
+++ b/tests/test_workflow_drift.py
@@ -1007,6 +1007,5 @@ class DriftNonAckResponseParksTest(
         ))
 
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_workflow_fixing_routing.py
+++ b/tests/test_workflow_fixing_routing.py
@@ -614,5 +614,6 @@ class FixingWorktreeDriftRoutingTest(unittest.TestCase):
         self.post.assert_not_called()
         self.recover.assert_not_called()
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_workflow_implementing_paused.py
+++ b/tests/test_workflow_implementing_paused.py
@@ -227,11 +227,13 @@ class ImplementingLivePauseRetryWindowTest(
         # the second fetch (after the retry) sees the label.
         unpaused = make_issue(740, label="implementing")
         get_issue_mock = MagicMock(side_effect=[unpaused, _paused_view(740)])
-        with patch.object(gh, "get_issue", get_issue_mock), \
-             patch.object(
-                 workflow, "_ensure_worktree", lambda spec, n, **_: _FAKE_WT,
-             ), \
-             patch.object(workflow, "run_agent", fake_run):
+        with (
+            patch.object(gh, "get_issue", get_issue_mock),
+            patch.object(
+                workflow, "_ensure_worktree", lambda spec, n, **_: _FAKE_WT,
+            ),
+            patch.object(workflow, "run_agent", fake_run),
+        ):
             _, _, paused = workflow._resume_dev_with_text(
                 gh, _TEST_SPEC, issue, state, "go", pause_guard=True,
             )

--- a/tests/test_workflow_implementing_pr_reuse.py
+++ b/tests/test_workflow_implementing_pr_reuse.py
@@ -519,7 +519,7 @@ class ConventionalSubjectHelperTest(unittest.TestCase):
             "feat:",            # no subject after colon
             "feat:   ",         # whitespace-only subject
             "Feat: cap type",   # types must be lowercase
-            "  feat: leading", # leading whitespace not accepted
+            "  feat: leading",  # leading whitespace not accepted
         ):
             self.assertFalse(
                 workflow._is_conventional_subject(subject),

--- a/tests/test_workflow_in_review_checks.py
+++ b/tests/test_workflow_in_review_checks.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import unittest
 
 
-
 class GitHubClientClosedIssueSweepLabelTest(unittest.TestCase):
     """Real PyGithub's `Repository.get_issues(labels=...)` expects Label
     OBJECTS and reads `label.name`. The closed-issue sweep used to pass a

--- a/tests/test_workflow_question.py
+++ b/tests/test_workflow_question.py
@@ -907,15 +907,17 @@ class QuestionLabelBaseRefreshSkipTest(unittest.TestCase):
         # The merge / rev-list helpers would shell out if reached;
         # patch them so a regression that lets the sync proceed
         # surfaces as a call on these mocks.
-        with patch.object(base_sync, "_git") as git_mock, \
-             patch.object(
-                 base_sync, "_worktree_dirty_files",
-                 return_value=[],
-             ), \
-             patch.object(
-                 base_sync, "_merge_base_into_worktree",
-                 return_value=(True, []),
-             ) as merge_mock:
+        with (
+            patch.object(base_sync, "_git") as git_mock,
+            patch.object(
+                base_sync, "_worktree_dirty_files",
+                return_value=[],
+            ),
+            patch.object(
+                base_sync, "_merge_base_into_worktree",
+                return_value=(True, []),
+            ) as merge_mock,
+        ):
             base_sync._sync_worktree_with_base(
                 gh,
                 _TEST_SPEC,

--- a/tests/test_workflow_scheduler_routing.py
+++ b/tests/test_workflow_scheduler_routing.py
@@ -715,6 +715,7 @@ class TickViaSchedulerTest(unittest.TestCase):
         class _FakeWtDir:
             def __init__(self, name: str) -> None:
                 self.name = name
+
             def is_dir(self) -> bool:
                 return True
 

--- a/tests/test_workflow_scheduler_routing.py
+++ b/tests/test_workflow_scheduler_routing.py
@@ -533,11 +533,13 @@ class TickViaSchedulerTest(unittest.TestCase):
             # folds it into the family bucket.
             gh._issues[50].labels = [FakeLabel(LABEL_BLOCKED)]
 
-            with self.assertLogs(
-                "orchestrator.workflow", level=logging.INFO,
-            ) as logs, \
-                 patch.object(workflow, REFRESH_BASE), \
-                 patch.object(workflow, PROCESS_ISSUE, side_effect=fake_process):
+            with (
+                self.assertLogs(
+                    "orchestrator.workflow", level=logging.INFO,
+                ) as logs,
+                patch.object(workflow, REFRESH_BASE),
+                patch.object(workflow, PROCESS_ISSUE, side_effect=fake_process),
+            ):
                 workflow.tick(gh, self._spec(), scheduler=sched)
                 # Wait for the bucket drain to attempt #50 and skip it.
                 deadline = time.monotonic() + 2.0

--- a/tests/test_workflow_tick_parallel.py
+++ b/tests/test_workflow_tick_parallel.py
@@ -458,6 +458,7 @@ class TickPerRepoParallelLimitTest(unittest.TestCase):
 
         original_workflow_label = FakeGitHubClient.workflow_label
         # Raise for issue #2 only; #1 and #3 return their real labels.
+
         def flaky_workflow_label(self, issue):
             if getattr(issue, "number", None) == 2:
                 raise RuntimeError("simulated label-read failure")
@@ -468,6 +469,7 @@ class TickPerRepoParallelLimitTest(unittest.TestCase):
         # bucket (the partition routes label-read failures there) so the
         # fake_process gets called for it too -- but ALSO for #1 and #3,
         # proving the other issues weren't aborted.
+
         def fake_process(_gh, _spec, issue) -> None:
             processed.append(issue.number)
 

--- a/tests/test_workflow_tick_parallel.py
+++ b/tests/test_workflow_tick_parallel.py
@@ -848,17 +848,19 @@ class TickPerRepoParallelLimitTest(unittest.TestCase):
         # the thread that actually drives it.
         scenario = _WorkerClientScenario()
 
-        with patch.object(
-            scenario.parent,
-            "_for_worker_thread",
-            side_effect=scenario.clone_client,
-        ), \
-             patch.object(workflow, REFRESH_BASE), \
-             patch.object(
-                 workflow,
-                 PROCESS_ISSUE,
-                 side_effect=scenario.process_issue,
-             ):
+        with (
+            patch.object(
+                scenario.parent,
+                "_for_worker_thread",
+                side_effect=scenario.clone_client,
+            ),
+            patch.object(workflow, REFRESH_BASE),
+            patch.object(
+                workflow,
+                PROCESS_ISSUE,
+                side_effect=scenario.process_issue,
+            ),
+        ):
             workflow.tick(scenario.parent, self._spec(parallel_limit=3))
 
         scenario.assert_distinct_worker_clients(self)

--- a/tests/test_workflow_worktree_serialization.py
+++ b/tests/test_workflow_worktree_serialization.py
@@ -119,14 +119,16 @@ class WorktreePlumbingSerializationTest(unittest.TestCase):
         def call_ensure(n: int) -> None:
             worktrees._ensure_worktree(spec, n)
 
-        with patch.object(worktree_lifecycle, "_git", side_effect=fake_git), \
-             patch.object(
-                 worktree_lifecycle, "_authed_target_fetch",
-                 side_effect=fake_authed_fetch,
-             ), \
-             patch.object(worktree_lifecycle, "_has_new_commits", fake_has_new_commits), \
-             patch.object(Path, "exists", lambda self: False), \
-             patch.object(Path, "mkdir", lambda self, **_kw: None):
+        with (
+            patch.object(worktree_lifecycle, "_git", side_effect=fake_git),
+            patch.object(
+                worktree_lifecycle, "_authed_target_fetch",
+                side_effect=fake_authed_fetch,
+            ),
+            patch.object(worktree_lifecycle, "_has_new_commits", fake_has_new_commits),
+            patch.object(Path, "exists", lambda self: False),
+            patch.object(Path, "mkdir", lambda self, **_kw: None),
+        ):
             threads = [
                 threading.Thread(target=call_ensure, args=(n,))
                 for n in (1, 2, 3, 4)
@@ -285,14 +287,16 @@ class WorktreePlumbingSerializationTest(unittest.TestCase):
         def fake_has_new_commits(*_a, **_kw) -> bool:
             return False
 
-        with patch.object(worktree_lifecycle, "_git", side_effect=fake_git), \
-             patch.object(
-                 worktree_lifecycle, "_authed_target_fetch",
-                 side_effect=fake_authed_fetch,
-             ), \
-             patch.object(worktree_lifecycle, "_has_new_commits", fake_has_new_commits), \
-             patch.object(Path, "exists", lambda self: False), \
-             patch.object(Path, "mkdir", lambda self, **_kw: None):
+        with (
+            patch.object(worktree_lifecycle, "_git", side_effect=fake_git),
+            patch.object(
+                worktree_lifecycle, "_authed_target_fetch",
+                side_effect=fake_authed_fetch,
+            ),
+            patch.object(worktree_lifecycle, "_has_new_commits", fake_has_new_commits),
+            patch.object(Path, "exists", lambda self: False),
+            patch.object(Path, "mkdir", lambda self, **_kw: None),
+        ):
             t_a = threading.Thread(
                 target=lambda: worktrees._ensure_worktree(spec_a, 1)
             )


### PR DESCRIPTION
## Summary

- Complete all nine Stage 1 packages in `plans/linter-remediation.md`.
- Fix blank-line, continuation-indentation, and inline-comment spacing
findings.
- Replace an unscoped source read with UTF-8 `Path.read_text()`.
- Simplify redundant constructs while preserving fail-open behavior.
- Clarify scheduler, usage-cost, and loop-variable bindings.
- Update Stage 1 progress and the remediation session log.

These changes are intended to be behavior-preserving.

## Validation

- Targeted E303, E305, E306, E127, E128, E261, WPS121, WPS414, and WPS441
scans passed.
- Ruff and diff/whitespace checks passed.
- All focused test suites passed.
- Full tracked suite: 2,093 passed, 3 skipped.