### PR TITLE
refactor: simplify orchestration complexity hotspots

### DIFF
--- a/orchestrator/agents.py
+++ b/orchestrator/agents.py
@@ -22,7 +22,7 @@ import time
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterator, Optional
+from typing import Any, Iterator, NamedTuple, Optional, TypedDict, Unpack
 
 from orchestrator import config
 from orchestrator.usage import UsageMetrics
@@ -289,6 +289,21 @@ def _is_secret_shaped(name: str) -> bool:
     return any(upper.endswith(suffix) for suffix in _AGENT_SECRET_SUFFIXES)
 
 
+def _agent_env_key_allowed(
+    env_key: str, *, allow_provider_auth: bool,
+) -> bool:
+    if env_key in _FORBIDDEN_AGENT_ENV:
+        return False
+    if env_key in _AGENT_WRITE_CREDENTIAL_LOCATORS:
+        return False
+    if not _is_secret_shaped(env_key):
+        return True
+    return (
+        allow_provider_auth
+        and env_key in _AGENT_PROVIDER_AUTH_ALLOWLIST
+    )
+
+
 def _filter_agent_env(
     env: dict[str, str], *, allow_provider_auth: bool = True,
 ) -> dict[str, str]:
@@ -322,21 +337,13 @@ def _filter_agent_env(
       string verbatim, so an `ANTHROPIC_API_KEY=sk-… pytest` entry
       would leak the secret to GitHub on the first failure.
     """
-    filtered: dict[str, str] = {}
+    filtered_env: dict[str, str] = {}
     for env_key, env_value in env.items():
-        if env_key in _FORBIDDEN_AGENT_ENV:
-            continue
-        if env_key in _AGENT_WRITE_CREDENTIAL_LOCATORS:
-            continue
-        if _is_secret_shaped(env_key):
-            if (
-                allow_provider_auth
-                and env_key in _AGENT_PROVIDER_AUTH_ALLOWLIST
-            ):
-                filtered[env_key] = env_value
-            continue
-        filtered[env_key] = env_value
-    return filtered
+        if _agent_env_key_allowed(
+            env_key, allow_provider_auth=allow_provider_auth,
+        ):
+            filtered_env[env_key] = env_value
+    return filtered_env
 
 
 # Negative `Popen.returncode` values (the kernel reports `-N` for a child
@@ -375,25 +382,73 @@ class AgentResult:
 CodexResult = AgentResult
 
 
+@dataclass(frozen=True)
+class AgentRunOptions:
+    """Optional controls shared by fresh agent runs and session resumes."""
+
+    resume_session_id: Optional[str] = None
+    extra_env: Optional[dict[str, str]] = None
+    timeout: Optional[int] = None
+    extra_args: tuple[str, ...] = ()
+
+    @property
+    def timeout_seconds(self) -> int:
+        return self.timeout or config.AGENT_TIMEOUT
+
+
+class _AgentRunOptionFields(TypedDict, total=False):
+    resume_session_id: Optional[str]
+    extra_env: Optional[dict[str, str]]
+    timeout: Optional[int]
+    extra_args: tuple[str, ...]
+
+
+class _SubprocessResult(NamedTuple):
+    stdout: str
+    stderr: str
+    exit_code: int
+    timed_out: bool
+    interrupted: bool
+
+
+def _resolve_agent_run_options(
+    options: Optional[AgentRunOptions],
+    option_fields: _AgentRunOptionFields,
+) -> AgentRunOptions:
+    if options is not None and option_fields:
+        raise TypeError("pass either options or keyword option fields, not both")
+    if options is not None:
+        return options
+    return AgentRunOptions(**option_fields)
+
+
+def _first_nested_uuid(payload_nodes: Iterator[Any]) -> Optional[str]:
+    for payload_node in payload_nodes:
+        found = _walk_for_uuid(payload_node)
+        if found is not None:
+            return found
+    return None
+
+
+def _walk_mapping_for_uuid(payload_node: dict[Any, Any]) -> Optional[str]:
+    priority_values = (
+        payload_node[key]
+        for key in _PRIORITY_KEYS
+        if key in payload_node
+    )
+    priority_match = _first_nested_uuid(priority_values)
+    if priority_match is not None:
+        return priority_match
+    return _first_nested_uuid(iter(payload_node.values()))
+
+
 def _walk_for_uuid(payload_node: Any) -> Optional[str]:
     if isinstance(payload_node, str):
         return payload_node if _UUID_RE.match(payload_node) else None
     if isinstance(payload_node, dict):
-        for key in _PRIORITY_KEYS:
-            if key in payload_node:
-                found = _walk_for_uuid(payload_node[key])
-                if found:
-                    return found
-        for child_node in payload_node.values():
-            found = _walk_for_uuid(child_node)
-            if found:
-                return found
-        return None
+        return _walk_mapping_for_uuid(payload_node)
     if isinstance(payload_node, list):
-        for child_node in payload_node:
-            found = _walk_for_uuid(child_node)
-            if found:
-                return found
+        return _first_nested_uuid(iter(payload_node))
     return None
 
 
@@ -431,7 +486,7 @@ def _run_subprocess(
     cwd: Path,
     env: dict[str, str],
     timeout: int,
-) -> tuple[str, str, int, bool, bool]:
+) -> _SubprocessResult:
     # Spawn the agent in its own process group (start_new_session=True =>
     # setsid). On timeout we send SIGTERM to the whole group, not just the
     # direct child, so that grandchildren the agent forked (Maven, gradle,
@@ -455,14 +510,16 @@ def _run_subprocess(
             _terminate_process_group(proc)
             drained = _communicate_bounded(proc, 10)
             stdout, stderr = drained if drained is not None else ("", "")
-            return stdout, stderr, -1, True, False
+            return _SubprocessResult(stdout, stderr, -1, True, False)
         # A child killed by SIGTERM/SIGKILL exits with a negative code; the
         # most common cause is the shutdown sweep reaching this group while we
         # were parked in `communicate`. Flag it interrupted so it is not
         # mistaken for a normal non-timeout completion.
         stdout, stderr = drained
         interrupted = proc.returncode in _INTERRUPTED_RETURNCODES
-        return stdout, stderr, proc.returncode, False, interrupted
+        return _SubprocessResult(
+            stdout, stderr, proc.returncode, False, interrupted,
+        )
 
 
 def _terminate_process_group(proc: subprocess.Popen) -> None:
@@ -524,64 +581,91 @@ def _read_last_message(path: Path) -> str:
         return ""
 
 
-def _run_codex(
+def _build_agent_result(
+    options: AgentRunOptions,
+    process_result: _SubprocessResult,
+    last_message: str,
+) -> AgentResult:
+    return AgentResult(
+        session_id=(
+            options.resume_session_id
+            or parse_session_id(process_result.stdout)
+        ),
+        last_message=last_message,
+        exit_code=process_result.exit_code,
+        timed_out=process_result.timed_out,
+        stdout=process_result.stdout,
+        stderr=process_result.stderr,
+        interrupted=process_result.interrupted,
+    )
+
+
+def _codex_command(
     prompt: str,
     cwd: Path,
-    *,
-    resume_session_id: Optional[str] = None,
-    extra_env: Optional[dict[str, str]] = None,
-    timeout: Optional[int] = None,
-    extra_args: tuple[str, ...] = (),
-) -> AgentResult:
-    timeout = timeout or config.AGENT_TIMEOUT
+    last_message_path: Path,
+    options: AgentRunOptions,
+) -> list[str]:
     # codex applies `-C` AFTER it has already chdir'd into the subprocess cwd,
     # so a relative path resolves twice (once by Popen, once by codex) and
     # codex hits "No such file or directory (os error 2)". Pass an absolute
     # path so the second resolution is a no-op. WORKTREES_DIR=../wt-...
     # in .env is the common shape that triggers this.
     cwd_abs = Path(cwd).resolve()
-    with _codex_last_message_file() as last_msg_path:
-        # `codex exec resume` does not accept -C; we rely on subprocess cwd for it.
-        # Configured `extra_args` (e.g. `-m gpt-5.5 -c '...'`) are codex global
-        # options, so they go BEFORE the `exec` subcommand. The safety/output
-        # flags (`--dangerously-...`, `--json`, `-o`) and the prompt itself
-        # stay where they are -- operator-provided args must not be able to
-        # silently displace them.
-        common = [
-            "--dangerously-bypass-approvals-and-sandbox",
-            "--json",
-            "-o", str(last_msg_path),
+    # `codex exec resume` does not accept -C; we rely on subprocess cwd for it.
+    # Configured `extra_args` (e.g. `-m gpt-5.5 -c '...'`) are codex global
+    # options, so they go BEFORE the `exec` subcommand. The safety/output
+    # flags (`--dangerously-...`, `--json`, `-o`) and the prompt itself
+    # stay where they are -- operator-provided args must not be able to
+    # silently displace them.
+    common_args = [
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--json",
+        "-o", str(last_message_path),
+    ]
+    if options.resume_session_id:
+        return [
+            config.CODEX_BIN, *options.extra_args, "exec", "resume",
+            *common_args, options.resume_session_id, prompt,
         ]
-        if resume_session_id:
-            cmd = [
-                config.CODEX_BIN, *extra_args, "exec", "resume",
-                *common, resume_session_id, prompt,
-            ]
-        else:
-            cmd = [
-                config.CODEX_BIN, *extra_args, "exec", "-C", str(cwd_abs),
-                *common, prompt,
-            ]
+    return [
+        config.CODEX_BIN, *options.extra_args, "exec", "-C", str(cwd_abs),
+        *common_args, prompt,
+    ]
 
-        env = _agent_env(extra_env)
-        log.info(
-            "codex spawn: cwd=%s resume=%s timeout=%ss",
-            cwd, bool(resume_session_id), timeout,
+
+def _log_agent_spawn(
+    backend: str, cwd: Path, options: AgentRunOptions,
+) -> None:
+    log.info(
+        "%s spawn: cwd=%s resume=%s timeout=%ss",
+        backend,
+        cwd,
+        bool(options.resume_session_id),
+        options.timeout_seconds,
+    )
+
+
+def _run_codex(
+    prompt: str,
+    cwd: Path,
+    *,
+    options: Optional[AgentRunOptions] = None,
+    **option_fields: Unpack[_AgentRunOptionFields],
+) -> AgentResult:
+    run_options = _resolve_agent_run_options(options, option_fields)
+    with _codex_last_message_file() as last_message_path:
+        _log_agent_spawn("codex", cwd, run_options)
+        process_result = _run_subprocess(
+            _codex_command(prompt, cwd, last_message_path, run_options),
+            cwd,
+            _agent_env(run_options.extra_env),
+            run_options.timeout_seconds,
         )
-
-        stdout, stderr, exit_code, timed_out, interrupted = _run_subprocess(
-            cmd, cwd, env, timeout
-        )
-
-        sid = resume_session_id or parse_session_id(stdout)
-        return AgentResult(
-            session_id=sid,
-            last_message=_read_last_message(last_msg_path),
-            exit_code=exit_code,
-            timed_out=timed_out,
-            stdout=stdout,
-            stderr=stderr,
-            interrupted=interrupted,
+        return _build_agent_result(
+            run_options,
+            process_result,
+            _read_last_message(last_message_path),
         )
 
 
@@ -700,61 +784,66 @@ def _claude_last_message(
     )
 
 
-def _run_claude(
-    prompt: str,
-    cwd: Path,
-    *,
-    resume_session_id: Optional[str] = None,
-    extra_env: Optional[dict[str, str]] = None,
-    timeout: Optional[int] = None,
-    extra_args: tuple[str, ...] = (),
-) -> AgentResult:
-    timeout = timeout or config.AGENT_TIMEOUT
-
+def _claude_command(
+    prompt: str, options: AgentRunOptions,
+) -> list[str]:
     # Configured `extra_args` (e.g. `--model claude-opus-4-7 --effort high`)
     # go right after the binary, before our own flags and the prompt. The
     # safety/output flags (`-p`, `--dangerously-skip-permissions`,
     # `--output-format stream-json`, `--include-partial-messages`,
     # `--verbose`) and the prompt itself stay where they are so operator
     # args cannot silently override them.
-    cmd = [
+    command = [
         config.CLAUDE_BIN,
-        *extra_args,
+        *options.extra_args,
         "-p",
         "--dangerously-skip-permissions",
         "--output-format", "stream-json",
         "--include-partial-messages",
         "--verbose",
     ]
-    if resume_session_id:
-        cmd += ["--resume", resume_session_id]
-    cmd.append(prompt)
+    if options.resume_session_id:
+        command += ["--resume", options.resume_session_id]
+    command.append(prompt)
+    return command
 
-    env = _agent_env(extra_env)
-    log.info(
-        "claude spawn: cwd=%s resume=%s timeout=%ss",
-        cwd, bool(resume_session_id), timeout,
-    )
 
-    stdout, stderr, exit_code, timed_out, interrupted = _run_subprocess(
-        cmd, cwd, env, timeout
-    )
-
-    sid = resume_session_id or parse_session_id(stdout)
+def _claude_process_last_message(
+    process_result: _SubprocessResult,
+) -> str:
     # Only a clean, completed run may fall back to the last streamed assistant
     # chunk; interrupted/timed-out/non-zero runs expose "" unless they emitted
     # a terminal `result` event.
-    succeeded = exit_code == 0 and not timed_out and not interrupted
-    last_msg = _claude_last_message(stdout, allow_assistant_fallback=succeeded)
+    succeeded = (
+        process_result.exit_code == 0
+        and not process_result.timed_out
+        and not process_result.interrupted
+    )
+    return _claude_last_message(
+        process_result.stdout,
+        allow_assistant_fallback=succeeded,
+    )
 
-    return AgentResult(
-        session_id=sid,
-        last_message=last_msg,
-        exit_code=exit_code,
-        timed_out=timed_out,
-        stdout=stdout,
-        stderr=stderr,
-        interrupted=interrupted,
+
+def _run_claude(
+    prompt: str,
+    cwd: Path,
+    *,
+    options: Optional[AgentRunOptions] = None,
+    **option_fields: Unpack[_AgentRunOptionFields],
+) -> AgentResult:
+    run_options = _resolve_agent_run_options(options, option_fields)
+    _log_agent_spawn("claude", cwd, run_options)
+    process_result = _run_subprocess(
+        _claude_command(prompt, run_options),
+        cwd,
+        _agent_env(run_options.extra_env),
+        run_options.timeout_seconds,
+    )
+    return _build_agent_result(
+        run_options,
+        process_result,
+        _claude_process_last_message(process_result),
     )
 
 
@@ -763,24 +852,25 @@ def run_agent(
     prompt: str,
     cwd: Path,
     *,
-    resume_session_id: Optional[str] = None,
-    extra_env: Optional[dict[str, str]] = None,
-    timeout: Optional[int] = None,
-    extra_args: tuple[str, ...] = (),
+    options: Optional[AgentRunOptions] = None,
+    **option_fields: Unpack[_AgentRunOptionFields],
 ) -> AgentResult:
     """Dispatch to the per-backend runner. Config validates `backend` at
     import time, but we re-check here so a misuse from non-config call sites
     fails loudly instead of silently no-opping.
 
-    `extra_args` are forwarded verbatim to the backend CLI (e.g. `-m
-    gpt-5.5` for codex, `--model claude-opus-4-7` for claude). Callers
-    typically pull these from the role-specific config entries
+    The optional controls can be passed as an `AgentRunOptions` object or as
+    the established keyword fields. `extra_args` are forwarded verbatim to
+    the backend CLI (e.g. `-m gpt-5.5` for codex, `--model
+    claude-opus-4-7` for claude). Callers typically pull these from the
+    role-specific config entries
     (`DEV_AGENT_ARGS`, `REVIEW_AGENT_ARGS`, `DECOMPOSE_AGENT_ARGS`) so a
     role like "implement with codex at xhigh reasoning" stays declarative
     in env. They are injected for both fresh spawns and resumes; the
     backend's own session store carries forward model/effort selection
     across resumes, but explicit args keep the contract identical.
     """
+    run_options = _resolve_agent_run_options(options, option_fields)
     if backend == "codex":
         runner = _run_codex
     elif backend == "claude":
@@ -792,8 +882,5 @@ def run_agent(
     return runner(
         prompt,
         cwd,
-        resume_session_id=resume_session_id,
-        extra_env=extra_env,
-        timeout=timeout,
-        extra_args=extra_args,
+        options=run_options,
     )

--- a/orchestrator/analytics/__init__.py
+++ b/orchestrator/analytics/__init__.py
@@ -95,7 +95,7 @@ import logging
 import os
 import tempfile
 import threading
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -611,20 +611,7 @@ def _persist_agent_exit(
 ) -> None:
     """Write the baseline event, then the independently guarded trajectory."""
     append_record(_build_agent_exit_record(context, metrics, skill_fields))
-    _maybe_record_trajectory(
-        repo=context.repo,
-        issue=context.issue,
-        stage=context.stage,
-        agent_role=context.agent_role,
-        backend=context.backend,
-        result=context.agent_result,
-        prompt=context.prompt,
-        metrics=metrics,
-        review_round=context.review_round,
-        retry_count=context.retry_count,
-        codex_available_skills=codex_catalog.available_skills,
-        codex_tools=codex_catalog.tools,
-    )
+    _maybe_record_trajectory(context, metrics, codex_catalog)
 
 
 def record_agent_exit(
@@ -714,6 +701,39 @@ _TRAJECTORY_FIELD_TAIL = 2000
 _TRAJECTORY_RECORD_BUDGET = 200_000
 
 
+@dataclass(frozen=True)
+class _TrajectoryHeadline:
+    """Always-retained trajectory fields charged before variable arrays."""
+
+    user_input: Optional[str]
+    system_prompt: Optional[str]
+    output: Optional[str]
+    run_usage: dict[str, Any]
+
+    @property
+    def serialized_size(self) -> int:
+        text_size = sum(
+            len(value or "")
+            for value in (self.user_input, self.system_prompt, self.output)
+        )
+        return text_size + len(json.dumps(self.run_usage, default=str))
+
+
+@dataclass
+class _TrajectoryBudget:
+    """Track serialized variable-field bytes retained in one record."""
+
+    used: int
+    truncated: bool = False
+
+    def include(self, value: Any) -> bool:
+        self.used += len(json.dumps(value, default=str))
+        if self.used <= _TRAJECTORY_RECORD_BUDGET:
+            return True
+        self.truncated = True
+        return False
+
+
 def _truncate_head_tail(text: str, head: int, tail: int) -> str:
     """Keep the first `head` + last `tail` chars of `text`, eliding the
     middle with a marker recording how many chars were dropped. Returns
@@ -780,19 +800,71 @@ def _redact_and_truncate(value: Any, redact) -> Optional[str]:
     )
 
 
-def _build_trajectory_record(
-    *,
-    repo: str,
-    issue: int,
-    stage: str,
-    agent_role: str,
-    backend: str,
-    session_id: Optional[str],
-    prompt: Optional[str],
+def _trajectory_usage(metrics: usage.UsageMetrics) -> dict[str, Any]:
+    run_usage = metrics.to_dict()
+    run_usage.pop("backend", None)
+    return run_usage
+
+
+def _trajectory_headline(
+    context: _AgentExitContext,
     trajectory: usage.AgentTrajectory,
     metrics: usage.UsageMetrics,
-    review_round: Optional[int],
-    retry_count: Optional[int],
+    redact,
+) -> _TrajectoryHeadline:
+    return _TrajectoryHeadline(
+        user_input=_redact_and_truncate(context.prompt, redact),
+        system_prompt=_redact_and_truncate(trajectory.system_prompt, redact),
+        output=_redact_and_truncate(trajectory.final_output, redact),
+        run_usage=_trajectory_usage(metrics),
+    )
+
+
+def _bounded_trajectory_turns(
+    trajectory: usage.AgentTrajectory,
+    budget: _TrajectoryBudget,
+) -> list[dict[str, Any]]:
+    turns: list[dict[str, Any]] = []
+    for turn in trajectory.turns:
+        turn_dict = turn.to_dict()
+        if not budget.include(turn_dict):
+            break
+        turns.append(turn_dict)
+    return turns
+
+
+def _trajectory_step(step: usage.TrajectoryStep, redact) -> dict[str, Any]:
+    step_dict: dict[str, Any] = {
+        "kind": step.kind,
+        "name": step.name or None,
+        "tool_id": step.tool_id or None,
+        "content": _redact_and_truncate(step.content, redact),
+    }
+    if step.turn is not None:
+        step_dict["turn"] = step.turn
+    return step_dict
+
+
+def _bounded_trajectory_steps(
+    trajectory: usage.AgentTrajectory,
+    budget: _TrajectoryBudget,
+    redact,
+) -> list[dict[str, Any]]:
+    steps: list[dict[str, Any]] = []
+    if budget.truncated:
+        return steps
+    for step in trajectory.steps:
+        step_dict = _trajectory_step(step, redact)
+        if not budget.include(step_dict):
+            break
+        steps.append(step_dict)
+    return steps
+
+
+def _build_trajectory_record(
+    context: _AgentExitContext,
+    trajectory: usage.AgentTrajectory,
+    metrics: usage.UsageMetrics,
     redact,
 ) -> dict:
     """Assemble one redacted, truncated `agent_trajectory` record.
@@ -820,94 +892,68 @@ def _build_trajectory_record(
     no-trigger skill set, or codex's empty per-turn array leaves its key off
     rather than storing a null.
     """
-    user_input = _redact_and_truncate(prompt, redact)
-    system_prompt = _redact_and_truncate(trajectory.system_prompt, redact)
-    output = _redact_and_truncate(trajectory.final_output, redact)
-
-    run_usage = {k: v for k, v in metrics.to_dict().items() if k != "backend"}
-
-    used = len(user_input or "") + len(system_prompt or "") + len(output or "")
-    used += len(json.dumps(run_usage, default=str))
-    truncated = False
-
-    # The per-turn array is charged AND truncated under the record budget, not
-    # merely charged: a pathological claude run (thousands of turns) would
-    # otherwise write the whole array in full via `build_record` and blow the
-    # budget by its size. Turns are drawn down before steps, so `truncated` may
-    # already be set by the time the step loop runs. `run_usage` above is the
-    # small fixed run headline and stays whole.
-    turns: list[dict[str, Any]] = []
-    for turn in trajectory.turns:
-        turn_dict = turn.to_dict()
-        used += len(json.dumps(turn_dict, default=str))
-        if used > _TRAJECTORY_RECORD_BUDGET:
-            truncated = True
-            break
-        turns.append(turn_dict)
-
-    steps: list[dict[str, Any]] = []
-    for step in trajectory.steps:
-        if truncated:
-            break
-        step_dict: dict[str, Any] = {
-            "kind": step.kind,
-            "name": step.name or None,
-            "tool_id": step.tool_id or None,
-            "content": _redact_and_truncate(step.content, redact),
-        }
-        # `turn` is the assistant turn that produced this step (claude only);
-        # `tool_result` / `user_message` steps are turn *inputs*, not billed
-        # output, so their `turn` is None and the key is omitted -- matching
-        # the design's "step.turn only when present".
-        if step.turn is not None:
-            step_dict["turn"] = step.turn
-        # Charge the whole serialized step, not just its content: a run with
-        # thousands of empty- / metadata-only steps would otherwise evade a
-        # content-length-only budget and write an unbounded record.
-        used += len(json.dumps(step_dict, default=str))
-        if used > _TRAJECTORY_RECORD_BUDGET:
-            truncated = True
-            break
-        steps.append(step_dict)
-
-    skills = trajectory.skills
+    headline = _trajectory_headline(context, trajectory, metrics, redact)
+    budget = _TrajectoryBudget(headline.serialized_size)
+    turns = _bounded_trajectory_turns(trajectory, budget)
+    steps = _bounded_trajectory_steps(trajectory, budget, redact)
     return build_record(
-        repo=repo,
-        issue=int(issue),
+        repo=context.repo,
+        issue=context.issue,
         event="agent_trajectory",
-        stage=stage,
-        agent_role=agent_role,
-        backend=backend,
-        session_id=session_id,
-        review_round=review_round,
-        retry_count=retry_count,
-        user_input=user_input,
-        system_prompt=system_prompt,
+        stage=context.stage,
+        agent_role=context.agent_role,
+        backend=context.backend,
+        session_id=context.agent_result.session_id,
+        review_round=context.review_round,
+        retry_count=context.retry_count,
+        user_input=headline.user_input,
+        system_prompt=headline.system_prompt,
         tools=list(trajectory.tools) or None,
-        skills_triggered=list(skills.triggered) or None,
-        skills_available=list(skills.available) or None,
-        run_usage=run_usage,
+        skills_triggered=list(trajectory.skills.triggered) or None,
+        skills_available=list(trajectory.skills.available) or None,
+        run_usage=headline.run_usage,
         turns=turns or None,
         steps=steps,
-        output=output,
-        truncated=truncated or None,
+        output=headline.output,
+        truncated=budget.truncated or None,
     )
 
 
+def _codex_trajectory_changes(
+    trajectory: usage.AgentTrajectory,
+    catalog: _CodexCatalog,
+) -> dict[str, Any]:
+    changes: dict[str, Any] = {}
+    if catalog.available_skills and not trajectory.skills.available:
+        changes["skills"] = replace(
+            trajectory.skills,
+            available=tuple(catalog.available_skills),
+        )
+    if catalog.tools and not trajectory.tools:
+        changes["tools"] = tuple(catalog.tools)
+    return changes
+
+
+def _agent_trajectory(
+    context: _AgentExitContext,
+    catalog: _CodexCatalog,
+) -> usage.AgentTrajectory:
+    trajectory = usage.parse_agent_trajectory(
+        context.backend,
+        context.agent_result.stdout,
+    )
+    if context.backend != "codex":
+        return trajectory
+    changes = _codex_trajectory_changes(trajectory, catalog)
+    if not changes:
+        return trajectory
+    return replace(trajectory, **changes)
+
+
 def _maybe_record_trajectory(
-    *,
-    repo: str,
-    issue: int,
-    stage: str,
-    agent_role: str,
-    backend: str,
-    result: AgentResult,
-    prompt: Optional[str],
+    context: _AgentExitContext,
     metrics: usage.UsageMetrics,
-    review_round: Optional[int],
-    retry_count: Optional[int],
-    codex_available_skills: Optional[list[str]] = None,
-    codex_tools: Optional[list[str]] = None,
+    codex_catalog: _CodexCatalog,
 ) -> None:
     """Parse, redact, truncate, and append one trajectory record -- gated on
     the opt-in `TRAJECTORY_LOG_PATH` and wrapped in its own fail-open guard.
@@ -925,10 +971,10 @@ def _maybe_record_trajectory(
     `_redact_secrets` is imported at call time to avoid a
     `github` -> `analytics` -> `workflow_messages` -> `github` import cycle.
 
-    `codex_available_skills` / `codex_tools` are the out-of-band offered-skills
-    and offered-tools sets `record_agent_exit` discovered for a codex run
-    (empty / `None` for claude, whose offered sets already ride its stream).
-    When present they backfill the codex trajectory's otherwise-empty
+    `codex_catalog` carries the out-of-band offered-skills and offered-tools
+    sets `record_agent_exit` discovered for a codex run (empty for claude,
+    whose offered sets already ride its stream). When present they backfill
+    the codex trajectory's otherwise-empty
     `skills.available` / `tools` so the trajectory viewer's "Skills available"
     and "Tools offered" chips match a claude run's; a non-empty stream-parsed
     set is never overridden.
@@ -937,39 +983,16 @@ def _maybe_record_trajectory(
         return
     try:
         from orchestrator.workflow_messages import _redact_secrets
-        trajectory = usage.parse_agent_trajectory(backend, result.stdout)
-        if backend == "codex":
-            changes: dict[str, Any] = {}
-            if codex_available_skills and not trajectory.skills.available:
-                changes["skills"] = replace(
-                    trajectory.skills,
-                    available=tuple(codex_available_skills),
-                )
-            if codex_tools and not trajectory.tools:
-                changes["tools"] = tuple(codex_tools)
-            if changes:
-                trajectory = replace(trajectory, **changes)
+        trajectory = _agent_trajectory(context, codex_catalog)
         append_trajectory_record(
-            _build_trajectory_record(
-                repo=repo,
-                issue=int(issue),
-                stage=stage,
-                agent_role=agent_role,
-                backend=backend,
-                session_id=result.session_id,
-                prompt=prompt,
-                trajectory=trajectory,
-                metrics=metrics,
-                review_round=review_round,
-                retry_count=retry_count,
-                redact=_redact_secrets,
-            )
+            _build_trajectory_record(context, trajectory, metrics, _redact_secrets)
         )
     except Exception:
         log.exception(
             "issue=#%d analytics: trajectory record(%s) failed; "
             "baseline agent_exit record is unaffected",
-            issue, backend,
+            context.issue,
+            context.backend,
         )
 
 
@@ -1044,6 +1067,47 @@ def _probe_exists(path: Path) -> bool:
         return False
 
 
+def _prune_timestamp(raw_line: str) -> Optional[datetime]:
+    """Parse a JSONL record timestamp, returning None for kept malformed data."""
+    try:
+        record = json.loads(raw_line)
+    except json.JSONDecodeError:
+        return None
+    raw_timestamp = record.get("ts") if isinstance(record, dict) else None
+    if not isinstance(raw_timestamp, str):
+        return None
+    try:
+        timestamp = datetime.fromisoformat(raw_timestamp)
+    except ValueError:
+        return None
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp
+
+
+def _normalized_jsonl_line(raw_line: str) -> str:
+    if raw_line.endswith("\n"):
+        return raw_line
+    return raw_line + "\n"
+
+
+@dataclass
+class _PruneScan:
+    """Mutable partition of retained and expired JSONL records."""
+
+    kept: list[str] = field(default_factory=list)
+    removed: int = 0
+
+    def add(self, raw_line: str, cutoff: datetime) -> None:
+        if not raw_line.strip():
+            return
+        timestamp = _prune_timestamp(raw_line)
+        if timestamp is not None and timestamp < cutoff:
+            self.removed += 1
+            return
+        self.kept.append(_normalized_jsonl_line(raw_line))
+
+
 def _read_kept_records(
     path: Path, cutoff: datetime,
 ) -> Optional[tuple[list[str], int]]:
@@ -1056,40 +1120,15 @@ def _read_kept_records(
     to match the writer's forward-compat behavior. Returns None when the read
     itself raises OSError, which the caller turns into a logged no-op.
     """
-    kept: list[str] = []
-    removed = 0
+    scan = _PruneScan()
     try:
         with path.open("r", encoding="utf-8") as fh:
             for raw_line in fh:
-                if not raw_line.strip():
-                    continue
-                line = (
-                    raw_line if raw_line.endswith("\n") else raw_line + "\n"
-                )
-                try:
-                    rec = json.loads(raw_line)
-                except json.JSONDecodeError:
-                    kept.append(line)
-                    continue
-                ts_raw = rec.get("ts") if isinstance(rec, dict) else None
-                if not isinstance(ts_raw, str):
-                    kept.append(line)
-                    continue
-                try:
-                    ts = datetime.fromisoformat(ts_raw)
-                except ValueError:
-                    kept.append(line)
-                    continue
-                if ts.tzinfo is None:
-                    ts = ts.replace(tzinfo=timezone.utc)
-                if ts < cutoff:
-                    removed += 1
-                    continue
-                kept.append(line)
+                scan.add(raw_line, cutoff)
     except OSError as e:
         log.warning("could not read file %s for prune: %s", path, e)
         return None
-    return kept, removed
+    return scan.kept, scan.removed
 
 
 def _unlink_quietly(path: str) -> None:

--- a/orchestrator/analytics/connection.py
+++ b/orchestrator/analytics/connection.py
@@ -125,6 +125,57 @@ def _close_quietly(conn: Any) -> None:
         log.exception("analytics.read: connection close failed")
 
 
+def _cached_entry(url: str) -> Optional[tuple[str, Any]]:
+    """Return this thread's matching cache entry, closing a stale one."""
+    entry = getattr(_thread_local, "entry", None)
+    if entry is None:
+        return None
+    cached_url, cached_conn = entry
+    if cached_url == url:
+        return entry
+    _thread_local.entry = None
+    _close_quietly(cached_conn)
+    return None
+
+
+def _open_cached_connection(
+    url: str,
+    connect_fn: Callable[[str], Any],
+) -> Any:
+    """Open and cache one persistent connection with normalized errors."""
+    try:
+        conn = connect_fn(url)
+    except AnalyticsReadError:
+        raise
+    except Exception as error:
+        raise AnalyticsReadError(
+            f"could not connect to analytics database: {error}"
+        ) from error
+    _thread_local.entry = (url, conn)
+    return conn
+
+
+def _connection_for_url(
+    url: str,
+    connect_fn: Callable[[str], Any],
+) -> Any:
+    entry = _cached_entry(url)
+    if entry is None:
+        return _open_cached_connection(url, connect_fn)
+    return entry[1]
+
+
+def _discard_broken_connection(exc: BaseException) -> None:
+    """Evict this thread's cached socket when the escaped error broke it."""
+    if not _is_broken_connection_exc(exc):
+        return
+    entry = getattr(_thread_local, "entry", None)
+    if entry is None:
+        return
+    _thread_local.entry = None
+    _close_quietly(entry[1])
+
+
 @contextmanager
 def analytics_connection(
     *,
@@ -165,37 +216,11 @@ def analytics_connection(
     if not url:
         yield None
         return
-    connect_fn = connect or _default_persistent_connect
-    entry = getattr(_thread_local, "entry", None)
-    if entry is not None:
-        cached_url, cached_conn = entry
-        if cached_url != url:
-            # URL switched on this thread -- close the stale socket
-            # before reopening so a later read on the new URL does
-            # not silently land on the old one.
-            _thread_local.entry = None
-            _close_quietly(cached_conn)
-            entry = None
-    if entry is None:
-        try:
-            conn = connect_fn(url)
-        except AnalyticsReadError:
-            raise
-        except Exception as e:
-            raise AnalyticsReadError(
-                f"could not connect to analytics database: {e}"
-            ) from e
-        _thread_local.entry = (url, conn)
-    else:
-        _, conn = entry
+    conn = _connection_for_url(url, connect or _default_persistent_connect)
     try:
         yield conn
     except BaseException as exc:
-        if _is_broken_connection_exc(exc):
-            cached = getattr(_thread_local, "entry", None)
-            if cached is not None:
-                _thread_local.entry = None
-                _close_quietly(cached[1])
+        _discard_broken_connection(exc)
         raise
 
 

--- a/orchestrator/analytics/predicates.py
+++ b/orchestrator/analytics/predicates.py
@@ -15,18 +15,100 @@ built.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from typing import Any, Optional, Sequence
 
 
-def _build_window_where(
+@dataclass(frozen=True)
+class _WindowFilters:
+    """The common window and selection filters accepted by readers."""
+
+    start: Optional[datetime] = None
+    end: Optional[datetime] = None
+    repo: Optional[str] = None
+    events: Optional[Sequence[str]] = None
+    stages: Optional[Sequence[str]] = None
+    issue: Optional[int] = None
+
+    def without_events(self) -> _WindowFilters:
+        """Return filters suitable for a view with no `event` column."""
+        return replace(self, events=None)
+
+    def catalog_scope(self) -> _WindowFilters:
+        """Return the date/repo subset valid for repo-level catalog rows."""
+        return replace(self, events=None, stages=None, issue=None)
+
+
+@dataclass
+class _WhereBuilder:
+    """Accumulate one parameterized SQL predicate and its values."""
+
+    conditions: list[str] = field(default_factory=list)
+    params: list[Any] = field(default_factory=list)
+
+    def add_scalar(
+        self,
+        column: str,
+        value: Any,
+        *,
+        operator: str = "=",
+    ) -> None:
+        if value is None:
+            return
+        self.conditions.append(f"{column} {operator} %s")
+        self.params.append(value)
+
+    def add_selection(
+        self,
+        column: str,
+        values: Optional[Sequence[str]],
+    ) -> None:
+        if values is None:
+            return
+        if not values:
+            self.conditions.append("FALSE")
+            return
+        placeholders = ", ".join(["%s"] * len(values))
+        self.conditions.append(f"{column} IN ({placeholders})")
+        self.params.extend(values)
+
+    def render(self) -> tuple[str, list[Any]]:
+        if not self.conditions:
+            return "", self.params
+        return " WHERE " + " AND ".join(self.conditions), self.params
+
+
+def _day_bound(value: Optional[datetime]) -> Any:
+    if isinstance(value, datetime):
+        return value.date()
+    return value
+
+
+def _build_where(
+    filters: _WindowFilters,
     *,
-    start: Optional[datetime],
-    end: Optional[datetime],
-    repo: Optional[str],
-    events: Optional[Sequence[str]] = None,
-    stages: Optional[Sequence[str]] = None,
-    issue: Optional[int] = None,
+    time_column: str,
+    day_bounds: bool,
+) -> tuple[str, list[Any]]:
+    """Build a base-table or daily-rollup predicate from common filters."""
+    builder = _WhereBuilder()
+    start = _day_bound(filters.start) if day_bounds else filters.start
+    end = _day_bound(filters.end) if day_bounds else filters.end
+    builder.add_scalar(time_column, start, operator=">=")
+    builder.add_scalar(time_column, end, operator="<")
+    builder.add_scalar("repo", filters.repo)
+    builder.add_scalar(
+        "issue",
+        int(filters.issue) if filters.issue is not None else None,
+    )
+    builder.add_selection("event", filters.events)
+    builder.add_selection("stage", filters.stages)
+    return builder.render()
+
+
+def _build_window_where(
+    filters: _WindowFilters,
 ) -> tuple[str, list[Any]]:
     """Compose the shared `WHERE` clause for window-scoped queries.
 
@@ -56,37 +138,21 @@ def _build_window_where(
     to apply this filter when ``repo`` is not also set; the helper
     itself does not enforce that -- it just emits the predicate.
     """
-    conditions: list[str] = []
-    params: list[Any] = []
-    if start is not None:
-        conditions.append("ts >= %s")
-        params.append(start)
-    if end is not None:
-        conditions.append("ts < %s")
-        params.append(end)
-    if repo is not None:
-        conditions.append("repo = %s")
-        params.append(repo)
-    if issue is not None:
-        conditions.append("issue = %s")
-        params.append(int(issue))
-    if events is not None:
-        if not events:
-            conditions.append("FALSE")
-        else:
-            placeholders = ", ".join(["%s"] * len(events))
-            conditions.append(f"event IN ({placeholders})")
-            params.extend(events)
-    if stages is not None:
-        if not stages:
-            conditions.append("FALSE")
-        else:
-            placeholders = ", ".join(["%s"] * len(stages))
-            conditions.append(f"stage IN ({placeholders})")
-            params.extend(stages)
-    if not conditions:
-        return "", params
-    return " WHERE " + " AND ".join(conditions), params
+    return _build_where(filters, time_column="ts", day_bounds=False)
+
+
+def _append_where_condition(where: str, condition: str) -> str:
+    """Add a required condition after an optional generated predicate."""
+    if where:
+        return f"{where} AND {condition}"
+    return f" WHERE {condition}"
+
+
+def _prepend_where_condition(where: str, condition: str) -> str:
+    """Add a required condition before an optional generated predicate."""
+    if where:
+        return f" WHERE {condition} AND {where.removeprefix(' WHERE ')}"
+    return f" WHERE {condition}"
 
 
 def _agent_event_excluded(events: Optional[Sequence[str]]) -> bool:
@@ -113,12 +179,7 @@ def _agent_event_excluded(events: Optional[Sequence[str]]) -> bool:
 
 
 def _build_view_window_where(
-    *,
-    start: Optional[datetime],
-    end: Optional[datetime],
-    repo: Optional[str],
-    stages: Optional[Sequence[str]] = None,
-    issue: Optional[int] = None,
+    filters: _WindowFilters,
 ) -> tuple[str, list[Any]]:
     """`_build_window_where` minus the ``events`` clause.
 
@@ -126,23 +187,14 @@ def _build_view_window_where(
     already short-circuited on `_agent_event_excluded(events)` so
     the event-filter contract is honored before the SQL is built.
     """
-    return _build_window_where(
-        start=start, end=end, repo=repo,
-        events=None, stages=stages, issue=issue,
-    )
+    return _build_window_where(filters.without_events())
 
 
 _DAILY_ROLLUP_VIEW = "analytics_daily_rollup"
 
 
 def _build_rollup_window_where(
-    *,
-    start: Optional[datetime],
-    end: Optional[datetime],
-    repo: Optional[str],
-    events: Optional[Sequence[str]] = None,
-    stages: Optional[Sequence[str]] = None,
-    issue: Optional[int] = None,
+    filters: _WindowFilters,
 ) -> tuple[str, list[Any]]:
     """`_build_window_where` translated to the rollup's `day` column.
 
@@ -162,34 +214,4 @@ def _build_rollup_window_where(
     ``IN (...)``, and an empty sequence emits a tautologically-false
     predicate so the cleared-multiselect signal still drops to zero.
     """
-    conditions: list[str] = []
-    params: list[Any] = []
-    if start is not None:
-        conditions.append("day >= %s")
-        params.append(start.date() if isinstance(start, datetime) else start)
-    if end is not None:
-        conditions.append("day < %s")
-        params.append(end.date() if isinstance(end, datetime) else end)
-    if repo is not None:
-        conditions.append("repo = %s")
-        params.append(repo)
-    if issue is not None:
-        conditions.append("issue = %s")
-        params.append(int(issue))
-    if events is not None:
-        if not events:
-            conditions.append("FALSE")
-        else:
-            placeholders = ", ".join(["%s"] * len(events))
-            conditions.append(f"event IN ({placeholders})")
-            params.extend(events)
-    if stages is not None:
-        if not stages:
-            conditions.append("FALSE")
-        else:
-            placeholders = ", ".join(["%s"] * len(stages))
-            conditions.append(f"stage IN ({placeholders})")
-            params.extend(stages)
-    if not conditions:
-        return "", params
-    return " WHERE " + " AND ".join(conditions), params
+    return _build_where(filters, time_column="day", day_bounds=True)

--- a/orchestrator/analytics/query.py
+++ b/orchestrator/analytics/query.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Single-SELECT query execution for the analytics read path.
 
-`_query` runs one read-only SELECT and returns every row as a tuple,
+`_ReadQuery` resolves the configured URL and injected connection path for a
+reader. `_query` runs one read-only SELECT and returns every row as a tuple,
 either reusing a caller-owned `conn=` (typically an
 `analytics_connection` scope) or opening and closing a fresh
 connection via the injected `connect_fn`. Driver-level failures are
@@ -11,9 +12,56 @@ catch regardless of which step failed.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Callable, Optional, Sequence
 
-from orchestrator.analytics.connection import AnalyticsReadError, _close_quietly
+from orchestrator.analytics.connection import (
+    AnalyticsReadError,
+    _close_quietly,
+    _default_connect,
+)
+from orchestrator.analytics.db_url import _resolve_db_url
+
+
+@dataclass(frozen=True)
+class _ReadQuery:
+    """Resolved connection inputs shared by one public read operation."""
+
+    db_url: Optional[str]
+    connect_fn: Callable[[str], Any]
+    conn: Any
+
+    @classmethod
+    def resolve(
+        cls,
+        db_url: Optional[str],
+        connect: Optional[Callable[[str], Any]],
+        conn: Any,
+    ) -> _ReadQuery:
+        return cls(
+            db_url=_resolve_db_url(db_url),
+            connect_fn=connect or _default_connect,
+            conn=conn,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Whether a supplied connection or configured URL can serve reads."""
+        return self.conn is not None or bool(self.db_url)
+
+    def select(
+        self,
+        sql: str,
+        params: Sequence[Any] = (),
+    ) -> list[tuple]:
+        """Execute one SELECT through the resolved connection path."""
+        return _query(
+            self.connect_fn,
+            self.db_url,
+            sql,
+            params,
+            conn=self.conn,
+        )
 
 
 def _execute_select(

--- a/orchestrator/analytics/read_dashboard.py
+++ b/orchestrator/analytics/read_dashboard.py
@@ -22,18 +22,18 @@ aggregates in `read_rollup`.
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass, field
 from datetime import datetime
-from functools import partial
 from typing import Any, Callable, Optional, Sequence
 
-from orchestrator.analytics.connection import _default_connect
-from orchestrator.analytics.db_url import _resolve_db_url
 from orchestrator.analytics.predicates import (
+    _WindowFilters,
     _agent_event_excluded,
+    _append_where_condition,
     _build_view_window_where,
     _build_window_where,
 )
-from orchestrator.analytics.query import _query
+from orchestrator.analytics.query import _ReadQuery
 from orchestrator.analytics.read_models import (
     BackendDailyTokensRow,
     CostCoverageRow,
@@ -85,9 +85,44 @@ def _skill_matrix_order_key(
     cohort_runs: dict[tuple[str, str, str], int],
 ) -> tuple:
     repo, role, backend, skill = key
-    skill_runs = counts.get(key, 0)
-    total = cohort_runs.get((repo, role, backend), 0)
-    return (-skill_runs, -total, repo, role, backend, skill)
+    return (
+        -counts.get(key, 0),
+        -cohort_runs.get((repo, role, backend), 0),
+        repo,
+        role,
+        backend,
+        skill,
+    )
+
+
+def _row_value(row: Sequence[Any], index: int, default: Any = 0) -> Any:
+    if len(row) <= index:
+        return default
+    return row[index]
+
+
+def _day_value(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.date()
+    return value
+
+
+_AGENT_CACHE_TOKENS_SQL = (
+    "(COALESCE(cached_tokens, 0) "
+    "+ COALESCE(cache_read_tokens, 0) "
+    "+ COALESCE(cache_write_tokens, 0))"
+)
+_AGENT_ALL_TOKENS_SQL = (
+    "(COALESCE(input_tokens, 0) "
+    "+ COALESCE(output_tokens, 0) "
+    "+ COALESCE(cache_read_tokens, 0) "
+    "+ COALESCE(cache_write_tokens, 0))"
+)
+_AGENT_CACHE_FRACTION_SQL = (
+    f"CASE WHEN {_AGENT_ALL_TOKENS_SQL} = 0 THEN 0 "
+    f"ELSE {_AGENT_CACHE_TOKENS_SQL}::numeric "
+    f"/ {_AGENT_ALL_TOKENS_SQL}::numeric END"
+)
 
 
 # Default cap on the rows `get_skill_trigger_matrix` returns. The
@@ -95,6 +130,77 @@ def _skill_matrix_order_key(
 # expand from flooding the page when many repos x cohorts x catalog
 # skills multiply out. A non-positive `limit` disables the cap.
 SKILL_MATRIX_ROW_LIMIT = 100
+
+
+def _review_round_sql(where: str) -> str:
+    return (
+        "SELECT "
+        "CASE "
+        "WHEN review_round IS NULL "
+        "AND agent_role = 'developer' "
+        "AND stage = 'implementing' THEN '0' "
+        "WHEN review_round IS NULL THEN 'unknown' "
+        "WHEN review_round <= 0 THEN '0' "
+        "WHEN review_round >= 6 THEN '6+' "
+        "ELSE review_round::text "
+        "END AS bucket, "
+        "COUNT(*) AS runs, "
+        "SUM(CASE WHEN failed THEN 1 ELSE 0 END) AS failed_runs, "
+        "COALESCE(SUM(cost_usd), 0) AS bucket_cost_usd, "
+        "SUM(CASE WHEN agent_role = 'developer' THEN 1 ELSE 0 END) "
+        "AS developer_runs, "
+        "SUM(CASE WHEN agent_role = 'reviewer' THEN 1 ELSE 0 END) "
+        "AS reviewer_runs, "
+        "COALESCE(SUM(CASE WHEN agent_role = 'developer' "
+        "THEN cost_usd ELSE 0 END), 0) AS developer_cost_usd, "
+        "COALESCE(SUM(CASE WHEN agent_role = 'reviewer' "
+        "THEN cost_usd ELSE 0 END), 0) AS reviewer_cost_usd, "
+        "COALESCE(SUM(CASE WHEN agent_role = 'developer' "
+        f"THEN COALESCE(cost_usd, 0) * ({_AGENT_CACHE_FRACTION_SQL}) "
+        "ELSE 0 END), 0) AS developer_cache_cost_usd, "
+        "COALESCE(SUM(CASE WHEN agent_role = 'developer' "
+        f"THEN COALESCE(cost_usd, 0) * (1 - ({_AGENT_CACHE_FRACTION_SQL})) "
+        "ELSE 0 END), 0) AS developer_no_cache_cost_usd, "
+        "COALESCE(SUM(CASE WHEN agent_role = 'reviewer' "
+        f"THEN COALESCE(cost_usd, 0) * ({_AGENT_CACHE_FRACTION_SQL}) "
+        "ELSE 0 END), 0) AS reviewer_cache_cost_usd, "
+        "COALESCE(SUM(CASE WHEN agent_role = 'reviewer' "
+        f"THEN COALESCE(cost_usd, 0) * (1 - ({_AGENT_CACHE_FRACTION_SQL})) "
+        "ELSE 0 END), 0) AS reviewer_no_cache_cost_usd "
+        f"FROM analytics_agent_runs{where} "
+        "GROUP BY bucket "
+        "ORDER BY runs DESC, bucket ASC"
+    )
+
+
+def _review_round_from_row(row: Sequence[Any]) -> ReviewRoundBucketRow:
+    return ReviewRoundBucketRow(
+        bucket=str(row[0]),
+        runs=int(row[1] or 0),
+        failed=int(row[2] or 0),
+        total_cost_usd=float(_row_value(row, 3, 0.0) or 0.0),
+        developer_runs=int(_row_value(row, 4) or 0),
+        reviewer_runs=int(_row_value(row, 5) or 0),
+        developer_cost_usd=float(_row_value(row, 6, 0.0) or 0.0),
+        reviewer_cost_usd=float(_row_value(row, 7, 0.0) or 0.0),
+        developer_cache_cost_usd=float(_row_value(row, 8, 0.0) or 0.0),
+        developer_no_cache_cost_usd=float(_row_value(row, 9, 0.0) or 0.0),
+        reviewer_cache_cost_usd=float(_row_value(row, 10, 0.0) or 0.0),
+        reviewer_no_cache_cost_usd=float(_row_value(row, 11, 0.0) or 0.0),
+    )
+
+
+def _review_round_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+) -> list[ReviewRoundBucketRow]:
+    where, params = _build_view_window_where(filters)
+    where = _append_where_condition(
+        where,
+        "agent_role IN ('developer', 'reviewer')",
+    )
+    rows = query.select(_review_round_sql(where), params)
+    return [_review_round_from_row(row) for row in rows]
 
 
 def get_review_round_breakdown(
@@ -127,141 +233,56 @@ def get_review_round_breakdown(
     returns empty so the dashboard's "show nothing for this
     dimension" semantics stays consistent across widgets.
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
         return []
     if _agent_event_excluded(events):
         return []
-    connect_fn = connect or _default_connect
-    where, params = _build_view_window_where(
-        start=start, end=end, repo=repo,
-        stages=stages, issue=issue,
+    filters = _WindowFilters(
+        start=start,
+        end=end,
+        repo=repo,
+        stages=stages,
+        issue=issue,
     )
-    role_clause = "agent_role IN ('developer', 'reviewer')"
-    if where:
-        where = f"{where} AND {role_clause}"
-    else:
-        where = f" WHERE {role_clause}"
-    # Each run is split into a cache portion (the share of its tokens
-    # billed as cached / cache-read / cache-write) and a no-cache
-    # portion (the remaining input + output tokens). Cost is attributed
-    # proportionally so the per-round chart shows what fraction of
-    # spend actually flowed through the cache vs ran against fresh
-    # tokens -- the prior binary "any cache token => fully cache"
-    # classification collapsed to ~100% cache once every backend
-    # started reporting cache writes on the first call, leaving the
-    # no-cache stack empty. `total_cache_tokens` / `total_tokens` would
-    # let us inline these from the view but the columns only live
-    # there, not on the raw table, so encode the expressions directly
-    # off the underlying token columns for forward-compat with rollup
-    # paths.
-    #
-    # `cached_tokens` (Codex) is a subset of `input_tokens` -- the
-    # portion of the prompt served from cache -- so it stays out of
-    # the denominator to avoid double-counting. `cache_read_tokens` /
-    # `cache_write_tokens` (Claude) are reported alongside `input_tokens`
-    # rather than inside it, so they add to the denominator normally.
-    cache_tokens_expr = (
-        "(COALESCE(cached_tokens, 0) "
-        "+ COALESCE(cache_read_tokens, 0) "
-        "+ COALESCE(cache_write_tokens, 0))"
-    )
-    all_tokens_expr = (
-        "(COALESCE(input_tokens, 0) "
-        "+ COALESCE(output_tokens, 0) "
-        "+ COALESCE(cache_read_tokens, 0) "
-        "+ COALESCE(cache_write_tokens, 0))"
-    )
-    # Guard the denominator so a token-less row contributes its whole
-    # cost (if any) to the no-cache stack rather than dividing by zero.
-    cache_fraction_expr = (
-        f"CASE WHEN {all_tokens_expr} = 0 THEN 0 "
-        f"ELSE {cache_tokens_expr}::numeric / {all_tokens_expr}::numeric "
-        f"END"
-    )
-    sql = (
+    return _review_round_rows(query, filters)
+
+
+def _skill_trigger_rate_sql(clause: str) -> str:
+    return (
         "SELECT "
-        # Derive the bucket from the raw `review_round` so rounds 3, 4
-        # and 5 stay separate (the view's `review_round_bucket` collapses
-        # them into a single `3-5`). 6+ is still grouped to bound the
-        # long tail. Fresh implementing runs now log review_round=0;
-        # this explicit stage/role fallback keeps older rows in the
-        # same first-pass development bucket.
-        "CASE "
-        "WHEN review_round IS NULL "
-        "AND agent_role = 'developer' "
-        "AND stage = 'implementing' THEN '0' "
-        "WHEN review_round IS NULL THEN 'unknown' "
-        "WHEN review_round <= 0 THEN '0' "
-        "WHEN review_round >= 6 THEN '6+' "
-        "ELSE review_round::text "
-        "END AS bucket, "
+        "COALESCE(agent_role, 'unknown') AS role_label, "
+        "COALESCE(backend, 'unknown') AS backend_label, "
         "COUNT(*) AS runs, "
-        "SUM(CASE WHEN failed THEN 1 ELSE 0 END) AS failed_runs, "
-        "COALESCE(SUM(cost_usd), 0) AS bucket_cost_usd, "
-        "SUM(CASE WHEN agent_role = 'developer' THEN 1 ELSE 0 END) "
-        "AS developer_runs, "
-        "SUM(CASE WHEN agent_role = 'reviewer' THEN 1 ELSE 0 END) "
-        "AS reviewer_runs, "
-        "COALESCE(SUM(CASE WHEN agent_role = 'developer' "
-        "THEN cost_usd ELSE 0 END), 0) AS developer_cost_usd, "
-        "COALESCE(SUM(CASE WHEN agent_role = 'reviewer' "
-        "THEN cost_usd ELSE 0 END), 0) AS reviewer_cost_usd, "
-        "COALESCE(SUM(CASE WHEN agent_role = 'developer' "
-        f"THEN COALESCE(cost_usd, 0) * ({cache_fraction_expr}) "
-        "ELSE 0 END), 0) AS developer_cache_cost_usd, "
-        "COALESCE(SUM(CASE WHEN agent_role = 'developer' "
-        f"THEN COALESCE(cost_usd, 0) * (1 - ({cache_fraction_expr})) "
-        "ELSE 0 END), 0) AS developer_no_cache_cost_usd, "
-        "COALESCE(SUM(CASE WHEN agent_role = 'reviewer' "
-        f"THEN COALESCE(cost_usd, 0) * ({cache_fraction_expr}) "
-        "ELSE 0 END), 0) AS reviewer_cache_cost_usd, "
-        "COALESCE(SUM(CASE WHEN agent_role = 'reviewer' "
-        f"THEN COALESCE(cost_usd, 0) * (1 - ({cache_fraction_expr})) "
-        "ELSE 0 END), 0) AS reviewer_no_cache_cost_usd "
-        f"FROM analytics_agent_runs{where} "
-        "GROUP BY bucket "
-        "ORDER BY runs DESC, bucket ASC"
+        "COUNT(*) FILTER "
+        "  (WHERE extras -> 'skills_triggered' IS NOT NULL) AS skill_runs, "
+        "COALESCE(SUM((extras ->> 'skills_triggered_count')::int), 0) "
+        "  AS total_triggers "
+        f"FROM analytics_events{clause} "
+        "GROUP BY role_label, backend_label "
+        "ORDER BY skill_runs DESC, runs DESC, role_label ASC, "
+        "backend_label ASC"
     )
-    rows = _query(connect_fn, url, sql, params, conn=conn)
-    out: list[ReviewRoundBucketRow] = []
-    for row in rows:
-        bucket = row[0]
-        runs = row[1]
-        failed = row[2]
-        # Older fixtures may still emit rows without the role / cache
-        # split; default those columns so unrelated tests keep
-        # round-tripping.
-        cost = row[3] if len(row) > 3 else 0.0
-        developer_runs = row[4] if len(row) > 4 else 0
-        reviewer_runs = row[5] if len(row) > 5 else 0
-        developer_cost = row[6] if len(row) > 6 else 0.0
-        reviewer_cost = row[7] if len(row) > 7 else 0.0
-        developer_cache_cost = row[8] if len(row) > 8 else 0.0
-        developer_no_cache_cost = row[9] if len(row) > 9 else 0.0
-        reviewer_cache_cost = row[10] if len(row) > 10 else 0.0
-        reviewer_no_cache_cost = row[11] if len(row) > 11 else 0.0
-        out.append(
-            ReviewRoundBucketRow(
-                bucket=str(bucket),
-                runs=int(runs or 0),
-                failed=int(failed or 0),
-                total_cost_usd=float(cost or 0.0),
-                developer_runs=int(developer_runs or 0),
-                reviewer_runs=int(reviewer_runs or 0),
-                developer_cost_usd=float(developer_cost or 0.0),
-                reviewer_cost_usd=float(reviewer_cost or 0.0),
-                developer_cache_cost_usd=float(developer_cache_cost or 0.0),
-                developer_no_cache_cost_usd=float(
-                    developer_no_cache_cost or 0.0
-                ),
-                reviewer_cache_cost_usd=float(reviewer_cache_cost or 0.0),
-                reviewer_no_cache_cost_usd=float(
-                    reviewer_no_cache_cost or 0.0
-                ),
-            )
-        )
-    return out
+
+
+def _skill_trigger_rate_from_row(row: Sequence[Any]) -> SkillTriggerRateRow:
+    return SkillTriggerRateRow(
+        agent_role=_label_or_unknown(row[0]),
+        backend=_label_or_unknown(row[1]),
+        runs=int(row[2] or 0),
+        skill_runs=int(_row_value(row, 3) or 0),
+        total_triggers=int(_row_value(row, 4) or 0),
+    )
+
+
+def _skill_trigger_rate_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+) -> list[SkillTriggerRateRow]:
+    where, params = _build_window_where(filters.without_events())
+    clause = _append_where_condition(where, "event = 'agent_exit'")
+    rows = query.select(_skill_trigger_rate_sql(clause), params)
+    return [_skill_trigger_rate_from_row(row) for row in rows]
 
 
 def get_skill_trigger_rates(
@@ -291,59 +312,131 @@ def get_skill_trigger_rates(
     sums `skills_triggered_count`. NULL `agent_role` / `backend` bucket
     under `"unknown"`. Rows are ordered skill-active groups first.
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
         return []
     if _agent_event_excluded(events):
         return []
-    connect_fn = connect or _default_connect
-    where, params = _build_window_where(
-        start=start, end=end, repo=repo,
-        events=None, stages=stages, issue=issue,
+    filters = _WindowFilters(
+        start=start,
+        end=end,
+        repo=repo,
+        stages=stages,
+        issue=issue,
     )
-    clause = (
-        f"{where} AND event = 'agent_exit'"
-        if where
-        else " WHERE event = 'agent_exit'"
+    return _skill_trigger_rate_rows(query, filters)
+
+
+_SkillCohort = tuple[str, str, str]
+_SkillMatrixKey = tuple[str, str, str, str]
+
+
+def _skill_catalog_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+) -> list[tuple]:
+    where, params = _build_window_where(filters.catalog_scope())
+    clause = _append_where_condition(where, "event = 'repo_skill_catalog'")
+    return query.select(
+        "SELECT repo, extras -> 'skills_available' AS skills_available "
+        f"FROM analytics_events{clause}",
+        params,
     )
-    # `extras -> 'skills_triggered' IS NOT NULL` (not the jsonb `?`
-    # operator) tests key presence without tripping the `?`/`%s`
-    # placeholder ambiguity some drivers and poolers apply.
-    sql = (
-        "SELECT "
+
+
+def _skill_catalog(rows: Sequence[tuple]) -> dict[str, set[str]]:
+    catalog: dict[str, set[str]] = {}
+    for row in rows:
+        if row[0] is None:
+            continue
+        repo = str(row[0])
+        names = _as_skill_names(_row_value(row, 1, None))
+        catalog.setdefault(repo, set()).update(names)
+    return catalog
+
+
+def _skill_run_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+) -> list[tuple]:
+    where, params = _build_window_where(filters.without_events())
+    clause = _append_where_condition(where, "event = 'agent_exit'")
+    return query.select(
+        "SELECT repo, "
         "COALESCE(agent_role, 'unknown') AS role_label, "
         "COALESCE(backend, 'unknown') AS backend_label, "
-        "COUNT(*) AS runs, "
-        "COUNT(*) FILTER "
-        "  (WHERE extras -> 'skills_triggered' IS NOT NULL) AS skill_runs, "
-        "COALESCE(SUM((extras ->> 'skills_triggered_count')::int), 0) "
-        "  AS total_triggers "
-        f"FROM analytics_events{clause} "
-        "GROUP BY role_label, backend_label "
-        "ORDER BY skill_runs DESC, runs DESC, role_label ASC, "
-        "backend_label ASC"
+        "extras -> 'skills_triggered' AS skills_triggered "
+        f"FROM analytics_events{clause}",
+        params,
     )
-    rows = _query(connect_fn, url, sql, params, conn=conn)
-    out: list[SkillTriggerRateRow] = []
-    for row in rows:
-        role = row[0]
-        backend = row[1]
-        runs = row[2]
-        # Older fixtures may emit 3-tuple rows without the skill
-        # columns; default to zero so unrelated test cases need not
-        # know about the JSONB aggregates.
-        skill_runs = row[3] if len(row) > 3 else 0
-        total_triggers = row[4] if len(row) > 4 else 0
-        out.append(
-            SkillTriggerRateRow(
-                agent_role=_label_or_unknown(role),
-                backend=_label_or_unknown(backend),
-                runs=int(runs or 0),
-                skill_runs=int(skill_runs or 0),
-                total_triggers=int(total_triggers or 0),
-            )
+
+
+def _skill_cohort(row: Sequence[Any]) -> _SkillCohort:
+    return (
+        _label_or_unknown(row[0]),
+        _row_label(row, 1),
+        _row_label(row, 2),
+    )
+
+
+@dataclass
+class _SkillMatrixCounts:
+    """Run and trigger counts used to assemble the skill matrix."""
+
+    cohort_runs: dict[_SkillCohort, int] = field(default_factory=dict)
+    skill_runs: dict[_SkillMatrixKey, int] = field(default_factory=dict)
+
+    @classmethod
+    def from_rows(cls, rows: Sequence[tuple]) -> _SkillMatrixCounts:
+        counts = cls()
+        for row in rows:
+            cohort = _skill_cohort(row)
+            counts.cohort_runs[cohort] = counts.cohort_runs.get(cohort, 0) + 1
+            for skill in set(_as_skill_names(_row_value(row, 3, None))):
+                key = (*cohort, skill)
+                counts.skill_runs[key] = counts.skill_runs.get(key, 0) + 1
+        return counts
+
+    def matrix_keys(
+        self,
+        catalog: dict[str, set[str]],
+    ) -> set[_SkillMatrixKey]:
+        keys = set(self.skill_runs)
+        for cohort in self.cohort_runs:
+            for skill in catalog.get(cohort[0], ()):
+                keys.add((*cohort, skill))
+        return keys
+
+    def order_key(self, key: _SkillMatrixKey) -> tuple:
+        return _skill_matrix_order_key(
+            key,
+            counts=self.skill_runs,
+            cohort_runs=self.cohort_runs,
         )
-    return out
+
+    def as_row(self, key: _SkillMatrixKey) -> SkillTriggerMatrixRow:
+        repo, role, backend, skill = key
+        return SkillTriggerMatrixRow(
+            repo=repo,
+            skill=skill,
+            agent_role=role,
+            backend=backend,
+            runs=self.cohort_runs.get((repo, role, backend), 0),
+            skill_runs=self.skill_runs.get(key, 0),
+        )
+
+
+def _skill_trigger_matrix_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+    limit: int,
+) -> list[SkillTriggerMatrixRow]:
+    catalog = _skill_catalog(_skill_catalog_rows(query, filters))
+    counts = _SkillMatrixCounts.from_rows(_skill_run_rows(query, filters))
+    keys = sorted(counts.matrix_keys(catalog), key=counts.order_key)
+    if limit > 0:
+        keys = keys[:limit]
+    return [counts.as_row(key) for key in keys]
 
 
 def get_skill_trigger_matrix(
@@ -398,115 +491,49 @@ def get_skill_trigger_matrix(
     non-positive `limit` disables the cap) so the dashboard's fold-out
     never floods the page.
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
         return []
     if _agent_event_excluded(events):
         return []
-    connect_fn = connect or _default_connect
+    filters = _WindowFilters(
+        start=start,
+        end=end,
+        repo=repo,
+        stages=stages,
+        issue=issue,
+    )
+    return _skill_trigger_matrix_rows(query, filters, limit)
 
-    # 1. Catalog universe. Catalog records are repo-level (issue == 0,
-    #    NULL stage), so only the date / repo filters apply -- pushing
-    #    the issue / stage filters down here would drop every row.
-    cat_where, cat_params = _build_window_where(
-        start=start, end=end, repo=repo,
-        events=None, stages=None, issue=None,
-    )
-    cat_clause = (
-        f"{cat_where} AND event = 'repo_skill_catalog'"
-        if cat_where
-        else " WHERE event = 'repo_skill_catalog'"
-    )
-    cat_sql = (
-        "SELECT repo, extras -> 'skills_available' AS skills_available "
-        f"FROM analytics_events{cat_clause}"
-    )
-    cat_rows = _query(connect_fn, url, cat_sql, cat_params, conn=conn)
-    catalog: dict[str, set[str]] = {}
-    for row in cat_rows:
-        if row[0] is None:
-            continue
-        c_repo = str(row[0])
-        names = _as_skill_names(row[1] if len(row) > 1 else None)
-        # `setdefault` even on an empty catalog so a "scanned, found
-        # none" record still registers the repo (it just contributes no
-        # zero rows).
-        catalog.setdefault(c_repo, set()).update(names)
 
-    # 2. Observed triggers. One `(repo, role, backend)` cohort per
-    #    agent-exit run plus the distinct skills it fired. `skills_triggered`
-    #    is already de-duplicated per run, but the per-row `set()` guards
-    #    against a malformed array so a name is never double-counted.
-    run_where, run_params = _build_window_where(
-        start=start, end=end, repo=repo,
-        events=None, stages=stages, issue=issue,
+def _cost_coverage_from_row(row: Sequence[Any]) -> CostCoverageRow:
+    return CostCoverageRow(
+        cost_source=str(row[0]),
+        runs=int(row[1] or 0),
+        total_tokens=int(_row_value(row, 2) or 0),
     )
-    run_clause = (
-        f"{run_where} AND event = 'agent_exit'"
-        if run_where
-        else " WHERE event = 'agent_exit'"
+
+
+def _cost_coverage_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+) -> list[CostCoverageRow]:
+    where, params = _build_view_window_where(filters)
+    rows = query.select(
+        "SELECT "
+        "COALESCE(cost_source, 'unknown') AS source_label, "
+        "COUNT(*) AS runs, "
+        "COALESCE(SUM("
+        "  COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0) + "
+        "  COALESCE(cache_read_tokens, 0) + "
+        "  COALESCE(cache_write_tokens, 0)"
+        "), 0) AS source_total_tokens "
+        f"FROM analytics_agent_runs{where} "
+        "GROUP BY source_label "
+        "ORDER BY runs DESC, source_label ASC",
+        params,
     )
-    run_sql = (
-        "SELECT repo, "
-        "COALESCE(agent_role, 'unknown') AS role_label, "
-        "COALESCE(backend, 'unknown') AS backend_label, "
-        "extras -> 'skills_triggered' AS skills_triggered "
-        f"FROM analytics_events{run_clause}"
-    )
-    run_rows = _query(connect_fn, url, run_sql, run_params, conn=conn)
-
-    cohort_runs: dict[tuple[str, str, str], int] = {}
-    counts: dict[tuple[str, str, str, str], int] = {}
-    for row in run_rows:
-        r_repo = _label_or_unknown(row[0])
-        role = _row_label(row, 1)
-        backend = _row_label(row, 2)
-        cohort = (r_repo, role, backend)
-        # One agent-exit row == one run in the cohort, regardless of how
-        # many (or whether any) skills it fired.
-        cohort_runs[cohort] = cohort_runs.get(cohort, 0) + 1
-        names = _as_skill_names(row[3] if len(row) > 3 else None)
-        for skill in set(names):
-            key = (r_repo, role, backend, skill)
-            counts[key] = counts.get(key, 0) + 1
-
-    # 3. Assemble the matrix: every observed cell carries its skill-run
-    #    count, and every catalog skill is zero-padded across the cohorts
-    #    seen for that repo. `catalog.get(repo, ())` yields no skills when
-    #    the catalog is missing, so the fall-back path emits only the
-    #    observed-trigger cells.
-    keys: set[tuple[str, str, str, str]] = set(counts)
-    for (catalog_repo, catalog_role, catalog_backend) in cohort_runs:
-        for catalog_skill in catalog.get(catalog_repo, ()):
-            keys.add((catalog_repo, catalog_role, catalog_backend, catalog_skill))
-
-    ordered = sorted(
-        keys,
-        key=partial(
-            _skill_matrix_order_key,
-            counts=counts,
-            cohort_runs=cohort_runs,
-        ),
-    )
-    if limit > 0:
-        ordered = ordered[:limit]
-
-    out: list[SkillTriggerMatrixRow] = []
-    for key in ordered:
-        matrix_repo, matrix_role, matrix_backend, matrix_skill = key
-        out.append(
-            SkillTriggerMatrixRow(
-                repo=matrix_repo,
-                skill=matrix_skill,
-                agent_role=matrix_role,
-                backend=matrix_backend,
-                runs=cohort_runs.get(
-                    (matrix_repo, matrix_role, matrix_backend), 0
-                ),
-                skill_runs=counts.get(key, 0),
-            )
-        )
-    return out
+    return [_cost_coverage_from_row(row) for row in rows]
 
 
 def get_cost_coverage(
@@ -533,51 +560,51 @@ def get_cost_coverage(
     not priced). The `events` filter is honored by short-circuit
     against `_agent_event_excluded`.
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
         return []
     if _agent_event_excluded(events):
         return []
-    connect_fn = connect or _default_connect
-    where, params = _build_view_window_where(
-        start=start, end=end, repo=repo,
-        stages=stages, issue=issue,
+    filters = _WindowFilters(
+        start=start,
+        end=end,
+        repo=repo,
+        stages=stages,
+        issue=issue,
     )
-    sql = (
+    return _cost_coverage_rows(query, filters)
+
+
+def _backend_daily_tokens_from_row(
+    row: Sequence[Any],
+) -> BackendDailyTokensRow:
+    return BackendDailyTokensRow(
+        day=_day_value(row[0]),
+        backend=str(row[1]),
+        total_tokens=int(row[2] or 0),
+    )
+
+
+def _backend_daily_token_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+) -> list[BackendDailyTokensRow]:
+    where, params = _build_view_window_where(filters)
+    rows = query.select(
         "SELECT "
-        "COALESCE(cost_source, 'unknown') AS source_label, "
-        "COUNT(*) AS runs, "
-        # Tokens-by-cost-source rollup so the dashboard can render
-        # coverage as a token share. The view exposes the cache
-        # columns; the standalone mock totals
-        # `input + output + cache_read + cache_write` per row, so
-        # we mirror that accounting here.
+        "date_trunc('day', ts)::date AS day, "
+        "COALESCE(backend, 'unknown') AS backend_label, "
         "COALESCE(SUM("
         "  COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0) + "
         "  COALESCE(cache_read_tokens, 0) + "
         "  COALESCE(cache_write_tokens, 0)"
-        "), 0) AS source_total_tokens "
+        "), 0) AS day_backend_tokens "
         f"FROM analytics_agent_runs{where} "
-        "GROUP BY source_label "
-        "ORDER BY runs DESC, source_label ASC"
+        "GROUP BY day, backend_label "
+        "ORDER BY day ASC, backend_label ASC",
+        params,
     )
-    rows = _query(connect_fn, url, sql, params, conn=conn)
-    out: list[CostCoverageRow] = []
-    for row in rows:
-        source = row[0]
-        runs = row[1]
-        # Older fixtures may still emit 2-tuple rows; default the
-        # token total to 0 so the test harness does not have to
-        # know about the new SQL column in unrelated cases.
-        tokens = row[2] if len(row) > 2 else 0
-        out.append(
-            CostCoverageRow(
-                cost_source=str(source),
-                runs=int(runs or 0),
-                total_tokens=int(tokens or 0),
-            )
-        )
-    return out
+    return [_backend_daily_tokens_from_row(row) for row in rows]
 
 
 def get_backend_daily_tokens(
@@ -605,46 +632,55 @@ def get_backend_daily_tokens(
     is honored by short-circuit against `_agent_event_excluded` --
     see `get_review_round_breakdown` for the rationale.
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
         return []
     if _agent_event_excluded(events):
         return []
-    connect_fn = connect or _default_connect
-    where, params = _build_view_window_where(
-        start=start, end=end, repo=repo,
-        stages=stages, issue=issue,
+    filters = _WindowFilters(
+        start=start,
+        end=end,
+        repo=repo,
+        stages=stages,
+        issue=issue,
     )
-    sql = (
+    return _backend_daily_token_rows(query, filters)
+
+
+def _hourly_heatmap_from_row(row: Sequence[Any]) -> HourlyHeatmapPoint:
+    return HourlyHeatmapPoint(
+        weekday=int(row[0]),
+        hour=int(row[1]),
+        count=int(row[2] or 0),
+        total_tokens=int(_row_value(row, 3) or 0),
+    )
+
+
+def _hourly_heatmap_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+    tz_offset_hours: int,
+) -> list[HourlyHeatmapPoint]:
+    where, params = _build_window_where(filters)
+    offset = int(tz_offset_hours)
+    rows = query.select(
         "SELECT "
-        "date_trunc('day', ts)::date AS day, "
-        "COALESCE(backend, 'unknown') AS backend_label, "
-        # Token total includes cache_read / cache_write so the
-        # backend stack mirrors the standalone mock's
-        # `input + output + cache_read + cache_write` accounting.
+        "EXTRACT(DOW FROM ((ts AT TIME ZONE 'UTC') "
+        "+ %s * INTERVAL '1 hour'))::int AS weekday, "
+        "EXTRACT(HOUR FROM ((ts AT TIME ZONE 'UTC') "
+        "+ %s * INTERVAL '1 hour'))::int AS hour, "
+        "COUNT(*) AS c, "
         "COALESCE(SUM("
         "  COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0) + "
         "  COALESCE(cache_read_tokens, 0) + "
         "  COALESCE(cache_write_tokens, 0)"
-        "), 0) AS day_backend_tokens "
-        f"FROM analytics_agent_runs{where} "
-        "GROUP BY day, backend_label "
-        "ORDER BY day ASC, backend_label ASC"
+        "), 0) AS cell_total_tokens "
+        f"FROM analytics_events{where} "
+        "GROUP BY weekday, hour "
+        "ORDER BY weekday ASC, hour ASC",
+        [offset, offset, *params],
     )
-    rows = _query(connect_fn, url, sql, params, conn=conn)
-    out: list[BackendDailyTokensRow] = []
-    for row in rows:
-        day_value, backend, tokens = row
-        if isinstance(day_value, datetime):
-            day_value = day_value.date()
-        out.append(
-            BackendDailyTokensRow(
-                day=day_value,
-                backend=str(backend),
-                total_tokens=int(tokens or 0),
-            )
-        )
-    return out
+    return [_hourly_heatmap_from_row(row) for row in rows]
 
 
 def get_hourly_heatmap(
@@ -674,56 +710,15 @@ def get_hourly_heatmap(
     the heatmap in a non-UTC timezone (the orchestrator stores
     `ts` in UTC). Zero is the historical behavior.
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
         return []
-    connect_fn = connect or _default_connect
-    where, params = _build_window_where(
-        start=start, end=end, repo=repo,
-        events=events, stages=stages, issue=issue,
+    filters = _WindowFilters(
+        start=start,
+        end=end,
+        repo=repo,
+        events=events,
+        stages=stages,
+        issue=issue,
     )
-    # Normalize `ts` (TIMESTAMPTZ) to a UTC naive `TIMESTAMP` via
-    # `AT TIME ZONE 'UTC'` before applying the offset and extracting.
-    # `EXTRACT()` on a TIMESTAMPTZ is read in the database session
-    # timezone, so without this normalization a non-UTC session would
-    # shift the buckets again on top of our explicit offset.
-    # Parameterised so the integer is never spliced into the SQL.
-    sql = (
-        "SELECT "
-        "EXTRACT(DOW FROM ((ts AT TIME ZONE 'UTC') "
-        "+ %s * INTERVAL '1 hour'))::int AS weekday, "
-        "EXTRACT(HOUR FROM ((ts AT TIME ZONE 'UTC') "
-        "+ %s * INTERVAL '1 hour'))::int AS hour, "
-        "COUNT(*) AS c, "
-        # Per-cell token volume so the dashboard heatmap can render
-        # token intensity instead of event count -- matching the
-        # standalone mock's "Token volume by hour x weekday" panel.
-        "COALESCE(SUM("
-        "  COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0) + "
-        "  COALESCE(cache_read_tokens, 0) + "
-        "  COALESCE(cache_write_tokens, 0)"
-        "), 0) AS cell_total_tokens "
-        f"FROM analytics_events{where} "
-        "GROUP BY weekday, hour "
-        "ORDER BY weekday ASC, hour ASC"
-    )
-    offset_int = int(tz_offset_hours)
-    params = [offset_int, offset_int, *params]
-    rows = _query(connect_fn, url, sql, params, conn=conn)
-    out: list[HourlyHeatmapPoint] = []
-    for row in rows:
-        weekday = row[0]
-        hour = row[1]
-        count = row[2]
-        # Older 3-tuple fixtures (no token column) round-trip with
-        # zero token volume so unrelated tests keep working.
-        tokens = row[3] if len(row) > 3 else 0
-        out.append(
-            HourlyHeatmapPoint(
-                weekday=int(weekday),
-                hour=int(hour),
-                count=int(count or 0),
-                total_tokens=int(tokens or 0),
-            )
-        )
-    return out
+    return _hourly_heatmap_rows(query, filters, tz_offset_hours)

--- a/orchestrator/analytics/read_raw.py
+++ b/orchestrator/analytics/read_raw.py
@@ -21,10 +21,13 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Callable, Optional, Sequence
 
-from orchestrator.analytics.connection import _default_connect
-from orchestrator.analytics.db_url import _resolve_db_url
-from orchestrator.analytics.predicates import _build_window_where
-from orchestrator.analytics.query import _query
+from orchestrator.analytics.predicates import (
+    _WindowFilters,
+    _agent_event_excluded,
+    _build_window_where,
+    _prepend_where_condition,
+)
+from orchestrator.analytics.query import _ReadQuery
 from orchestrator.analytics.read_models import (
     AgentExitRow,
     DataExtent,
@@ -52,6 +55,12 @@ def _float_or_none(raw: Any) -> Optional[float]:
     return float(raw)
 
 
+def _row_int(row: Sequence[Any], index: int) -> int:
+    if len(row) <= index:
+        return 0
+    return int(row[index] or 0)
+
+
 def _bool_or_none(raw: Any) -> Optional[bool]:
     if raw is None:
         return None
@@ -62,6 +71,35 @@ def _empty_filter_selected(values: Optional[Sequence[str]]) -> bool:
     if values is None:
         return False
     return len(values) == 0
+
+
+def _filter_options_sql() -> str:
+    return " UNION ".join(
+        f"SELECT '{column}' AS dim, {column} AS value "
+        f"FROM analytics_events WHERE {column} IS NOT NULL"
+        for column in _FILTER_OPTION_COLUMNS
+    )
+
+
+def _filter_options_from_rows(rows: Sequence[tuple]) -> FilterOptions:
+    buckets: dict[str, list[str]] = {
+        column: [] for column in _FILTER_OPTION_COLUMNS
+    }
+    for row in rows:
+        if not row or row[1] is None:
+            continue
+        dimension = row[0]
+        if dimension in buckets:
+            buckets[dimension].append(row[1])
+    for values in buckets.values():
+        values.sort()
+    return FilterOptions(
+        repos=tuple(buckets["repo"]),
+        events=tuple(buckets["event"]),
+        stages=tuple(buckets["stage"]),
+        backends=tuple(buckets["backend"]),
+        agent_roles=tuple(buckets["agent_role"]),
+    )
 
 
 def get_filter_options(
@@ -86,34 +124,10 @@ def get_filter_options(
     Python after the fetch (the lists are tiny -- at most a few
     hundred values per column).
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
         return FilterOptions()
-    connect_fn = connect or _default_connect
-    sql = " UNION ".join(
-        f"SELECT '{col}' AS dim, {col} AS value "
-        f"FROM analytics_events WHERE {col} IS NOT NULL"
-        for col in _FILTER_OPTION_COLUMNS
-    )
-    rows = _query(connect_fn, url, sql, conn=conn)
-    buckets: dict[str, list[str]] = {
-        col: [] for col in _FILTER_OPTION_COLUMNS
-    }
-    for row in rows:
-        if not row or row[1] is None:
-            continue
-        dim = row[0]
-        if dim in buckets:
-            buckets[dim].append(row[1])
-    for values in buckets.values():
-        values.sort()
-    return FilterOptions(
-        repos=tuple(buckets["repo"]),
-        events=tuple(buckets["event"]),
-        stages=tuple(buckets["stage"]),
-        backends=tuple(buckets["backend"]),
-        agent_roles=tuple(buckets["agent_role"]),
-    )
+    return _filter_options_from_rows(query.select(_filter_options_sql()))
 
 
 def get_data_extent(
@@ -130,21 +144,34 @@ def get_data_extent(
     `DataExtent()` (both fields `None`) when the DB URL is unset or
     the table is empty.
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
         return DataExtent()
-    connect_fn = connect or _default_connect
-    rows = _query(
-        connect_fn,
-        url,
+    rows = query.select(
         "SELECT MIN(ts) AS data_min_ts, MAX(ts) AS data_max_ts "
         "FROM analytics_events",
-        conn=conn,
     )
     if not rows:
         return DataExtent()
     min_ts, max_ts = rows[0]
     return DataExtent(min_ts=min_ts, max_ts=max_ts)
+
+
+def _event_breakdown_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+) -> list[EventBreakdown]:
+    where, params = _build_window_where(filters)
+    rows = query.select(
+        "SELECT event, COUNT(*) AS c "
+        f"FROM analytics_events{where} "
+        "GROUP BY event ORDER BY c DESC, event ASC",
+        params,
+    )
+    return [
+        EventBreakdown(event=event, count=int(count))
+        for event, count in rows
+    ]
 
 
 def get_event_breakdown(
@@ -164,21 +191,62 @@ def get_event_breakdown(
     Mirrors `get_stage_breakdown`'s shape so the dashboard can render
     the two side-by-side without divergent typing.
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
         return []
-    connect_fn = connect or _default_connect
-    where, params = _build_window_where(
-        start=start, end=end, repo=repo,
-        events=events, stages=stages, issue=issue,
+    filters = _WindowFilters(
+        start=start,
+        end=end,
+        repo=repo,
+        events=events,
+        stages=stages,
+        issue=issue,
     )
-    sql = (
-        "SELECT event, COUNT(*) AS c "
+    return _event_breakdown_rows(query, filters)
+
+
+def _agent_exit_from_row(row: Sequence[Any]) -> AgentExitRow:
+    return AgentExitRow(
+        ts=row[0],
+        repo=row[1],
+        issue=int(row[2]),
+        stage=row[3],
+        agent_role=row[4],
+        backend=row[5],
+        duration_s=_float_or_none(row[6]),
+        exit_code=_int_or_none(row[7]),
+        timed_out=_bool_or_none(row[8]),
+        review_round=_int_or_none(row[9]),
+        retry_count=_int_or_none(row[10]),
+        input_tokens=_int_or_none(row[11]),
+        output_tokens=_int_or_none(row[12]),
+        cost_usd=_float_or_none(row[13]),
+        cost_source=row[14],
+    )
+
+
+def _recent_agent_exit_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+    limit: int,
+) -> list[AgentExitRow]:
+    if _agent_event_excluded(filters.events):
+        return []
+    if _empty_filter_selected(filters.stages):
+        return []
+    where, params = _build_window_where(filters.without_events())
+    where = _prepend_where_condition(where, "event = %s")
+    params.insert(0, "agent_exit")
+    params.append(int(limit))
+    rows = query.select(
+        "SELECT ts, repo, issue, stage, agent_role, backend, "
+        "duration_s, exit_code, timed_out, review_round, retry_count, "
+        "input_tokens, output_tokens, cost_usd, cost_source "
         f"FROM analytics_events{where} "
-        "GROUP BY event ORDER BY c DESC, event ASC"
+        "ORDER BY ts DESC LIMIT %s",
+        params,
     )
-    rows = _query(connect_fn, url, sql, params, conn=conn)
-    return [EventBreakdown(event=ev, count=int(c)) for ev, c in rows]
+    return [_agent_exit_from_row(row) for row in rows]
 
 
 def get_recent_agent_exits(
@@ -210,86 +278,20 @@ def get_recent_agent_exits(
     which is the consistent answer when the operator excludes the
     rows this widget displays.
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
-        return []
+    query = _ReadQuery.resolve(db_url, connect, conn)
     if limit <= 0:
         return []
-    # Operator deselected agent_exit from the events multiselect;
-    # this widget is exclusively about agent_exit rows, so short
-    # circuit to an empty table without a DB round trip.
-    if events is not None and "agent_exit" not in events:
+    if not query.available:
         return []
-    connect_fn = connect or _default_connect
-    conditions = ["event = %s"]
-    params: list[Any] = ["agent_exit"]
-    if start is not None:
-        conditions.append("ts >= %s")
-        params.append(start)
-    if end is not None:
-        conditions.append("ts < %s")
-        params.append(end)
-    if repo is not None:
-        conditions.append("repo = %s")
-        params.append(repo)
-    if issue is not None:
-        conditions.append("issue = %s")
-        params.append(int(issue))
-    if stages is not None:
-        if not stages:
-            return []
-        placeholders = ", ".join(["%s"] * len(stages))
-        conditions.append(f"stage IN ({placeholders})")
-        params.extend(stages)
-    where = " WHERE " + " AND ".join(conditions)
-    params.append(int(limit))
-    sql = (
-        "SELECT ts, repo, issue, stage, agent_role, backend, "
-        "duration_s, exit_code, timed_out, review_round, retry_count, "
-        "input_tokens, output_tokens, cost_usd, cost_source "
-        f"FROM analytics_events{where} "
-        "ORDER BY ts DESC LIMIT %s"
+    filters = _WindowFilters(
+        start=start,
+        end=end,
+        repo=repo,
+        events=events,
+        stages=stages,
+        issue=issue,
     )
-    rows = _query(connect_fn, url, sql, params, conn=conn)
-    out: list[AgentExitRow] = []
-    for row in rows:
-        (
-            ts,
-            repo_v,
-            issue_v,
-            stage,
-            agent_role,
-            backend,
-            duration_s,
-            exit_code,
-            timed_out,
-            review_round,
-            retry_count,
-            input_tokens,
-            output_tokens,
-            cost_usd,
-            cost_source,
-        ) = row
-        out.append(
-            AgentExitRow(
-                ts=ts,
-                repo=repo_v,
-                issue=int(issue_v),
-                stage=stage,
-                agent_role=agent_role,
-                backend=backend,
-                duration_s=_float_or_none(duration_s),
-                exit_code=_int_or_none(exit_code),
-                timed_out=_bool_or_none(timed_out),
-                review_round=_int_or_none(review_round),
-                retry_count=_int_or_none(retry_count),
-                input_tokens=_int_or_none(input_tokens),
-                output_tokens=_int_or_none(output_tokens),
-                cost_usd=_float_or_none(cost_usd),
-                cost_source=cost_source,
-            )
-        )
-    return out
+    return _recent_agent_exit_rows(query, filters, limit)
 
 
 SORT_BY_LAST_SEEN = "last_seen"
@@ -297,6 +299,72 @@ SORT_BY_COST = "cost"
 _ISSUE_SORT_BY_OPTIONS: frozenset[str] = frozenset(
     {SORT_BY_LAST_SEEN, SORT_BY_COST}
 )
+
+
+def _issue_order_sql(sort_by: str) -> str:
+    if sort_by == SORT_BY_COST:
+        return (
+            "ORDER BY SUM(cost_usd) DESC NULLS LAST, "
+            "last_seen DESC, repo ASC, issue ASC"
+        )
+    return "ORDER BY last_seen DESC, repo ASC, issue ASC"
+
+
+def _issues_sql(where: str, sort_by: str) -> str:
+    return (
+        "SELECT "
+        "repo, issue, "
+        "COUNT(*) AS event_count, "
+        "MIN(ts) AS first_seen, "
+        "MAX(ts) AS last_seen, "
+        "(array_agg(stage ORDER BY ts DESC) "
+        "  FILTER (WHERE stage IS NOT NULL))[1] AS latest_stage, "
+        "SUM(CASE WHEN event = 'agent_exit' THEN 1 ELSE 0 END) "
+        "  AS agent_exits, "
+        "SUM(cost_usd) AS total_cost_usd, "
+        "COALESCE(SUM(input_tokens), 0) AS total_input_tokens, "
+        "COALESCE(SUM(output_tokens), 0) AS total_output_tokens, "
+        "MAX(review_round) AS max_review_round, "
+        "SUM(CASE WHEN event = 'agent_exit' AND exit_code <> 0 "
+        "         THEN 1 ELSE 0 END) AS failed_agent_runs, "
+        "MAX(retry_count) AS max_retry_count "
+        f"FROM analytics_events{where} "
+        "GROUP BY repo, issue "
+        f"{_issue_order_sql(sort_by)} "
+        "LIMIT %s"
+    )
+
+
+def _issue_summary_from_row(row: Sequence[Any]) -> IssueSummaryRow:
+    return IssueSummaryRow(
+        repo=row[0],
+        issue=int(row[1]),
+        event_count=int(row[2] or 0),
+        first_seen=row[3],
+        last_seen=row[4],
+        latest_stage=row[5],
+        agent_exits=int(row[6] or 0),
+        total_cost_usd=_float_or_none(row[7]),
+        total_input_tokens=int(row[8] or 0),
+        total_output_tokens=int(row[9] or 0),
+        max_review_round=_int_or_none(row[10] if len(row) > 10 else None),
+        failed_agent_runs=_row_int(row, 11),
+        max_retry_count=_int_or_none(row[12] if len(row) > 12 else None),
+    )
+
+
+def _issue_summary_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+    limit: int,
+    sort_by: str,
+) -> list[IssueSummaryRow]:
+    where, params = _build_window_where(filters)
+    rows = query.select(
+        _issues_sql(where, sort_by),
+        [*params, int(limit)],
+    )
+    return [_issue_summary_from_row(row) for row in rows]
 
 
 def get_issues(
@@ -353,93 +421,52 @@ def get_issues(
             f"unknown sort_by {sort_by!r}; expected one of "
             f"{sorted(_ISSUE_SORT_BY_OPTIONS)}"
         )
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
-        return []
+    query = _ReadQuery.resolve(db_url, connect, conn)
     if limit <= 0:
         return []
-    connect_fn = connect or _default_connect
-    where, params = _build_window_where(
-        start=start, end=end, repo=repo,
-        events=events, stages=stages, issue=issue,
+    if not query.available:
+        return []
+    filters = _WindowFilters(
+        start=start,
+        end=end,
+        repo=repo,
+        events=events,
+        stages=stages,
+        issue=issue,
     )
-    # Order primary key matches `sort_by`; secondary keys
-    # (`last_seen DESC, repo ASC, issue ASC`) keep the ordering
-    # deterministic when the primary key ties.
-    if sort_by == SORT_BY_COST:
-        order_sql = (
-            "ORDER BY SUM(cost_usd) DESC NULLS LAST, "
-            "last_seen DESC, repo ASC, issue ASC"
-        )
-    else:
-        order_sql = "ORDER BY last_seen DESC, repo ASC, issue ASC"
-    sql = (
-        "SELECT "
-        "repo, issue, "
-        "COUNT(*) AS event_count, "
-        "MIN(ts) AS first_seen, "
-        "MAX(ts) AS last_seen, "
-        "(array_agg(stage ORDER BY ts DESC) "
-        "  FILTER (WHERE stage IS NOT NULL))[1] AS latest_stage, "
-        "SUM(CASE WHEN event = 'agent_exit' THEN 1 ELSE 0 END) "
-        "  AS agent_exits, "
-        "SUM(cost_usd) AS total_cost_usd, "
-        "COALESCE(SUM(input_tokens), 0) AS total_input_tokens, "
-        "COALESCE(SUM(output_tokens), 0) AS total_output_tokens, "
-        # `review_round` is only ever set on agent_exit rows so a
-        # plain MAX is correct -- the filter is implicit.
-        "MAX(review_round) AS max_review_round, "
-        "SUM(CASE WHEN event = 'agent_exit' AND exit_code <> 0 "
-        "         THEN 1 ELSE 0 END) AS failed_agent_runs, "
-        # `retry_count` is also only ever set on agent_exit rows,
-        # so a plain MAX picks the highest retry the implementer
-        # ever rode up to before the issue cleared. The redesigned
-        # "Most expensive issues" table renders this as the
-        # "Retries" column matching the standalone mock.
-        "MAX(retry_count) AS max_retry_count "
+    return _issue_summary_rows(query, filters, limit, sort_by)
+
+
+def _issue_event_from_row(row: Sequence[Any]) -> IssueEventRow:
+    return IssueEventRow(
+        ts=row[0],
+        event=row[1],
+        stage=row[2],
+        duration_s=_float_or_none(row[3]),
+        result=row[4],
+        agent_role=row[5],
+        backend=row[6],
+        exit_code=_int_or_none(row[7]),
+        cost_usd=_float_or_none(row[8]),
+    )
+
+
+def _issue_event_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+    repo: str,
+    issue: int,
+) -> list[IssueEventRow]:
+    where, params = _build_window_where(filters)
+    where = _prepend_where_condition(where, "repo = %s AND issue = %s")
+    rows = query.select(
+        "SELECT ts, event, stage, duration_s, result, "
+        "agent_role, backend, exit_code, cost_usd "
         f"FROM analytics_events{where} "
-        "GROUP BY repo, issue "
-        f"{order_sql} "
-        "LIMIT %s"
+        "ORDER BY ts ASC, id ASC",
+        [repo, int(issue), *params],
     )
-    bound_params = list(params) + [int(limit)]
-    rows = _query(connect_fn, url, sql, bound_params, conn=conn)
-    out: list[IssueSummaryRow] = []
-    for row in rows:
-        repo_v = row[0]
-        issue_v = row[1]
-        event_count = row[2]
-        first_seen = row[3]
-        last_seen = row[4]
-        latest_stage = row[5]
-        agent_exits = row[6]
-        total_cost_usd = row[7]
-        total_input_tokens = row[8]
-        total_output_tokens = row[9]
-        # Old fixtures may still emit 10- or 12-tuple rows; default
-        # the extensions to None / 0 so tests written against the
-        # prior shape continue to round-trip.
-        max_review_round = row[10] if len(row) > 10 else None
-        failed_agent_runs = row[11] if len(row) > 11 else 0
-        max_retry_count = row[12] if len(row) > 12 else None
-        out.append(
-            IssueSummaryRow(
-                repo=repo_v,
-                issue=int(issue_v),
-                event_count=int(event_count or 0),
-                first_seen=first_seen,
-                last_seen=last_seen,
-                latest_stage=latest_stage,
-                agent_exits=int(agent_exits or 0),
-                total_cost_usd=_float_or_none(total_cost_usd),
-                total_input_tokens=int(total_input_tokens or 0),
-                total_output_tokens=int(total_output_tokens or 0),
-                max_review_round=_int_or_none(max_review_round),
-                failed_agent_runs=int(failed_agent_runs or 0),
-                max_retry_count=_int_or_none(max_retry_count),
-            )
-        )
-    return out
+    return [_issue_event_from_row(row) for row in rows]
 
 
 def get_issue_events(
@@ -465,62 +492,17 @@ def get_issue_events(
     / `stages` follow the standard shape: ``None`` = no filter,
     empty = no rows match, non-empty = ``IN (...)``.
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
-        return []
     if _empty_filter_selected(events):
         return []
     if _empty_filter_selected(stages):
         return []
-    connect_fn = connect or _default_connect
-    conditions = ["repo = %s", "issue = %s"]
-    params: list[Any] = [repo, int(issue)]
-    if start is not None:
-        conditions.append("ts >= %s")
-        params.append(start)
-    if end is not None:
-        conditions.append("ts < %s")
-        params.append(end)
-    if events:
-        placeholders = ", ".join(["%s"] * len(events))
-        conditions.append(f"event IN ({placeholders})")
-        params.extend(events)
-    if stages:
-        placeholders = ", ".join(["%s"] * len(stages))
-        conditions.append(f"stage IN ({placeholders})")
-        params.extend(stages)
-    sql = (
-        "SELECT ts, event, stage, duration_s, result, "
-        "agent_role, backend, exit_code, cost_usd "
-        "FROM analytics_events "
-        f"WHERE {' AND '.join(conditions)} "
-        "ORDER BY ts ASC, id ASC"
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
+        return []
+    filters = _WindowFilters(
+        start=start,
+        end=end,
+        events=events,
+        stages=stages,
     )
-    rows = _query(connect_fn, url, sql, params, conn=conn)
-    out: list[IssueEventRow] = []
-    for row in rows:
-        (
-            ts,
-            event,
-            stage,
-            duration_s,
-            result,
-            agent_role,
-            backend,
-            exit_code,
-            cost_usd,
-        ) = row
-        out.append(
-            IssueEventRow(
-                ts=ts,
-                event=event,
-                stage=stage,
-                duration_s=_float_or_none(duration_s),
-                result=result,
-                agent_role=agent_role,
-                backend=backend,
-                exit_code=_int_or_none(exit_code),
-                cost_usd=_float_or_none(cost_usd),
-            )
-        )
-    return out
+    return _issue_event_rows(query, filters, repo, issue)

--- a/orchestrator/analytics/read_rollup.py
+++ b/orchestrator/analytics/read_rollup.py
@@ -20,18 +20,19 @@ remaining view-backed dashboard chart breakdowns in
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import replace
 from datetime import datetime
 from typing import Any, Callable, Optional, Sequence
 
-from orchestrator.analytics.connection import _default_connect
-from orchestrator.analytics.db_url import _resolve_db_url
 from orchestrator.analytics.predicates import (
     _DAILY_ROLLUP_VIEW,
+    _WindowFilters,
     _agent_event_excluded,
+    _append_where_condition,
     _build_rollup_window_where,
+    _prepend_where_condition,
 )
-from orchestrator.analytics.query import _query
+from orchestrator.analytics.query import _ReadQuery
 from orchestrator.analytics.read_models import (
     BackendEfficiencyRow,
     RepoBreakdownRow,
@@ -40,18 +41,6 @@ from orchestrator.analytics.read_models import (
     ThroughputDayRow,
     TimeSeriesPoint,
 )
-
-
-@dataclass(frozen=True)
-class _SummaryFilters:
-    """Filter values applied to the summary's rollup window."""
-
-    start: Optional[datetime]
-    end: Optional[datetime]
-    repo: Optional[str]
-    events: Optional[Sequence[str]]
-    stages: Optional[Sequence[str]]
-    issue: Optional[int]
 
 
 _SUMMARY_TOTAL_FIELD_CASTS = (
@@ -70,17 +59,10 @@ _SUMMARY_TOTAL_FIELD_CASTS = (
 
 
 def _build_summary_where(
-    filters: _SummaryFilters,
+    filters: _WindowFilters,
 ) -> tuple[str, list[Any]]:
     """Build the predicate and bound values for one summary window."""
-    return _build_rollup_window_where(
-        start=filters.start,
-        end=filters.end,
-        repo=filters.repo,
-        events=filters.events,
-        stages=filters.stages,
-        issue=filters.issue,
-    )
+    return _build_rollup_window_where(filters)
 
 
 def _build_summary_sql(where_clause: str) -> str:
@@ -130,22 +112,13 @@ def _build_summary_sql(where_clause: str) -> str:
 
 
 def _query_summary_rows(
-    filters: _SummaryFilters,
-    *,
-    db_url: Optional[str],
-    connect_fn: Callable[[str], Any],
-    conn: Any,
+    query: _ReadQuery,
+    filters: _WindowFilters,
 ) -> list[tuple]:
     """Execute one summary query using the requested connection path."""
     where_clause, query_parameters = _build_summary_where(filters)
     query_sql = _build_summary_sql(where_clause)
-    return _query(
-        connect_fn,
-        db_url,
-        query_sql,
-        query_parameters,
-        conn=conn,
-    )
+    return query.select(query_sql, query_parameters)
 
 
 def _summary_totals_row(rows: Sequence[tuple]) -> Optional[tuple]:
@@ -167,8 +140,12 @@ def _ordered_summary_counts(
         for row in rows
         if row and row[0] == row_kind and row[1] is not None
     ]
-    counts.sort(key=lambda pair: (-pair[1], pair[0]))
+    counts.sort(key=_summary_count_order)
     return dict(counts)
+
+
+def _summary_count_order(pair: tuple[str, int]) -> tuple[int, str]:
+    return -pair[1], pair[0]
 
 
 def _summary_total_values(totals_row: tuple) -> dict[str, Any]:
@@ -196,6 +173,24 @@ def _summary_from_rows(rows: Sequence[tuple]) -> Summary:
     )
 
 
+def _row_value(row: Sequence[Any], index: int, default: Any = 0) -> Any:
+    if len(row) <= index:
+        return default
+    return row[index]
+
+
+def _day_value(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.date()
+    return value
+
+
+def _float_or_none(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    return float(value)
+
+
 def get_summary(
     *,
     start: Optional[datetime] = None,
@@ -218,10 +213,10 @@ def get_summary(
     no rows match. Returns a zero-valued `Summary` when the DB URL
     is unset or the (post-filter) window holds no rows.
     """
-    resolved_url = _resolve_db_url(db_url)
-    if conn is None and not resolved_url:
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
         return Summary()
-    filters = _SummaryFilters(
+    filters = _WindowFilters(
         start=start,
         end=end,
         repo=repo,
@@ -229,13 +224,7 @@ def get_summary(
         stages=stages,
         issue=issue,
     )
-    rows = _query_summary_rows(
-        filters,
-        db_url=resolved_url,
-        connect_fn=connect or _default_connect,
-        conn=conn,
-    )
-    return _summary_from_rows(rows)
+    return _summary_from_rows(_query_summary_rows(query, filters))
 
 
 def get_kpi_prev(
@@ -271,15 +260,22 @@ def get_kpi_prev(
     `events` / `stages` / `issue` are identical to `get_summary` --
     they share `_build_window_where`.
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
         return Summary()
-    connect_fn = connect or _default_connect
-    where, params = _build_rollup_window_where(
-        start=start, end=end, repo=repo,
-        events=events, stages=stages, issue=issue,
+    filters = _WindowFilters(
+        start=start,
+        end=end,
+        repo=repo,
+        events=events,
+        stages=stages,
+        issue=issue,
     )
-    sql = (
+    return _kpi_prev_summary(query, filters)
+
+
+def _kpi_prev_sql(where: str) -> str:
+    return (
         "SELECT "
         "COALESCE(SUM(total_cost_usd), 0) AS total_cost_usd, "
         "COALESCE(SUM(total_input_tokens), 0) AS total_input_tokens, "
@@ -293,7 +289,14 @@ def get_kpi_prev(
         "  AS total_agent_runs "
         f"FROM {_DAILY_ROLLUP_VIEW}{where}"
     )
-    rows = _query(connect_fn, url, sql, params, conn=conn)
+
+
+def _kpi_prev_summary(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+) -> Summary:
+    where, params = _build_rollup_window_where(filters)
+    rows = query.select(_kpi_prev_sql(where), params)
     if not rows:
         return Summary()
     row = rows[0]
@@ -303,8 +306,44 @@ def get_kpi_prev(
         total_output_tokens=int(row[2] or 0),
         total_cache_read_tokens=int(row[3] or 0),
         total_cache_write_tokens=int(row[4] or 0),
-        total_agent_runs=int(row[5] or 0) if len(row) > 5 else 0,
+        total_agent_runs=int(_row_value(row, 5) or 0),
     )
+
+
+def _time_series_from_row(row: Sequence[Any]) -> TimeSeriesPoint:
+    return TimeSeriesPoint(
+        day=_day_value(row[0]),
+        event=row[1],
+        count=int(row[2]),
+        cost_usd=float(_row_value(row, 3, 0.0) or 0.0),
+        input_tokens=int(_row_value(row, 4) or 0),
+        output_tokens=int(_row_value(row, 5) or 0),
+        cache_read_tokens=int(_row_value(row, 6) or 0),
+        cache_write_tokens=int(_row_value(row, 7) or 0),
+    )
+
+
+def _time_series_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+) -> list[TimeSeriesPoint]:
+    where, params = _build_rollup_window_where(filters)
+    rows = query.select(
+        "SELECT day, event, "
+        "COALESCE(SUM(event_count), 0) AS c, "
+        "COALESCE(SUM(total_cost_usd), 0) AS day_cost_usd, "
+        "COALESCE(SUM(total_input_tokens), 0) AS day_input_tokens, "
+        "COALESCE(SUM(total_output_tokens), 0) AS day_output_tokens, "
+        "COALESCE(SUM(total_cache_read_tokens), 0) "
+        "  AS day_cache_read_tokens, "
+        "COALESCE(SUM(total_cache_write_tokens), 0) "
+        "  AS day_cache_write_tokens "
+        f"FROM {_DAILY_ROLLUP_VIEW}{where} "
+        "GROUP BY day, event "
+        "ORDER BY day ASC, event ASC",
+        params,
+    )
+    return [_time_series_from_row(row) for row in rows]
 
 
 def get_time_series(
@@ -328,58 +367,82 @@ def get_time_series(
     DB round trip. Returns an empty list when the DB URL is unset or
     no rows match.
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
         return []
-    connect_fn = connect or _default_connect
-    where, params = _build_rollup_window_where(
-        start=start, end=end, repo=repo,
-        events=events, stages=stages, issue=issue,
+    filters = _WindowFilters(
+        start=start,
+        end=end,
+        repo=repo,
+        events=events,
+        stages=stages,
+        issue=issue,
     )
-    # Reads directly from the daily rollup: `day` is the GROUP BY
-    # key the view is keyed on, so a per-day per-event aggregate
-    # collapses to a tiny scan compared with the equivalent
-    # `date_trunc('day', ts)` over the events table.
-    sql = (
-        "SELECT day, event, "
+    return _time_series_rows(query, filters)
+
+
+_ROLLUP_CACHE_TOKENS_SQL = (
+    "(COALESCE(total_cached_tokens, 0) "
+    "+ COALESCE(total_cache_read_tokens, 0) "
+    "+ COALESCE(total_cache_write_tokens, 0))"
+)
+_ROLLUP_ALL_TOKENS_SQL = (
+    "(COALESCE(total_input_tokens, 0) "
+    "+ COALESCE(total_output_tokens, 0) "
+    "+ COALESCE(total_cache_read_tokens, 0) "
+    "+ COALESCE(total_cache_write_tokens, 0))"
+)
+_ROLLUP_CACHE_FRACTION_SQL = (
+    f"CASE WHEN {_ROLLUP_ALL_TOKENS_SQL} = 0 THEN 0 "
+    f"ELSE {_ROLLUP_CACHE_TOKENS_SQL}::numeric "
+    f"/ {_ROLLUP_ALL_TOKENS_SQL}::numeric END"
+)
+
+
+def _stage_breakdown_sql(clause: str) -> str:
+    return (
+        "SELECT stage, "
         "COALESCE(SUM(event_count), 0) AS c, "
-        "COALESCE(SUM(total_cost_usd), 0) AS day_cost_usd, "
-        "COALESCE(SUM(total_input_tokens), 0) AS day_input_tokens, "
-        "COALESCE(SUM(total_output_tokens), 0) AS day_output_tokens, "
-        "COALESCE(SUM(total_cache_read_tokens), 0) "
-        "  AS day_cache_read_tokens, "
-        "COALESCE(SUM(total_cache_write_tokens), 0) "
-        "  AS day_cache_write_tokens "
-        f"FROM {_DAILY_ROLLUP_VIEW}{where} "
-        "GROUP BY day, event "
-        "ORDER BY day ASC, event ASC"
+        "SUM(duration_s_sum) / NULLIF(SUM(duration_s_count), 0) "
+        "  AS avg_dur, "
+        "COALESCE(SUM(total_cost_usd), 0) AS stage_cost_usd, "
+        "COALESCE(SUM(total_input_tokens), 0) AS stage_input_tokens, "
+        "COALESCE(SUM(total_output_tokens), 0) AS stage_output_tokens, "
+        "COALESCE(SUM(CASE WHEN event = 'agent_exit' "
+        "                  THEN event_count ELSE 0 END), 0) "
+        "  AS stage_agent_runs, "
+        "COALESCE(SUM(COALESCE(total_cost_usd, 0) "
+        f"* ({_ROLLUP_CACHE_FRACTION_SQL})), 0) AS stage_cache_cost_usd, "
+        "COALESCE(SUM(COALESCE(total_cost_usd, 0) "
+        f"* (1 - ({_ROLLUP_CACHE_FRACTION_SQL}))), 0) "
+        "AS stage_no_cache_cost_usd "
+        f"FROM {_DAILY_ROLLUP_VIEW}{clause} "
+        "GROUP BY stage ORDER BY c DESC, stage ASC"
     )
-    rows = _query(connect_fn, url, sql, params, conn=conn)
-    points: list[TimeSeriesPoint] = []
-    for row in rows:
-        day_value = row[0]
-        event = row[1]
-        count = row[2]
-        cost_usd = row[3] if len(row) > 3 else 0.0
-        input_tokens = row[4] if len(row) > 4 else 0
-        output_tokens = row[5] if len(row) > 5 else 0
-        cache_read_tokens = row[6] if len(row) > 6 else 0
-        cache_write_tokens = row[7] if len(row) > 7 else 0
-        if isinstance(day_value, datetime):
-            day_value = day_value.date()
-        points.append(
-            TimeSeriesPoint(
-                day=day_value,
-                event=event,
-                count=int(count),
-                cost_usd=float(cost_usd or 0.0),
-                input_tokens=int(input_tokens or 0),
-                output_tokens=int(output_tokens or 0),
-                cache_read_tokens=int(cache_read_tokens or 0),
-                cache_write_tokens=int(cache_write_tokens or 0),
-            )
-        )
-    return points
+
+
+def _stage_breakdown_from_row(row: Sequence[Any]) -> StageBreakdown:
+    return StageBreakdown(
+        stage=row[0],
+        count=int(row[1]),
+        avg_duration_s=_float_or_none(row[2]),
+        total_cost_usd=float(_row_value(row, 3, 0.0) or 0.0),
+        total_input_tokens=int(_row_value(row, 4) or 0),
+        total_output_tokens=int(_row_value(row, 5) or 0),
+        runs=int(_row_value(row, 6) or 0),
+        cache_cost_usd=float(_row_value(row, 7, 0.0) or 0.0),
+        no_cache_cost_usd=float(_row_value(row, 8, 0.0) or 0.0),
+    )
+
+
+def _stage_breakdown_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+) -> list[StageBreakdown]:
+    where, params = _build_rollup_window_where(filters)
+    clause = _append_where_condition(where, "stage IS NOT NULL")
+    rows = query.select(_stage_breakdown_sql(clause), params)
+    return [_stage_breakdown_from_row(row) for row in rows]
 
 
 def get_stage_breakdown(
@@ -402,107 +465,65 @@ def get_stage_breakdown(
     columns are summed across the stage so the breakdown can plot
     "spend per stage" without a second query.
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
         return []
-    connect_fn = connect or _default_connect
-    where, params = _build_rollup_window_where(
-        start=start, end=end, repo=repo,
-        events=events, stages=stages, issue=issue,
+    filters = _WindowFilters(
+        start=start,
+        end=end,
+        repo=repo,
+        events=events,
+        stages=stages,
+        issue=issue,
     )
-    clause = (
-        f"{where} AND stage IS NOT NULL"
-        if where
-        else " WHERE stage IS NOT NULL"
-    )
-    # Reads from the daily rollup. `duration_s_sum` / `duration_s_count`
-    # are the prerequisites for `AVG(duration_s)` -- averaging averages
-    # across days does not preserve the row-weighted mean, so the
-    # rollup carries the sum and the non-NULL count separately and
-    # the reader recovers `AVG` as `SUM(sum) / SUM(count)` here.
-    # `NULLIF` keeps the denominator-NULL case (no row in the window
-    # carried a duration) returning NULL rather than raising.
-    #
-    # Each rollup row is split into a cache portion (the share of its
-    # tokens billed as cached / cache-read / cache-write) and a
-    # no-cache portion (the remaining input + output tokens). Cost is
-    # attributed proportionally so the per-stage chart shows what
-    # fraction of spend flowed through the cache vs ran against fresh
-    # tokens -- mirroring `get_review_round_breakdown`'s per-row
-    # proration. Codex `cached_tokens` is a subset of `input_tokens`,
-    # so it stays out of the denominator to avoid double-counting;
-    # Claude `cache_read_tokens` / `cache_write_tokens` are reported
-    # alongside `input_tokens` and so add to the denominator normally.
-    # Proration is per rollup row -- one `(day, repo, issue, event,
-    # stage, backend, cost_source)` bucket -- which is the finest
-    # granularity available without bypassing the rollup.
-    cache_tokens_expr = (
-        "(COALESCE(total_cached_tokens, 0) "
-        "+ COALESCE(total_cache_read_tokens, 0) "
-        "+ COALESCE(total_cache_write_tokens, 0))"
-    )
-    all_tokens_expr = (
-        "(COALESCE(total_input_tokens, 0) "
-        "+ COALESCE(total_output_tokens, 0) "
-        "+ COALESCE(total_cache_read_tokens, 0) "
-        "+ COALESCE(total_cache_write_tokens, 0))"
-    )
-    cache_fraction_expr = (
-        f"CASE WHEN {all_tokens_expr} = 0 THEN 0 "
-        f"ELSE {cache_tokens_expr}::numeric / {all_tokens_expr}::numeric "
-        f"END"
-    )
-    sql = (
-        "SELECT stage, "
-        "COALESCE(SUM(event_count), 0) AS c, "
+    return _stage_breakdown_rows(query, filters)
+
+
+def _backend_efficiency_sql(clause: str) -> str:
+    return (
+        "SELECT "
+        "COALESCE(backend, 'unknown') AS backend_label, "
+        "COALESCE(SUM(event_count), 0) AS runs, "
+        "COALESCE(SUM(failed_count), 0) AS failed_runs, "
         "SUM(duration_s_sum) / NULLIF(SUM(duration_s_count), 0) "
         "  AS avg_dur, "
-        "COALESCE(SUM(total_cost_usd), 0) AS stage_cost_usd, "
-        "COALESCE(SUM(total_input_tokens), 0) AS stage_input_tokens, "
-        "COALESCE(SUM(total_output_tokens), 0) AS stage_output_tokens, "
-        # Agent-run subset of `count`: the rollup carries `event_count`
-        # per `(day, repo, issue, event, stage, backend, cost_source)`
-        # bucket, so summing `event_count` over the agent_exit slice
-        # recovers the per-stage run count without double-counting
-        # rows the way a `COUNT(*)` on the rollup table would.
-        "COALESCE(SUM(CASE WHEN event = 'agent_exit' "
-        "                  THEN event_count ELSE 0 END), 0) "
-        "  AS stage_agent_runs, "
-        "COALESCE(SUM(COALESCE(total_cost_usd, 0) "
-        f"* ({cache_fraction_expr})), 0) AS stage_cache_cost_usd, "
-        "COALESCE(SUM(COALESCE(total_cost_usd, 0) "
-        f"* (1 - ({cache_fraction_expr}))), 0) AS stage_no_cache_cost_usd "
+        "COALESCE(SUM(total_cost_usd), 0) AS backend_cost_usd, "
+        "COALESCE(SUM(total_input_tokens), 0) AS backend_input_tokens, "
+        "COALESCE(SUM(total_output_tokens), 0) AS backend_output_tokens, "
+        "COALESCE(SUM(total_cache_read_tokens), 0) "
+        "  AS backend_cache_read_tokens, "
+        "COALESCE(SUM(total_cache_write_tokens), 0) "
+        "  AS backend_cache_write_tokens "
         f"FROM {_DAILY_ROLLUP_VIEW}{clause} "
-        "GROUP BY stage ORDER BY c DESC, stage ASC"
+        "GROUP BY backend_label "
+        "ORDER BY runs DESC, backend_label ASC"
     )
-    rows = _query(connect_fn, url, sql, params, conn=conn)
-    out: list[StageBreakdown] = []
-    for row in rows:
-        stage = row[0]
-        count = row[1]
-        avg_dur = row[2]
-        cost = row[3] if len(row) > 3 else 0.0
-        in_tok = row[4] if len(row) > 4 else 0
-        out_tok = row[5] if len(row) > 5 else 0
-        runs = row[6] if len(row) > 6 else 0
-        # Older fixtures may still emit rows without the cache split;
-        # default those columns so unrelated tests round-trip.
-        cache_cost = row[7] if len(row) > 7 else 0.0
-        no_cache_cost = row[8] if len(row) > 8 else 0.0
-        out.append(
-            StageBreakdown(
-                stage=stage,
-                count=int(count),
-                avg_duration_s=float(avg_dur) if avg_dur is not None else None,
-                total_cost_usd=float(cost or 0.0),
-                total_input_tokens=int(in_tok or 0),
-                total_output_tokens=int(out_tok or 0),
-                runs=int(runs or 0),
-                cache_cost_usd=float(cache_cost or 0.0),
-                no_cache_cost_usd=float(no_cache_cost or 0.0),
-            )
-        )
-    return out
+
+
+def _backend_efficiency_from_row(
+    row: Sequence[Any],
+) -> BackendEfficiencyRow:
+    return BackendEfficiencyRow(
+        backend=str(row[0]),
+        runs=int(row[1] or 0),
+        failed=int(row[2] or 0),
+        avg_duration_s=_float_or_none(row[3]),
+        total_cost_usd=float(row[4] or 0.0),
+        total_input_tokens=int(row[5] or 0),
+        total_output_tokens=int(row[6] or 0),
+        total_cache_read_tokens=int(_row_value(row, 7) or 0),
+        total_cache_write_tokens=int(_row_value(row, 8) or 0),
+    )
+
+
+def _backend_efficiency_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+) -> list[BackendEfficiencyRow]:
+    where, params = _build_rollup_window_where(filters.without_events())
+    clause = _append_where_condition(where, "event = 'agent_exit'")
+    rows = query.select(_backend_efficiency_sql(clause), params)
+    return [_backend_efficiency_from_row(row) for row in rows]
 
 
 def get_backend_efficiency(
@@ -532,71 +553,49 @@ def get_backend_efficiency(
     `SUM(duration_s_sum) / SUM(duration_s_count)` so averaging
     averages across days never blurs the row-weighted mean.
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
         return []
     if _agent_event_excluded(events):
         return []
-    connect_fn = connect or _default_connect
-    where, params = _build_rollup_window_where(
-        start=start, end=end, repo=repo,
-        events=None, stages=stages, issue=issue,
+    filters = _WindowFilters(
+        start=start,
+        end=end,
+        repo=repo,
+        stages=stages,
+        issue=issue,
     )
-    clause = (
-        f"{where} AND event = 'agent_exit'"
-        if where
-        else " WHERE event = 'agent_exit'"
+    return _backend_efficiency_rows(query, filters)
+
+
+def _repo_breakdown_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+) -> list[RepoBreakdownRow]:
+    where, params = _build_rollup_window_where(filters)
+    rows = query.select(
+        "SELECT repo, "
+        "COUNT(DISTINCT issue) AS repo_issues, "
+        "COALESCE(SUM(event_count), 0) AS repo_events, "
+        "COALESCE(SUM(CASE WHEN event = 'agent_exit' "
+        "                  THEN event_count ELSE 0 END), 0) "
+        "  AS repo_agent_exits, "
+        "COALESCE(SUM(total_cost_usd), 0) AS repo_cost_usd "
+        f"FROM {_DAILY_ROLLUP_VIEW}{where} "
+        "GROUP BY repo "
+        "ORDER BY repo_events DESC, repo ASC",
+        params,
     )
-    sql = (
-        "SELECT "
-        "COALESCE(backend, 'unknown') AS backend_label, "
-        "COALESCE(SUM(event_count), 0) AS runs, "
-        "COALESCE(SUM(failed_count), 0) AS failed_runs, "
-        "SUM(duration_s_sum) / NULLIF(SUM(duration_s_count), 0) "
-        "  AS avg_dur, "
-        "COALESCE(SUM(total_cost_usd), 0) AS backend_cost_usd, "
-        "COALESCE(SUM(total_input_tokens), 0) AS backend_input_tokens, "
-        "COALESCE(SUM(total_output_tokens), 0) AS backend_output_tokens, "
-        "COALESCE(SUM(total_cache_read_tokens), 0) "
-        "  AS backend_cache_read_tokens, "
-        "COALESCE(SUM(total_cache_write_tokens), 0) "
-        "  AS backend_cache_write_tokens "
-        f"FROM {_DAILY_ROLLUP_VIEW}{clause} "
-        "GROUP BY backend_label "
-        "ORDER BY runs DESC, backend_label ASC"
-    )
-    rows = _query(connect_fn, url, sql, params, conn=conn)
-    out: list[BackendEfficiencyRow] = []
-    for row in rows:
-        backend = row[0]
-        runs = row[1]
-        failed = row[2]
-        avg_dur = row[3]
-        cost = row[4]
-        in_tok = row[5]
-        out_tok = row[6]
-        # Older fixtures may still emit 7-tuple rows without the
-        # cache totals; default to zero so the test harness does
-        # not have to know about the new SQL columns in unrelated
-        # cases.
-        cache_read = row[7] if len(row) > 7 else 0
-        cache_write = row[8] if len(row) > 8 else 0
-        out.append(
-            BackendEfficiencyRow(
-                backend=str(backend),
-                runs=int(runs or 0),
-                failed=int(failed or 0),
-                avg_duration_s=(
-                    float(avg_dur) if avg_dur is not None else None
-                ),
-                total_cost_usd=float(cost or 0.0),
-                total_input_tokens=int(in_tok or 0),
-                total_output_tokens=int(out_tok or 0),
-                total_cache_read_tokens=int(cache_read or 0),
-                total_cache_write_tokens=int(cache_write or 0),
-            )
+    return [
+        RepoBreakdownRow(
+            repo=row[0],
+            issues=int(row[1] or 0),
+            events=int(row[2] or 0),
+            agent_exits=int(row[3] or 0),
+            total_cost_usd=float(row[4] or 0.0),
         )
-    return out
+        for row in rows
+    ]
 
 
 def get_repo_breakdown(
@@ -622,37 +621,18 @@ def get_repo_breakdown(
     each rollup row carries one issue, so distinct counting after
     `GROUP BY repo` does not over-count.
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
         return []
-    connect_fn = connect or _default_connect
-    where, params = _build_rollup_window_where(
-        start=start, end=end, repo=repo,
-        events=events, stages=stages, issue=issue,
+    filters = _WindowFilters(
+        start=start,
+        end=end,
+        repo=repo,
+        events=events,
+        stages=stages,
+        issue=issue,
     )
-    sql = (
-        "SELECT repo, "
-        "COUNT(DISTINCT issue) AS repo_issues, "
-        "COALESCE(SUM(event_count), 0) AS repo_events, "
-        "COALESCE(SUM(CASE WHEN event = 'agent_exit' "
-        "                  THEN event_count ELSE 0 END), 0) "
-        "  AS repo_agent_exits, "
-        "COALESCE(SUM(total_cost_usd), 0) AS repo_cost_usd "
-        f"FROM {_DAILY_ROLLUP_VIEW}{where} "
-        "GROUP BY repo "
-        "ORDER BY repo_events DESC, repo ASC"
-    )
-    rows = _query(connect_fn, url, sql, params, conn=conn)
-    return [
-        RepoBreakdownRow(
-            repo=r,
-            issues=int(iss or 0),
-            events=int(ev or 0),
-            agent_exits=int(ax or 0),
-            total_cost_usd=float(cost or 0.0),
-        )
-        for r, iss, ev, ax, cost in rows
-    ]
+    return _repo_breakdown_rows(query, filters)
 
 
 # Stages a `stage_enter` event must carry to count as a terminal
@@ -661,6 +641,51 @@ def get_repo_breakdown(
 # because the throughput helper is the only consumer; if a future
 # caller needs the same set, promote it to a documented constant.
 _THROUGHPUT_RESOLVED_STAGES: tuple[str, ...] = ("done", "rejected")
+
+
+def _selected_throughput_stages(
+    stages: Optional[Sequence[str]],
+) -> tuple[str, ...]:
+    if stages is None:
+        return _THROUGHPUT_RESOLVED_STAGES
+    return tuple(
+        stage for stage in stages if stage in _THROUGHPUT_RESOLVED_STAGES
+    )
+
+
+def _throughput_from_row(row: Sequence[Any]) -> ThroughputDayRow:
+    return ThroughputDayRow(
+        day=_day_value(row[0]),
+        resolved=int(row[1] or 0),
+        rejected=int(row[2] or 0),
+    )
+
+
+def _throughput_rows(
+    query: _ReadQuery,
+    filters: _WindowFilters,
+) -> list[ThroughputDayRow]:
+    if filters.events is not None and "stage_enter" not in filters.events:
+        return []
+    active_stages = _selected_throughput_stages(filters.stages)
+    if not active_stages:
+        return []
+    scoped_filters = replace(filters, events=None, stages=active_stages)
+    where, params = _build_rollup_window_where(scoped_filters)
+    where = _prepend_where_condition(where, "event = %s")
+    params.insert(0, "stage_enter")
+    rows = query.select(
+        "SELECT day, "
+        "COALESCE(SUM(CASE WHEN stage = 'done' "
+        "                  THEN event_count ELSE 0 END), 0) AS resolved, "
+        "COALESCE(SUM(CASE WHEN stage = 'rejected' "
+        "                  THEN event_count ELSE 0 END), 0) AS rejected "
+        f"FROM {_DAILY_ROLLUP_VIEW}{where} "
+        "GROUP BY day "
+        "ORDER BY day ASC",
+        params,
+    )
+    return [_throughput_from_row(row) for row in rows]
 
 
 def get_throughput_breakdown(
@@ -694,66 +719,15 @@ def get_throughput_breakdown(
     - `start` / `end` / `repo` / `issue` apply as in every other
       reader.
     """
-    url = _resolve_db_url(db_url)
-    if conn is None and not url:
+    query = _ReadQuery.resolve(db_url, connect, conn)
+    if not query.available:
         return []
-    if events is not None and "stage_enter" not in events:
-        return []
-    # Intersect the user's stage selection with the resolved /
-    # rejected pair this widget is by definition about.
-    if stages is None:
-        active_stages = list(_THROUGHPUT_RESOLVED_STAGES)
-    elif not stages:
-        return []
-    else:
-        active_stages = [s for s in stages if s in _THROUGHPUT_RESOLVED_STAGES]
-        if not active_stages:
-            return []
-    connect_fn = connect or _default_connect
-    conditions = ["event = %s"]
-    params: list[Any] = ["stage_enter"]
-    if start is not None:
-        conditions.append("day >= %s")
-        params.append(start.date() if isinstance(start, datetime) else start)
-    if end is not None:
-        conditions.append("day < %s")
-        params.append(end.date() if isinstance(end, datetime) else end)
-    if repo is not None:
-        conditions.append("repo = %s")
-        params.append(repo)
-    if issue is not None:
-        conditions.append("issue = %s")
-        params.append(int(issue))
-    placeholders = ", ".join(["%s"] * len(active_stages))
-    conditions.append(f"stage IN ({placeholders})")
-    params.extend(active_stages)
-    where = " WHERE " + " AND ".join(conditions)
-    # Reads from the daily rollup: `event_count` already collapses
-    # multiple `stage_enter` rows for the same `(day, repo, issue,
-    # stage, backend, cost_source)` bucket into one row, so summing
-    # `event_count` per day per terminal stage recovers the prior
-    # per-day `COUNT(*)` without re-scanning `analytics_events`.
-    sql = (
-        "SELECT day, "
-        "COALESCE(SUM(CASE WHEN stage = 'done' "
-        "                  THEN event_count ELSE 0 END), 0) AS resolved, "
-        "COALESCE(SUM(CASE WHEN stage = 'rejected' "
-        "                  THEN event_count ELSE 0 END), 0) AS rejected "
-        f"FROM {_DAILY_ROLLUP_VIEW}{where} "
-        "GROUP BY day "
-        "ORDER BY day ASC"
+    filters = _WindowFilters(
+        start=start,
+        end=end,
+        repo=repo,
+        events=events,
+        stages=stages,
+        issue=issue,
     )
-    rows = _query(connect_fn, url, sql, params, conn=conn)
-    out: list[ThroughputDayRow] = []
-    for row in rows:
-        day_value, resolved, rejected = row
-        if isinstance(day_value, datetime):
-            day_value = day_value.date()
-        out.append(
-            ThroughputDayRow(
-                day=day_value,
-                resolved=int(resolved or 0),
-                rejected=int(rejected or 0),
-            )
-        )
-    return out
+    return _throughput_rows(query, filters)

--- a/orchestrator/analytics/sync.py
+++ b/orchestrator/analytics/sync.py
@@ -193,6 +193,48 @@ def _parse_ts(raw: Any) -> Optional[datetime]:
     return dt
 
 
+def _required_text(value: Any) -> Optional[str]:
+    if not isinstance(value, str) or not value:
+        return None
+    return value
+
+
+def _issue_number(value: Any) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _required_columns(record: dict) -> Optional[dict[str, Any]]:
+    if any(key not in record for key in _REQUIRED_KEYS):
+        return None
+    timestamp = _parse_ts(record.get("ts"))
+    repo = _required_text(record.get("repo"))
+    issue = _issue_number(record.get("issue"))
+    event = _required_text(record.get("event"))
+    if timestamp is None or repo is None or issue is None or event is None:
+        return None
+    return {
+        "ts": timestamp,
+        "repo": repo,
+        "issue": issue,
+        "event": event,
+    }
+
+
+def _extra_columns(record: dict, columns: dict[str, Any]) -> dict[str, Any]:
+    extras: dict[str, Any] = {}
+    for key, value in record.items():
+        if key in _REQUIRED_KEYS:
+            continue
+        if key in _PROMOTED_COLUMNS:
+            columns[key] = value
+        else:
+            extras[key] = value
+    return extras
+
+
 def _split_row(record: dict) -> Optional[tuple[dict, dict]]:
     """Promote known columns and route the rest to `extras`.
 
@@ -200,38 +242,10 @@ def _split_row(record: dict) -> Optional[tuple[dict, dict]]:
     or `ts` does not parse. The caller treats None as a malformed-line
     skip so a record with garbled `ts` does not abort the entire sync.
     """
-    for key in _REQUIRED_KEYS:
-        if key not in record:
-            return None
-    ts = _parse_ts(record.get("ts"))
-    if ts is None:
+    columns = _required_columns(record)
+    if columns is None:
         return None
-    repo = record.get("repo")
-    if not isinstance(repo, str) or not repo:
-        return None
-    try:
-        issue = int(record["issue"])
-    except (TypeError, ValueError):
-        return None
-    event = record.get("event")
-    if not isinstance(event, str) or not event:
-        return None
-
-    columns: dict[str, Any] = {
-        "ts": ts,
-        "repo": repo,
-        "issue": issue,
-        "event": event,
-    }
-    extras: dict[str, Any] = {}
-    for key, value in record.items():
-        if key in ("ts", "repo", "issue", "event"):
-            continue
-        if key in _PROMOTED_COLUMNS:
-            columns[key] = value
-        else:
-            extras[key] = value
-    return columns, extras
+    return columns, _extra_columns(record, columns)
 
 
 def _build_insert_sql() -> str:
@@ -257,12 +271,19 @@ def _build_insert_sql() -> str:
     )
 
 
+@dataclass(frozen=True)
+class _RowProvenance:
+    """Source identity and stable dedup hash for one prepared row."""
+
+    source_path: Optional[str]
+    source_line: int
+    content_hash: str
+
+
 def _row_values(
     columns: dict,
     extras: dict,
-    source_path: Optional[str],
-    source_line: int,
-    content_hash: str,
+    provenance: _RowProvenance,
     json_adapter: Callable[[Any], Any],
 ) -> tuple:
     values: list[Any] = []
@@ -272,9 +293,9 @@ def _row_values(
             value = json_adapter(value)
         values.append(value)
     values.append(json_adapter(extras) if extras else None)
-    values.append(source_path)
-    values.append(source_line)
-    values.append(content_hash)
+    values.append(provenance.source_path)
+    values.append(provenance.source_line)
+    values.append(provenance.content_hash)
     return tuple(values)
 
 
@@ -288,6 +309,27 @@ def _row_values(
 _REDACTED_QUERY_PARAMS = frozenset(
     {"user", "password", "passfile", "sslpassword"}
 )
+
+
+def _redacted_netloc(parts: Any) -> str:
+    if not parts.username and not parts.password:
+        return parts.netloc
+    host = parts.hostname or ""
+    netloc = f"{host}:{parts.port}" if parts.port else host
+    return f"***@{netloc}" if netloc else "***"
+
+
+def _redacted_query(query: str) -> str:
+    if not query:
+        return query
+    pairs = parse_qsl(query, keep_blank_values=True)
+    redacted_pairs = [
+        (key, "***" if key.lower() in _REDACTED_QUERY_PARAMS else value)
+        for key, value in pairs
+    ]
+    if redacted_pairs == pairs:
+        return query
+    return urlencode(redacted_pairs, safe="*")
 
 
 def _redact_db_url(url: str) -> str:
@@ -307,31 +349,14 @@ def _redact_db_url(url: str) -> str:
         parts = urlsplit(url)
     except ValueError:
         return "<db-url-unparseable>"
-    netloc = parts.netloc
-    if parts.username or parts.password:
-        host = parts.hostname or ""
-        netloc = f"{host}:{parts.port}" if parts.port else host
-        netloc = f"***@{netloc}" if netloc else "***"
-    query = parts.query
-    if query:
-        # `keep_blank_values=True` so `?password=` (operator left it
-        # empty) still surfaces as a `password=***` pair rather than
-        # silently disappearing -- the operator-visible shape of the
-        # query string should not change just because a value was
-        # blank.
-        pairs = parse_qsl(query, keep_blank_values=True)
-        redacted_pairs = [
-            (key, "***" if key.lower() in _REDACTED_QUERY_PARAMS else value)
-            for key, value in pairs
-        ]
-        if redacted_pairs != pairs:
-            # `safe="*"` keeps the redaction marker readable in the
-            # log line; without it `urlencode` percent-encodes the
-            # asterisks to `%2A` and the redacted URL turns into
-            # `password=%2A%2A%2A`, which obscures the intent.
-            query = urlencode(redacted_pairs, safe="*")
     return urlunsplit(
-        (parts.scheme, netloc, parts.path, query, parts.fragment)
+        (
+            parts.scheme,
+            _redacted_netloc(parts),
+            parts.path,
+            _redacted_query(parts.query),
+            parts.fragment,
+        )
     )
 
 
@@ -502,14 +527,114 @@ def _note_malformed_line(
     )
 
 
+@dataclass(frozen=True)
+class _PreparedRecord:
+    """Validated promoted fields, extras, and hash for one JSONL record."""
+
+    columns: dict[str, Any]
+    extras: dict[str, Any]
+    content_hash: str
+
+
+@dataclass(frozen=True)
+class _IngestContext:
+    """Stable inputs and mutable counters shared by one ingest pass."""
+
+    log_path: Path
+    insert_sql: str
+    source_path: Optional[str]
+    json_adapter: Callable[[Any], Any]
+    counters: _SyncCounters
+    start: float
+
+
+def _prepare_record(
+    raw_line: str,
+) -> tuple[Optional[_PreparedRecord], Optional[str]]:
+    stripped = raw_line.strip()
+    if not stripped:
+        return None, None
+    try:
+        record = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None, "not JSON"
+    if not isinstance(record, dict):
+        return None, "JSON not an object"
+    split = _split_row(record)
+    if split is None:
+        return None, "missing/invalid required keys"
+    columns, extras = split
+    return _PreparedRecord(columns, extras, _content_hash(record)), None
+
+
+def _existing_hashes(cur: Any) -> set[str]:
+    cur.execute(
+        "SELECT content_hash FROM analytics_events "
+        "WHERE content_hash IS NOT NULL"
+    )
+    return {row[0] for row in cur if row[0] is not None}
+
+
+@dataclass
+class _RecordIngester:
+    """Classify, deduplicate, and batch records for one open cursor."""
+
+    cur: Any
+    context: _IngestContext
+    existing_hashes: set[str]
+    batch: list[tuple] = field(default_factory=list)
+
+    def add(self, line_number: int, raw_line: str) -> None:
+        self.context.counters.total_lines += 1
+        prepared, reason = _prepare_record(raw_line)
+        if prepared is None:
+            if reason is not None:
+                _note_malformed_line(
+                    self.context.counters,
+                    line_number,
+                    self.context.log_path,
+                    reason,
+                )
+            return
+        if prepared.content_hash in self.existing_hashes:
+            self.context.counters.skipped_duplicate += 1
+            return
+        provenance = _RowProvenance(
+            source_path=self.context.source_path,
+            source_line=line_number,
+            content_hash=prepared.content_hash,
+        )
+        self.batch.append(
+            _row_values(
+                prepared.columns,
+                prepared.extras,
+                provenance,
+                self.context.json_adapter,
+            )
+        )
+        self.existing_hashes.add(prepared.content_hash)
+        if len(self.batch) >= _BATCH_SIZE:
+            self.flush()
+
+    def flush(self) -> None:
+        _flush_batch(
+            self.cur,
+            self.context.insert_sql,
+            self.batch,
+            self.context.counters,
+            self.context.start,
+        )
+
+
+def _stream_records(ingester: _RecordIngester) -> None:
+    with ingester.context.log_path.open("r", encoding="utf-8") as source_file:
+        for line_number, raw_line in enumerate(source_file, start=1):
+            ingester.add(line_number, raw_line)
+
+
 def _ingest_records(
     conn: Any,
-    log_path: Path,
-    insert_sql: str,
-    source_path_str: Optional[str],
-    json_adapter_fn: Callable[[Any], Any],
-    counters: _SyncCounters,
-    start: float,
+    context: _IngestContext,
 ) -> None:
     """Stream `log_path` into `conn` under one cursor, batching valid rows.
 
@@ -531,59 +656,146 @@ def _ingest_records(
     closes the connection.
     """
     with conn.cursor() as cur:
-        cur.execute(
-            "SELECT content_hash FROM analytics_events "
-            "WHERE content_hash IS NOT NULL"
+        ingester = _RecordIngester(
+            cur=cur,
+            context=context,
+            existing_hashes=_existing_hashes(cur),
         )
-        existing_hashes: set[str] = {
-            row[0] for row in cur if row[0] is not None
-        }
+        _stream_records(ingester)
+        ingester.flush()
 
-        batch: list[tuple] = []
-        with Path(log_path).open("r", encoding="utf-8") as fh:
-            for line_number, raw_line in enumerate(fh, start=1):
-                counters.total_lines += 1
-                stripped = raw_line.strip()
-                if not stripped:
-                    continue
-                try:
-                    record = json.loads(stripped)
-                except json.JSONDecodeError:
-                    _note_malformed_line(
-                        counters, line_number, log_path, "not JSON"
-                    )
-                    continue
-                if not isinstance(record, dict):
-                    _note_malformed_line(
-                        counters, line_number, log_path, "JSON not an object"
-                    )
-                    continue
-                split = _split_row(record)
-                if split is None:
-                    _note_malformed_line(
-                        counters, line_number, log_path,
-                        "missing/invalid required keys",
-                    )
-                    continue
-                columns, extras = split
-                content_hash = _content_hash(record)
-                if content_hash in existing_hashes:
-                    counters.skipped_duplicate += 1
-                    continue
-                batch.append(
-                    _row_values(
-                        columns,
-                        extras,
-                        source_path_str,
-                        line_number,
-                        content_hash,
-                        json_adapter_fn,
-                    )
-                )
-                existing_hashes.add(content_hash)
-                if len(batch) >= _BATCH_SIZE:
-                    _flush_batch(cur, insert_sql, batch, counters, start)
-        _flush_batch(cur, insert_sql, batch, counters, start)
+
+@dataclass(frozen=True)
+class _SyncRequest:
+    """Resolved source, destination, and injected adapters for one sync."""
+
+    log_path: Optional[Path]
+    db_url: Optional[str]
+    connect_fn: Callable[[str], Any]
+    json_adapter: Callable[[Any], Any]
+
+    @classmethod
+    def resolve(
+        cls,
+        log_path: Optional[Path],
+        db_url: Optional[str],
+        connect: Optional[Callable[[str], Any]],
+        json_adapter: Optional[Callable[[Any], Any]],
+    ) -> _SyncRequest:
+        return cls(
+            log_path=(
+                log_path
+                if log_path is not None
+                else _analytics.ANALYTICS_LOG_PATH
+            ),
+            db_url=db_url if db_url is not None else _analytics.ANALYTICS_DB_URL,
+            connect_fn=connect or _default_connect,
+            json_adapter=json_adapter or _default_json_adapter,
+        )
+
+    def ready(self) -> bool:
+        """Log and reject configured no-op paths before any connection work."""
+        if self.log_path is None:
+            log.info(
+                "analytics_sync: ANALYTICS_LOG_PATH not configured; "
+                "nothing to sync"
+            )
+            return False
+        if not self.db_url:
+            log.info(
+                "analytics_sync: ANALYTICS_DB_URL not configured; "
+                "nothing to sync"
+            )
+            return False
+        if not self.log_path.exists():
+            log.info(
+                "analytics_sync: %s does not exist yet; nothing to sync",
+                self.log_path,
+            )
+            return False
+        return True
+
+
+@dataclass
+class _SyncRun:
+    """Connection lifecycle, ingest state, and reporting for one replay."""
+
+    request: _SyncRequest
+    counters: _SyncCounters = field(default_factory=_SyncCounters)
+    start: float = field(default_factory=time.monotonic)
+
+    def connect(self) -> Any:
+        redacted_url = _redact_db_url(self.request.db_url or "")
+        log.info(
+            "analytics_sync: connecting to %s (source=%s)",
+            redacted_url,
+            self.request.log_path,
+        )
+        conn = self.request.connect_fn(self.request.db_url)
+        log.info(
+            "analytics_sync: connection established to %s after %.3fs",
+            redacted_url,
+            time.monotonic() - self.start,
+        )
+        return conn
+
+    def ingest_context(self) -> _IngestContext:
+        log_path = Path(self.request.log_path)
+        return _IngestContext(
+            log_path=log_path,
+            insert_sql=_build_insert_sql(),
+            source_path=str(log_path),
+            json_adapter=self.request.json_adapter,
+            counters=self.counters,
+            start=self.start,
+        )
+
+    def commit(self, conn: Any) -> None:
+        """Commit rows and refresh the rollup even for duplicate-only runs."""
+        log.info(
+            "analytics_sync: committing transaction (lines=%d inserted=%d "
+            "duplicate=%d malformed=%d elapsed=%.3fs)",
+            self.counters.total_lines,
+            self.counters.inserted,
+            self.counters.skipped_duplicate,
+            self.counters.skipped_malformed,
+            time.monotonic() - self.start,
+        )
+        conn.commit()
+        _refresh_daily_rollup(conn)
+
+    def result(self) -> SyncResult:
+        duration_s = round(time.monotonic() - self.start, 3)
+        log.info(
+            "analytics_sync: completed in %.3fs (inserted=%d duplicate=%d "
+            "malformed=%d total_lines=%d source=%s)",
+            duration_s,
+            self.counters.inserted,
+            self.counters.skipped_duplicate,
+            self.counters.skipped_malformed,
+            self.counters.total_lines,
+            self.request.log_path,
+        )
+        return SyncResult(
+            inserted=self.counters.inserted,
+            skipped_duplicate=self.counters.skipped_duplicate,
+            skipped_malformed=self.counters.skipped_malformed,
+            total_lines=self.counters.total_lines,
+            malformed_line_numbers=tuple(self.counters.malformed_lines),
+            duration_s=duration_s,
+        )
+
+    def execute(self) -> SyncResult:
+        conn = self.connect()
+        try:
+            _ingest_records(conn, self.ingest_context())
+            self.commit(conn)
+        except Exception:
+            _rollback_quietly(conn, "analytics_sync: rollback failed")
+            raise
+        finally:
+            _close_quietly(conn)
+        return self.result()
 
 
 def sync_jsonl_to_postgres(
@@ -617,99 +829,15 @@ def sync_jsonl_to_postgres(
     psycopg. Production callers leave both at None to get the real
     psycopg connection and the default `Json` wrapper.
     """
-    if log_path is None:
-        log_path = _analytics.ANALYTICS_LOG_PATH
-    if db_url is None:
-        db_url = _analytics.ANALYTICS_DB_URL
-    connect_fn = connect or _default_connect
-    json_adapter_fn = json_adapter or _default_json_adapter
-
-    if log_path is None:
-        log.info("analytics_sync: ANALYTICS_LOG_PATH not configured; nothing to sync")
+    request = _SyncRequest.resolve(
+        log_path,
+        db_url,
+        connect,
+        json_adapter,
+    )
+    if not request.ready():
         return SyncResult()
-    if not db_url:
-        log.info("analytics_sync: ANALYTICS_DB_URL not configured; nothing to sync")
-        return SyncResult()
-    if not Path(log_path).exists():
-        log.info("analytics_sync: %s does not exist yet; nothing to sync", log_path)
-        return SyncResult()
-
-    insert_sql = _build_insert_sql()
-    source_path_str = str(log_path)
-    redacted_url = _redact_db_url(db_url)
-
-    counters = _SyncCounters()
-
-    start = time.monotonic()
-    log.info(
-        "analytics_sync: connecting to %s (source=%s)",
-        redacted_url, log_path,
-    )
-    conn = connect_fn(db_url)
-    log.info(
-        "analytics_sync: connection established to %s after %.3fs",
-        redacted_url, time.monotonic() - start,
-    )
-
-    try:
-        _ingest_records(
-            conn,
-            Path(log_path),
-            insert_sql,
-            source_path_str,
-            json_adapter_fn,
-            counters,
-            start,
-        )
-        log.info(
-            "analytics_sync: committing transaction (lines=%d inserted=%d "
-            "duplicate=%d malformed=%d elapsed=%.3fs)",
-            counters.total_lines, counters.inserted,
-            counters.skipped_duplicate, counters.skipped_malformed,
-            time.monotonic() - start,
-        )
-        conn.commit()
-        # Post-commit refresh of the daily rollup MV defined in
-        # `analytics-db/init/01-schema.sql`. The committed inserts
-        # are durable regardless of what happens here, so a refresh
-        # failure is logged and swallowed -- the operator-driven
-        # sync still reports success on the rows that landed in
-        # `analytics_events`. The refresh fires unconditionally on
-        # every successful commit (rather than only when
-        # `inserted > 0`) so that rerunning the sync is the
-        # documented recovery path for a stale rollup: a prior sync
-        # whose refresh failed leaves the rollup stale, and the
-        # operator's only signal that "the sync committed but the
-        # rollup is out of sync" is the swallowed refresh log line.
-        # Gating refresh on inserted>0 would mean a rerun against a
-        # duplicate-only or empty JSONL never recovers the rollup
-        # and the operator has to fall back to a manual `REFRESH
-        # MATERIALIZED VIEW` -- defeating the purpose of the hook.
-        # The wasted work on a no-insert rerun is bounded by the
-        # rollup's row count, which the dashboard's read pattern
-        # keeps small (one row per day per key tuple).
-        _refresh_daily_rollup(conn)
-    except Exception:
-        _rollback_quietly(conn, "analytics_sync: rollback failed")
-        raise
-    finally:
-        _close_quietly(conn)
-
-    duration_s = round(time.monotonic() - start, 3)
-    log.info(
-        "analytics_sync: completed in %.3fs (inserted=%d duplicate=%d "
-        "malformed=%d total_lines=%d source=%s)",
-        duration_s, counters.inserted, counters.skipped_duplicate,
-        counters.skipped_malformed, counters.total_lines, log_path,
-    )
-    return SyncResult(
-        inserted=counters.inserted,
-        skipped_duplicate=counters.skipped_duplicate,
-        skipped_malformed=counters.skipped_malformed,
-        total_lines=counters.total_lines,
-        malformed_line_numbers=tuple(counters.malformed_lines),
-        duration_s=duration_s,
-    )
+    return _SyncRun(request).execute()
 
 
 def _configure_cli_logging(level: str) -> None:
@@ -751,7 +879,7 @@ def _configure_cli_logging(level: str) -> None:
     root.addHandler(handler)
 
 
-def main(argv: Optional[list[str]] = None) -> int:
+def _cli_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python -m orchestrator.analytics.sync",
         description=(
@@ -780,10 +908,23 @@ def main(argv: Optional[list[str]] = None) -> int:
         ),
     )
     parser.add_argument("--log-level", default="INFO")
-    args = parser.parse_args(argv)
+    return parser
 
-    _configure_cli_logging(args.log_level)
 
+def _print_cli_result(result: SyncResult, cli_start: float) -> None:
+    """Print the UTC summary retained even when structured logs are hidden."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    duration_s = result.duration_s or round(time.monotonic() - cli_start, 3)
+    print(
+        f"{timestamp} analytics_sync: inserted={result.inserted} "
+        f"duplicate={result.skipped_duplicate} "
+        f"malformed={result.skipped_malformed} "
+        f"total_lines={result.total_lines} "
+        f"duration_s={duration_s:.3f}"
+    )
+
+
+def _run_cli(args: argparse.Namespace) -> int:
     cli_start = time.monotonic()
     try:
         result = sync_jsonl_to_postgres(
@@ -796,27 +937,14 @@ def main(argv: Optional[list[str]] = None) -> int:
             time.monotonic() - cli_start,
         )
         return 1
-
-    # CLI users want a one-line human-readable summary in addition to
-    # the structured log line; print to stdout so it survives
-    # `--log-level WARNING`. The leading UTC timestamp matches the
-    # `_configure_cli_logging` formatter (which is also UTC with a
-    # "UTC" suffix) so an operator piping stdout + stderr together
-    # gets a uniform time-ordered stream regardless of the host's
-    # local timezone. `duration_s` falls back to the CLI wall-clock
-    # when the sync took the no-op path and reported 0.0 -- otherwise
-    # the printed elapsed would disagree with what the operator just
-    # sat through.
-    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
-    duration_s = result.duration_s or round(time.monotonic() - cli_start, 3)
-    print(
-        f"{timestamp} analytics_sync: inserted={result.inserted} "
-        f"duplicate={result.skipped_duplicate} "
-        f"malformed={result.skipped_malformed} "
-        f"total_lines={result.total_lines} "
-        f"duration_s={duration_s:.3f}"
-    )
+    _print_cli_result(result, cli_start)
     return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _cli_parser().parse_args(argv)
+    _configure_cli_logging(args.log_level)
+    return _run_cli(args)
 
 
 if __name__ == "__main__":

--- a/orchestrator/base_sync.py
+++ b/orchestrator/base_sync.py
@@ -124,23 +124,63 @@ def _merge_base_into_worktree(
     return _rebase_base_into_worktree(spec, worktree)
 
 
+def _rebase_state_exists(worktree: Path, state_dir: str) -> bool:
+    """Resolve one git rebase-state path and report whether it exists."""
+    git_path_result = _git_hardened(
+        "rev-parse", "--git-path", state_dir, cwd=worktree,
+    )
+    if git_path_result.returncode != 0:
+        return False
+    path = (git_path_result.stdout or "").strip()
+    if not path:
+        return False
+    state_path = Path(path)
+    if not state_path.is_absolute():
+        state_path = worktree / state_path
+    return state_path.exists()
+
+
 def _rebase_in_progress(worktree: Path) -> bool:
     """Return True when the worktree still has an unfinished rebase."""
-    for state_dir in ("rebase-merge", "rebase-apply"):
-        git_path_result = _git_hardened(
-            "rev-parse", "--git-path", state_dir, cwd=worktree,
+    return any(
+        _rebase_state_exists(worktree, state_dir)
+        for state_dir in ("rebase-merge", "rebase-apply")
+    )
+
+
+def _issue_worktree_number(worktree: Path) -> Optional[int]:
+    """Return an issue number only for a valid issue worktree directory."""
+    if not worktree.is_dir() or not worktree.name.startswith("issue-"):
+        return None
+    try:
+        return int(worktree.name[len("issue-"):])
+    except ValueError:
+        return None
+
+
+def _sync_discovered_worktree(
+    gh: GitHubClient,
+    spec: RepoSpec,
+    worktree: Path,
+    issue_number: int,
+    scheduler: Optional[IssueScheduler],
+) -> None:
+    """Sync one discovered worktree unless its handler is still active."""
+    if scheduler is not None and scheduler.is_active(
+        spec.slug, issue_number,
+    ):
+        log.debug(
+            "repo=%s issue=#%d active in scheduler; skipping base "
+            "sync until the worker completes", spec.slug, issue_number,
         )
-        if git_path_result.returncode != 0:
-            continue
-        path = (git_path_result.stdout or "").strip()
-        if not path:
-            continue
-        state_path = Path(path)
-        if not state_path.is_absolute():
-            state_path = worktree / state_path
-        if state_path.exists():
-            return True
-    return False
+        return
+    try:
+        _sync_worktree_with_base(gh, spec, worktree, issue_number)
+    except Exception:
+        log.exception(
+            "repo=%s issue=#%d base sync failed; continuing",
+            spec.slug, issue_number,
+        )
 
 
 def _refresh_base_and_worktrees(
@@ -223,33 +263,11 @@ def _refresh_base_and_worktrees(
     if not root.exists():
         return
 
-    for wt in sorted(root.iterdir()):
-        if not wt.is_dir() or not wt.name.startswith("issue-"):
-            continue
-        try:
-            issue_number = int(wt.name[len("issue-"):])
-        except ValueError:
-            continue
-        if scheduler is not None and scheduler.is_active(
-            spec.slug, issue_number,
-        ):
-            # The handler for this issue is still running on a
-            # scheduler worker thread. Rebasing the pre-PR worktree
-            # would race the agent's working copy; the PR-having
-            # detour would relabel / write pinned state while the
-            # handler is mid-write. Skip the sync this tick -- the
-            # next polling pass picks it up once the worker exits.
-            log.debug(
-                "repo=%s issue=#%d active in scheduler; skipping base "
-                "sync until the worker completes", spec.slug, issue_number,
-            )
-            continue
-        try:
-            _sync_worktree_with_base(gh, spec, wt, issue_number)
-        except Exception:
-            log.exception(
-                "repo=%s issue=#%d base sync failed; continuing",
-                spec.slug, issue_number,
+    for worktree in sorted(root.iterdir()):
+        issue_number = _issue_worktree_number(worktree)
+        if issue_number is not None:
+            _sync_discovered_worktree(
+                gh, spec, worktree, issue_number, scheduler,
             )
 
 
@@ -313,6 +331,33 @@ class _AutoRebaseContext:
 
 
 @dataclass(frozen=True)
+class _AutoRebaseRecoveryContext:
+    """Stable inputs for finalizing one interrupted auto-rebase."""
+
+    gh: GitHubClient
+    spec: RepoSpec
+    issue: Issue
+    state: PinnedState
+    worktree: Path
+    pr_number: int
+    label: str
+    pending_pre_rebase_sha: str
+    behind: int = 0
+    unparking_consumed_max: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class _AutoRebaseRecoverySnapshot:
+    """Local and remote branch state observed during crash recovery."""
+
+    branch: str
+    local_head: str
+    remote_head: str = ""
+    ahead: int = 0
+    behind: int = 0
+
+
+@dataclass(frozen=True)
 class _AutoRebaseDecision:
     """Whether the coordinator should continue its normal rebase flow."""
 
@@ -357,10 +402,7 @@ def _park_auto_rebase_failure(
 
 
 def _reset_clear_and_park(
-    gh: GitHubClient,
-    issue: Issue,
-    state: PinnedState,
-    worktree: Path,
+    context: _AutoRebaseContext | _AutoRebaseRecoveryContext,
     reset_sha: str,
     *,
     message: str,
@@ -385,103 +427,496 @@ def _reset_clear_and_park(
     and it still lands even if the worktree is left on an unexpected SHA
     for the operator to inspect.
     """
-    reset = _git_hardened("reset", "--hard", reset_sha, cwd=worktree)
+    reset = _git_hardened(
+        "reset", "--hard", reset_sha, cwd=context.worktree,
+    )
     if reset.returncode != 0:
         log.error(
             "issue=#%d auto-rebase recovery: reset --hard to %s failed: "
             "%s; the awaiting_human park still short-circuits same-tick "
             "handler dispatch but operator inspection of HEAD is needed",
-            issue.number, reset_sha[:8], (reset.stderr or "").strip(),
+            context.issue.number,
+            reset_sha[:8],
+            (reset.stderr or "").strip(),
         )
     if clean:
-        cleaned = _git_hardened("clean", "-fd", cwd=worktree)
+        cleaned = _git_hardened("clean", "-fd", cwd=context.worktree)
         if cleaned.returncode != 0:
             log.error(
                 "issue=#%d auto-rebase recovery: `git clean -fd` after "
                 "the reset failed: %s",
-                issue.number, (cleaned.stderr or "").strip(),
+                context.issue.number, (cleaned.stderr or "").strip(),
             )
-    state.set("pending_auto_base_rebase_push_sha", None)
+    context.state.set("pending_auto_base_rebase_push_sha", None)
     _park_auto_rebase_failure(
-        gh, issue, state, message=message, reason=reason,
+        context.gh,
+        context.issue,
+        context.state,
+        message=message,
+        reason=reason,
     )
 
 
-def _finalize_recovered_rebase(
-    gh: GitHubClient,
-    spec: RepoSpec,
-    issue: Issue,
-    state: PinnedState,
-    *,
-    pr_number: int,
-    label: str,
-    local_head: str,
-    behind: int,
-    method: str,
-    notice: str,
-    unparking_consumed_max: Optional[int],
-) -> bool:
-    """Commit a recovered auto-rebase's success state and route by `behind`.
+def _prepare_recovered_rebase_state(
+    context: _AutoRebaseRecoveryContext,
+) -> None:
+    """Clear the recovery anchor and commit any pending human retry."""
+    if context.unparking_consumed_max is not None:
+        context.state.set(
+            "last_action_comment_id", context.unparking_consumed_max,
+        )
+        context.state.set("awaiting_human", False)
+        context.state.set("park_reason", None)
+    context.state.set("pending_auto_base_rebase_push_sha", None)
+    context.state.set("review_round", 0)
 
-    Shared tail of recovery cases 2 (push already landed) and 3 (push
-    reissued this tick): the recovered head is confirmed on the PR, so
-    clear the crash-recovery anchor, reset `review_round`, post `notice`
-    on the PR, and emit `base_rebased` with the case-specific `method`.
-    When `unparking_consumed_max` is set, the operator's "retry" reply is
-    committed (park cleared, watermark advanced) atomically with this
-    write; even on the `behind > 0` fall-through the recovered head IS on
-    the PR, so the unpark is safe to commit here.
 
-    `behind == 0` means the recovered head is current: relabel to
-    `validating` and return True (the caller returns immediately).
-    `behind > 0` means base advanced again since the interrupted rebase,
-    so write the recovery progress and return False -- the caller's
-    normal rebase + push flow then rebases the recovered head onto the
-    newer base before the final `validating` flip fires there. Without
-    that split the same-tick `validating` handler would run the reviewer
-    on a PR still behind base.
-    """
-    if unparking_consumed_max is not None:
-        state.set("last_action_comment_id", unparking_consumed_max)
-        state.set("awaiting_human", False)
-        state.set("park_reason", None)
-    state.set("pending_auto_base_rebase_push_sha", None)
-    state.set("review_round", 0)
+def _post_recovered_rebase_notice(
+    context: _AutoRebaseRecoveryContext, notice: str,
+) -> None:
+    """Post the recovery notice without blocking state finalization."""
     try:
-        _post_pr_comment(gh, pr_number, state, notice)
+        _post_pr_comment(
+            context.gh, context.pr_number, context.state, notice,
+        )
     except Exception:
         log.exception(
             "issue=#%s could not post auto-rebase recovery notice to "
-            "PR #%s", issue.number, pr_number,
+            "PR #%s", context.issue.number, context.pr_number,
         )
-    gh.emit_event(
+
+
+def _emit_recovered_rebase_event(
+    context: _AutoRebaseRecoveryContext,
+    local_head: str,
+    method: str,
+) -> None:
+    """Emit the stable audit shape for a recovered auto-rebase."""
+    context.gh.emit_event(
         "base_rebased",
-        issue_number=issue.number,
-        stage=label,
-        pr_number=pr_number,
+        issue_number=context.issue.number,
+        stage=context.label,
+        pr_number=context.pr_number,
         sha=local_head,
         method=method,
         review_round=0,
-        retry_count=state.get("retry_count"),
+        retry_count=context.state.get("retry_count"),
     )
-    if behind == 0:
+
+
+def _route_recovered_rebase(
+    context: _AutoRebaseRecoveryContext,
+    local_head: str,
+    method: str,
+) -> bool:
+    """Persist recovery progress and route only a current head to validation."""
+    if context.behind == 0:
         log.info(
             "issue=#%d auto-rebase recovery (%s): recovered head %s is "
             "current; routing %r -> validating",
-            issue.number, method, local_head[:8], label,
+            context.issue.number,
+            method,
+            local_head[:8],
+            context.label,
         )
-        gh.set_workflow_label(issue, "validating")
-        gh.write_pinned_state(issue, state)
+        context.gh.set_workflow_label(context.issue, "validating")
+        context.gh.write_pinned_state(context.issue, context.state)
         return True
-    gh.write_pinned_state(issue, state)
+    context.gh.write_pinned_state(context.issue, context.state)
     log.info(
         "issue=#%d auto-rebase recovery (%s): recovered head %s is still "
         "%d commit(s) behind %s/%s; falling through to the normal rebase "
         "+ push flow",
-        issue.number, method, local_head[:8], behind,
-        spec.remote_name, spec.base_branch,
+        context.issue.number,
+        method,
+        local_head[:8],
+        context.behind,
+        context.spec.remote_name,
+        context.spec.base_branch,
     )
     return False
+
+
+def _finalize_recovered_rebase(
+    context: _AutoRebaseRecoveryContext,
+    *,
+    local_head: str,
+    method: str,
+    notice: str,
+) -> bool:
+    """Finalize a recovered push and route it according to current base lag."""
+    _prepare_recovered_rebase_state(context)
+    _post_recovered_rebase_notice(context, notice)
+    _emit_recovered_rebase_event(context, local_head, method)
+    return _route_recovered_rebase(context, local_head, method)
+
+
+def _abort_recovery_unverified(
+    context: _AutoRebaseRecoveryContext, detail: str,
+) -> bool:
+    """Restore the recovery anchor when the remote state cannot be verified."""
+    _reset_clear_and_park(
+        context,
+        context.pending_pre_rebase_sha,
+        message=(
+            f"{config.HITL_MENTIONS} crash recovery for PR "
+            f"#{context.pr_number} could not safely finalize: {detail} "
+            f"Local HEAD has been reset to the pre-rebase SHA "
+            f"`{context.pending_pre_rebase_sha[:8]}` so the worktree "
+            "matches the (last-known) remote PR head -- the "
+            "issue is parked so the same-tick stage handlers do "
+            "NOT run against a SHA the PR may not carry. Reply "
+            "on this issue with anything once the underlying "
+            "problem is fixed and the orchestrator will re-"
+            "attempt the auto rebase on the next polling tick."
+        ),
+        reason="auto_base_rebase_push_failed",
+    )
+    return True
+
+
+def _clear_ineligible_recovery(
+    context: _AutoRebaseRecoveryContext,
+) -> bool:
+    """Clear an interrupted-rebase anchor after an operator relabel."""
+    context.state.set("pending_auto_base_rebase_push_sha", None)
+    context.gh.write_pinned_state(context.issue, context.state)
+    log.info(
+        "issue=#%d auto-rebase recovery: label %r is no longer in "
+        "the refresh-driven set; clearing pending flag",
+        context.issue.number,
+        context.label,
+    )
+    return True
+
+
+def _fetch_recovery_snapshot(
+    context: _AutoRebaseRecoveryContext,
+) -> Optional[_AutoRebaseRecoverySnapshot]:
+    """Fetch the PR branch and capture the local recovery head."""
+    branch = _resolve_branch_name(
+        context.state, context.spec, context.issue.number,
+    )
+    fetch_result = _authed_fetch(
+        context.spec,
+        f"+refs/heads/{branch}:refs/remotes/"
+        f"{context.spec.remote_name}/{branch}",
+        cwd=context.worktree,
+    )
+    if fetch_result.returncode != 0:
+        fetch_error = (fetch_result.stderr or "").strip()
+        log.warning(
+            "issue=#%d auto-rebase recovery fetch of %s/%s failed: %s; "
+            "aborting recovery and parking awaiting human",
+            context.issue.number,
+            context.spec.remote_name,
+            branch,
+            fetch_error,
+        )
+        _abort_recovery_unverified(
+            context,
+            f"the fetch of `{context.spec.remote_name}/{branch}` "
+            "needed to verify the recovered SHA against the remote PR "
+            f"head failed (`{fetch_error[:120]}`).",
+        )
+        return None
+    return _AutoRebaseRecoverySnapshot(
+        branch=branch,
+        local_head=_head_sha(context.worktree) or "",
+    )
+
+
+def _clear_unchanged_recovery(
+    context: _AutoRebaseRecoveryContext,
+) -> bool:
+    """Clear an anchor when HEAD never moved beyond the pre-rebase SHA."""
+    context.state.set("pending_auto_base_rebase_push_sha", None)
+    context.gh.write_pinned_state(context.issue, context.state)
+    log.info(
+        "issue=#%d auto-rebase recovery: local HEAD matches pre-"
+        "rebase SHA `%s`; clearing flag and falling through to "
+        "the normal rebase flow",
+        context.issue.number,
+        context.pending_pre_rebase_sha[:8],
+    )
+    return False
+
+
+def _read_remote_recovery_head(
+    context: _AutoRebaseRecoveryContext,
+    branch: str,
+) -> Optional[str]:
+    """Read the freshly fetched remote PR head or park fail-closed."""
+    remote_ref = f"refs/remotes/{context.spec.remote_name}/{branch}"
+    remote_head_result = _git_hardened(
+        "rev-parse", remote_ref, cwd=context.worktree,
+    )
+    if remote_head_result.returncode != 0:
+        remote_error = (remote_head_result.stderr or "").strip()
+        log.warning(
+            "issue=#%d auto-rebase recovery: rev-parse of %s failed "
+            "after fetch: %s; aborting recovery and parking awaiting human",
+            context.issue.number,
+            remote_ref,
+            remote_error,
+        )
+        _abort_recovery_unverified(
+            context,
+            f"`git rev-parse {remote_ref}` failed after the fetch "
+            f"(`{remote_error[:120]}`), so the remote PR head SHA "
+            "needed for the equality check could not be read.",
+        )
+        return None
+    remote_head = (remote_head_result.stdout or "").strip()
+    if remote_head:
+        return remote_head
+    log.warning(
+        "issue=#%d auto-rebase recovery: rev-parse of %s returned "
+        "no SHA; aborting recovery and parking awaiting human",
+        context.issue.number,
+        remote_ref,
+    )
+    _abort_recovery_unverified(
+        context,
+        f"`git rev-parse {remote_ref}` returned no SHA after the "
+        "fetch, so the remote PR head SHA needed for the equality "
+        "check could not be read.",
+    )
+    return None
+
+
+def _complete_recovery_snapshot(
+    context: _AutoRebaseRecoveryContext,
+    snapshot: _AutoRebaseRecoverySnapshot,
+) -> Optional[_AutoRebaseRecoverySnapshot]:
+    """Add the verified remote head and divergence counts to a snapshot."""
+    remote_head = _read_remote_recovery_head(context, snapshot.branch)
+    if remote_head is None:
+        return None
+    if snapshot.local_head == remote_head:
+        return _AutoRebaseRecoverySnapshot(
+            branch=snapshot.branch,
+            local_head=snapshot.local_head,
+            remote_head=remote_head,
+        )
+    ahead, behind = _branch_ahead_behind(
+        context.spec, context.worktree, snapshot.branch,
+    )
+    return _AutoRebaseRecoverySnapshot(
+        branch=snapshot.branch,
+        local_head=snapshot.local_head,
+        remote_head=remote_head,
+        ahead=ahead,
+        behind=behind,
+    )
+
+
+def _already_published_recovery_notice(
+    context: _AutoRebaseRecoveryContext,
+    local_head: str,
+) -> str:
+    """Format the notice for a recovery push that landed before restart."""
+    notice = (
+        f":mag: Recovered an interrupted auto-rebase for PR "
+        f"#{context.pr_number}; the new head `{local_head[:8]}` was "
+        "already published before the orchestrator restart."
+    )
+    if context.behind == 0:
+        return (
+            notice
+            + f" Routing `{context.label}` -> `validating` so the "
+            "reviewer re-runs against the rewritten branch."
+        )
+    return (
+        notice
+        + f" Base advanced again by {context.behind} commit(s)"
+        " since the interrupted rebase; rebasing once "
+        "more before routing to `validating`."
+    )
+
+
+def _pushed_recovery_notice(
+    context: _AutoRebaseRecoveryContext,
+    local_head: str,
+) -> str:
+    """Format the notice for a recovery push reissued this tick."""
+    notice = (
+        f":mag: Recovered an interrupted auto-rebase for PR "
+        f"#{context.pr_number}; pushed the recovered head "
+        f"`{local_head[:8]}`."
+    )
+    if context.behind == 0:
+        return notice + f" Routing `{context.label}` -> `validating`."
+    return (
+        notice
+        + f" Base advanced again by {context.behind} commit(s) "
+        "since the interrupted rebase; rebasing once more "
+        "before routing to `validating`."
+    )
+
+
+def _finalize_already_published_recovery(
+    context: _AutoRebaseRecoveryContext,
+    snapshot: _AutoRebaseRecoverySnapshot,
+) -> bool:
+    """Finalize state after confirming that the interrupted push landed."""
+    return _finalize_recovered_rebase(
+        context,
+        local_head=snapshot.local_head,
+        method="crash_recovery_relabel_only",
+        notice=_already_published_recovery_notice(
+            context, snapshot.local_head,
+        ),
+    )
+
+
+def _reject_unknown_recovery_comparison(
+    context: _AutoRebaseRecoveryContext,
+    snapshot: _AutoRebaseRecoverySnapshot,
+) -> bool:
+    """Park when unequal heads cannot be classified as ahead or behind."""
+    log.warning(
+        "issue=#%d auto-rebase recovery: local HEAD (`%s`) differs "
+        "from remote PR head (`%s`) but `_branch_ahead_behind` "
+        "returned `(0, 0)`; aborting recovery and parking awaiting "
+        "human",
+        context.issue.number,
+        snapshot.local_head[:8],
+        snapshot.remote_head[:8],
+    )
+    return _abort_recovery_unverified(
+        context,
+        f"local HEAD `{snapshot.local_head[:8]}` differs from remote "
+        f"PR head `{snapshot.remote_head[:8]}` but "
+        "`_branch_ahead_behind` returned `(0, 0)`, which means the "
+        "remote-tracking ref we just fetched is unexpectedly missing "
+        "-- the path the recovery would take next cannot be determined "
+        "safely.",
+    )
+
+
+def _park_diverged_recovery(
+    context: _AutoRebaseRecoveryContext,
+    snapshot: _AutoRebaseRecoverySnapshot,
+) -> bool:
+    """Restore the anchor instead of overwriting an out-of-band PR update."""
+    _reset_clear_and_park(
+        context,
+        context.pending_pre_rebase_sha,
+        message=(
+            f"{config.HITL_MENTIONS} crash recovery for PR "
+            f"#{context.pr_number}: local worktree "
+            f"(`{snapshot.local_head[:8]}`) is {snapshot.ahead} ahead "
+            f"and {snapshot.behind} behind remote "
+            f"`{context.spec.remote_name}/{snapshot.branch}` -- the "
+            "remote PR branch was updated out-of-band during the "
+            "interrupted auto rebase. HEAD has been reset to the pre-"
+            f"rebase SHA `{context.pending_pre_rebase_sha[:8]}`. "
+            "Investigate the remote PR head and reply on this issue "
+            "with anything once the divergence is reconciled."
+        ),
+        reason="auto_base_rebase_push_failed",
+    )
+    return True
+
+
+def _park_dirty_recovery(
+    context: _AutoRebaseRecoveryContext,
+    snapshot: _AutoRebaseRecoverySnapshot,
+    dirty_files: list[str],
+) -> bool:
+    """Reset and clean a recovered rebase that carries worktree changes."""
+    _reset_clear_and_park(
+        context,
+        context.pending_pre_rebase_sha,
+        message=(
+            f"{config.HITL_MENTIONS} crash recovery for PR "
+            f"#{context.pr_number}: the rebased worktree (recovered "
+            f"from a prior tick, HEAD `{snapshot.local_head[:8]}`) "
+            f"carries {len(dirty_files)} uncommitted change(s). HEAD "
+            "has been reset to the pre-rebase SHA "
+            f"`{context.pending_pre_rebase_sha[:8]}` and untracked "
+            "files cleaned (use `git reflog` if you need the "
+            "discarded edits). Investigate, then reply on this issue "
+            "with anything to retry."
+        ),
+        reason="auto_base_rebase_dirty",
+        clean=True,
+    )
+    return True
+
+
+def _park_failed_recovery_push(
+    context: _AutoRebaseRecoveryContext,
+    snapshot: _AutoRebaseRecoverySnapshot,
+) -> bool:
+    """Restore the anchor after a recovered force-push fails."""
+    _reset_clear_and_park(
+        context,
+        context.pending_pre_rebase_sha,
+        message=(
+            f"{config.HITL_MENTIONS} crash recovery for PR "
+            f"#{context.pr_number}: `--force-with-lease` push of the "
+            f"recovered rebase (`{snapshot.local_head[:8]}`, lease "
+            f"against `{context.pending_pre_rebase_sha[:8]}`) failed. "
+            "HEAD has been reset to the pre-rebase SHA. Most likely "
+            "the remote PR branch was updated out-of-band; investigate "
+            "and reply on this issue with anything to retry."
+        ),
+        reason="auto_base_rebase_push_failed",
+    )
+    return True
+
+
+def _retry_recovery_push(
+    context: _AutoRebaseRecoveryContext,
+    snapshot: _AutoRebaseRecoverySnapshot,
+) -> bool:
+    """Publish a verified ahead-only recovery head and finalize its state."""
+    dirty_files = _worktree_dirty_files(context.worktree)
+    if dirty_files:
+        return _park_dirty_recovery(context, snapshot, dirty_files)
+    if not _push_branch(
+        context.spec,
+        context.worktree,
+        snapshot.branch,
+        force_with_lease=context.pending_pre_rebase_sha,
+    ):
+        return _park_failed_recovery_push(context, snapshot)
+    return _finalize_recovered_rebase(
+        context,
+        local_head=snapshot.local_head,
+        method="crash_recovery_pushed",
+        notice=_pushed_recovery_notice(context, snapshot.local_head),
+    )
+
+
+def _recover_pending_auto_base_rebase_context(
+    context: _AutoRebaseRecoveryContext,
+) -> bool:
+    """Route an interrupted auto-rebase from verified local/remote state."""
+    if context.label not in _PR_REFRESH_DETOUR_LABELS:
+        return _clear_ineligible_recovery(context)
+
+    snapshot = _fetch_recovery_snapshot(context)
+    if snapshot is None:
+        return True
+    if (
+        snapshot.local_head
+        and snapshot.local_head == context.pending_pre_rebase_sha
+    ):
+        return _clear_unchanged_recovery(context)
+
+    snapshot = _complete_recovery_snapshot(context, snapshot)
+    if snapshot is None:
+        return True
+    if snapshot.local_head and snapshot.local_head == snapshot.remote_head:
+        return _finalize_already_published_recovery(context, snapshot)
+    if snapshot.ahead == 0 and snapshot.behind == 0:
+        return _reject_unknown_recovery_comparison(context, snapshot)
+    if snapshot.behind > 0:
+        return _park_diverged_recovery(context, snapshot)
+    return _retry_recovery_push(context, snapshot)
 
 
 def _recover_pending_auto_base_rebase(
@@ -499,356 +934,134 @@ def _recover_pending_auto_base_rebase(
 ) -> bool:
     """Finalize a clean auto-base-rebase interrupted by a prior crash.
 
-    Called by `_sync_pr_worktree_to_base` when the pinned state carries
-    a `pending_auto_base_rebase_push_sha` from a previous tick. The
-    flag is set BEFORE `_rebase_base_into_worktree` and cleared on
-    every exit; a crash between then and the post-push state write
-    leaves the worktree in one of four shapes, each handled here:
-
-      1. Local HEAD == `pending_pre_rebase_sha` -- rebase was reverted
-         (or never moved HEAD). Nothing to recover. Clear the flag and
-         let the caller's normal flow re-attempt the rebase on this
-         same tick.
-      2. Local HEAD == remote PR head AND != `pending_pre_rebase_sha`
-         -- push went through on a prior tick; the relabel /
-         `review_round=0` write didn't. Finalize: clear flag, reset
-         `review_round`, post a recovery PR notice, emit
-         `base_rebased`, flip the label to `validating`.
-      3. Local HEAD ahead of remote PR head -- rebase done, push
-         didn't (or push succeeded but the remote ref was rolled back
-         out-of-band before the next tick). Push with
-         `--force-with-lease=<pending_pre_rebase_sha>` and finalize on
-         success.
-      4. Local HEAD behind or diverged from remote PR head -- someone
-         else updated the PR branch out-of-band. Reset HEAD back to
-         the pre-rebase SHA and park awaiting human.
-
-    Returns True when recovery finalized / parked (caller must return
-    immediately); False only for case 1 above (caller should continue
-    with the normal flow on this same tick).
+    The pinned pre-rebase SHA distinguishes an unchanged worktree, an
+    already-published rewrite, an ahead-only rewrite that still needs a
+    push, and a branch that diverged through an out-of-band update. Returns
+    False only when HEAD still equals the anchor and the normal rebase flow
+    should continue on the same tick.
     """
-    if label not in _PR_REFRESH_DETOUR_LABELS:
-        # Operator manually relabeled (e.g. to `resolving_conflict`
-        # for an unrelated reason). Clear the flag without acting.
-        state.set("pending_auto_base_rebase_push_sha", None)
-        gh.write_pinned_state(issue, state)
-        log.info(
-            "issue=#%d auto-rebase recovery: label %r is no longer in "
-            "the refresh-driven set; clearing pending flag",
-            issue.number, label,
-        )
-        return True
-
-    branch = _resolve_branch_name(state, spec, issue.number)
-
-    def _abort_recovery_unverified(detail: str) -> bool:
-        """Reset HEAD to the pre-rebase anchor and park awaiting human.
-
-        The four 'cannot positively verify the recovery target' paths
-        below (fetch failed, rev-parse failed, empty remote SHA,
-        `(0, 0)` ahead/behind with a SHA mismatch) must NOT just
-        `return True` without acting: that leaves the issue unparked
-        and the same-tick stage handler dispatch can run on a local
-        HEAD that we have NOT confirmed is published on the PR.
-        `_reset_clear_and_park` restores HEAD to `pending_pre_rebase_sha`
-        (= the local HEAD before the rebase = the remote PR head at the
-        time the anchor was set) and parks; the operator's reply on the
-        issue thread later un-parks via the refresh's
-        `_AUTO_REBASE_PARK_REASONS` recovery branch and re-attempts the
-        rebase fresh.
-        """
-        _reset_clear_and_park(
-            gh, issue, state, worktree, pending_pre_rebase_sha,
-            message=(
-                f"{config.HITL_MENTIONS} crash recovery for PR "
-                f"#{pr_number} could not safely finalize: {detail} "
-                f"Local HEAD has been reset to the pre-rebase SHA "
-                f"`{pending_pre_rebase_sha[:8]}` so the worktree "
-                "matches the (last-known) remote PR head -- the "
-                "issue is parked so the same-tick stage handlers do "
-                "NOT run against a SHA the PR may not carry. Reply "
-                "on this issue with anything once the underlying "
-                "problem is fixed and the orchestrator will re-"
-                "attempt the auto rebase on the next polling tick."
-            ),
-            reason="auto_base_rebase_push_failed",
-        )
-        return True
-
-    fetch_branch = _authed_fetch(
-        spec,
-        f"+refs/heads/{branch}:refs/remotes/{spec.remote_name}/{branch}",
-        cwd=worktree,
+    context = _AutoRebaseRecoveryContext(
+        gh=gh,
+        spec=spec,
+        issue=issue,
+        state=state,
+        worktree=worktree,
+        pr_number=pr_number,
+        label=label,
+        pending_pre_rebase_sha=pending_pre_rebase_sha,
+        behind=behind,
+        unparking_consumed_max=unparking_consumed_max,
     )
-    if fetch_branch.returncode != 0:
-        log.warning(
-            "issue=#%d auto-rebase recovery fetch of %s/%s failed: %s; "
-            "aborting recovery and parking awaiting human",
-            issue.number, spec.remote_name, branch,
-            (fetch_branch.stderr or "").strip(),
-        )
-        return _abort_recovery_unverified(
-            f"the fetch of `{spec.remote_name}/{branch}` needed to "
-            f"verify the recovered SHA against the remote PR head "
-            f"failed (`{(fetch_branch.stderr or '').strip()[:120]}`)."
-        )
+    return _recover_pending_auto_base_rebase_context(context)
 
-    local_head = _head_sha(worktree) or ""
-
-    if local_head and local_head == pending_pre_rebase_sha:
-        # Case 1: HEAD never moved past the pre-rebase SHA (or was
-        # reset back). Clear the flag and let the caller's normal
-        # flow re-attempt the rebase.
-        state.set("pending_auto_base_rebase_push_sha", None)
-        gh.write_pinned_state(issue, state)
-        log.info(
-            "issue=#%d auto-rebase recovery: local HEAD matches pre-"
-            "rebase SHA `%s`; clearing flag and falling through to "
-            "the normal rebase flow",
-            issue.number, pending_pre_rebase_sha[:8],
+def _base_sync_issue(
+    gh: GitHubClient, issue_number: int,
+) -> Optional[Issue]:
+    """Return the issue for a worktree, or None when it is not retrievable."""
+    try:
+        return gh.get_issue(issue_number)
+    except Exception:
+        log.debug(
+            "issue=#%d not retrievable; skipping base sync", issue_number,
         )
+        return None
+
+
+def _issue_skips_base_sync(issue: Issue, issue_number: int) -> bool:
+    """Apply dispatcher hard-skips and the question-stage read-only gate."""
+    skip_label = hard_skip_control_label(issue)
+    if skip_label is not None:
+        log.debug(
+            "issue=#%d has %r; skipping base sync",
+            issue_number,
+            skip_label,
+        )
+        return True
+    if not issue_has_label(issue, "question"):
         return False
-
-    # Read the freshly-fetched remote PR head SHA directly. We do NOT
-    # rely on `_branch_ahead_behind` alone for the case-2 finalize
-    # decision: that helper returns `(0, 0)` on git errors AND on the
-    # legitimate "in sync" case, which is indistinguishable. A
-    # case-2 finalize relabels to `validating` and clears the
-    # recovery anchor, so silently treating a git error as proof
-    # that the push landed would route the issue to validating
-    # against an unpublished SHA. `rev-parse` makes the comparison
-    # source explicit: an unreadable remote ref aborts recovery
-    # this tick AND parks (the same-tick handler dispatch would
-    # otherwise run on a local HEAD that may not be on the PR), and
-    # the case-2 finalize requires positive `local_head ==
-    # remote_pr_head`.
-    remote_ref = f"refs/remotes/{spec.remote_name}/{branch}"
-    remote_head_r = _git_hardened("rev-parse", remote_ref, cwd=worktree)
-    if remote_head_r.returncode != 0:
-        log.warning(
-            "issue=#%d auto-rebase recovery: rev-parse of %s failed "
-            "after fetch: %s; aborting recovery and parking awaiting human",
-            issue.number, remote_ref, (remote_head_r.stderr or "").strip(),
-        )
-        return _abort_recovery_unverified(
-            f"`git rev-parse {remote_ref}` failed after the fetch "
-            f"(`{(remote_head_r.stderr or '').strip()[:120]}`), so "
-            "the remote PR head SHA needed for the equality check "
-            "could not be read."
-        )
-    remote_pr_head = (remote_head_r.stdout or "").strip()
-    if not remote_pr_head:
-        log.warning(
-            "issue=#%d auto-rebase recovery: rev-parse of %s returned "
-            "no SHA; aborting recovery and parking awaiting human",
-            issue.number, remote_ref,
-        )
-        return _abort_recovery_unverified(
-            f"`git rev-parse {remote_ref}` returned no SHA after the "
-            "fetch, so the remote PR head SHA needed for the "
-            "equality check could not be read."
-        )
-
-    if local_head and local_head == remote_pr_head:
-        # Case 2: local HEAD == remote PR head, verified by an explicit
-        # rev-parse against the freshly-fetched remote ref. The push
-        # from the prior tick landed, so hand off to the shared finalize
-        # tail (clear anchor, reset `review_round`, notice, audit event,
-        # behind-aware relabel-or-fall-through).
-        notice = (
-            f":mag: Recovered an interrupted auto-rebase for PR "
-            f"#{pr_number}; the new head `{local_head[:8]}` was "
-            f"already published before the orchestrator restart."
-            + (
-                f" Routing `{label}` -> `validating` so the "
-                "reviewer re-runs against the rewritten branch."
-                if behind == 0
-                else f" Base advanced again by {behind} commit(s)"
-                f" since the interrupted rebase; rebasing once "
-                "more before routing to `validating`."
-            )
-        )
-        return _finalize_recovered_rebase(
-            gh, spec, issue, state,
-            pr_number=pr_number, label=label, local_head=local_head,
-            behind=behind, method="crash_recovery_relabel_only",
-            notice=notice, unparking_consumed_max=unparking_consumed_max,
-        )
-
-    # `local_head != remote_pr_head` here. Use `_branch_ahead_behind`
-    # to distinguish "push pending" (HEAD ahead of remote PR head,
-    # case 3) from "diverged" (HEAD behind / both ahead-and-behind,
-    # case 4). On a `_branch_ahead_behind` git error we get `(0, 0)`,
-    # which we have already ruled out (via the SHA inequality) is
-    # the legitimate in-sync state -- so a `(0, 0)` here means the
-    # remote-tracking ref we just fetched is unexpectedly missing.
-    # Bail rather than guess.
-    ahead, behind_pr = _branch_ahead_behind(spec, worktree, branch)
-    if ahead == 0 and behind_pr == 0:
-        log.warning(
-            "issue=#%d auto-rebase recovery: local HEAD (`%s`) differs "
-            "from remote PR head (`%s`) but `_branch_ahead_behind` "
-            "returned `(0, 0)`; aborting recovery and parking awaiting "
-            "human", issue.number, local_head[:8], remote_pr_head[:8],
-        )
-        return _abort_recovery_unverified(
-            f"local HEAD `{local_head[:8]}` differs from remote PR "
-            f"head `{remote_pr_head[:8]}` but `_branch_ahead_behind` "
-            "returned `(0, 0)`, which means the remote-tracking ref "
-            "we just fetched is unexpectedly missing -- the path the "
-            "recovery would take next cannot be determined safely."
-        )
-
-    if behind_pr > 0:
-        # Case 4: diverged from remote PR head (someone updated the PR
-        # branch out-of-band). Restore HEAD to the pre-rebase SHA and
-        # park -- force-pushing the local rebase here would clobber the
-        # out-of-band update.
-        _reset_clear_and_park(
-            gh, issue, state, worktree, pending_pre_rebase_sha,
-            message=(
-                f"{config.HITL_MENTIONS} crash recovery for PR "
-                f"#{pr_number}: local worktree (`{local_head[:8]}`) "
-                f"is {ahead} ahead and {behind_pr} behind remote "
-                f"`{spec.remote_name}/{branch}` -- the remote PR "
-                "branch was updated out-of-band during the interrupted "
-                "auto rebase. HEAD has been reset to the pre-rebase "
-                f"SHA `{pending_pre_rebase_sha[:8]}`. Investigate the "
-                "remote PR head and reply on this issue with anything "
-                "once the divergence is reconciled."
-            ),
-            reason="auto_base_rebase_push_failed",
-        )
-        return True
-
-    # Case 3: local HEAD ahead of remote PR head. Push didn't go
-    # through on the prior tick; try again with the original lease.
-    dirty = _worktree_dirty_files(worktree)
-    if dirty:
-        _reset_clear_and_park(
-            gh, issue, state, worktree, pending_pre_rebase_sha,
-            message=(
-                f"{config.HITL_MENTIONS} crash recovery for PR "
-                f"#{pr_number}: the rebased worktree (recovered from "
-                f"a prior tick, HEAD `{local_head[:8]}`) carries "
-                f"{len(dirty)} uncommitted change(s). HEAD has been "
-                f"reset to the pre-rebase SHA `{pending_pre_rebase_sha[:8]}` "
-                "and untracked files cleaned (use `git reflog` if you "
-                "need the discarded edits). Investigate, then reply on "
-                "this issue with anything to retry."
-            ),
-            reason="auto_base_rebase_dirty",
-            clean=True,
-        )
-        return True
-
-    if not _push_branch(
-        spec, worktree, branch, force_with_lease=pending_pre_rebase_sha,
-    ):
-        _reset_clear_and_park(
-            gh, issue, state, worktree, pending_pre_rebase_sha,
-            message=(
-                f"{config.HITL_MENTIONS} crash recovery for PR "
-                f"#{pr_number}: `--force-with-lease` push of the "
-                f"recovered rebase (`{local_head[:8]}`, lease against "
-                f"`{pending_pre_rebase_sha[:8]}`) failed. HEAD has been "
-                "reset to the pre-rebase SHA. Most likely the remote "
-                "PR branch was updated out-of-band; investigate and "
-                "reply on this issue with anything to retry."
-            ),
-            reason="auto_base_rebase_push_failed",
-        )
-        return True
-
-    # Recovery push succeeded: hand off to the shared finalize tail with
-    # the same `behind`-aware split as case 2. The recovered head is now
-    # the live PR head, so a fall-through (`behind > 0`) lets the
-    # caller's normal flow rebase it onto the newer base before routing.
-    notice = (
-        f":mag: Recovered an interrupted auto-rebase for PR "
-        f"#{pr_number}; pushed the recovered head "
-        f"`{local_head[:8]}`."
-        + (
-            f" Routing `{label}` -> `validating`."
-            if behind == 0
-            else f" Base advanced again by {behind} commit(s) "
-            "since the interrupted rebase; rebasing once more "
-            "before routing to `validating`."
-        )
+    log.debug(
+        "issue=#%d has 'question' label; skipping base sync "
+        "(read-only stage)",
+        issue_number,
     )
-    return _finalize_recovered_rebase(
-        gh, spec, issue, state,
-        pr_number=pr_number, label=label, local_head=local_head,
-        behind=behind, method="crash_recovery_pushed",
-        notice=notice, unparking_consumed_max=unparking_consumed_max,
+    return True
+
+
+def _worktree_behind_base(
+    spec: RepoSpec, worktree: Path, issue_number: int,
+) -> Optional[int]:
+    """Return the base lag, or None when the comparison cannot be read."""
+    base_ref = f"{spec.remote_name}/{spec.base_branch}"
+    behind_result = _git(
+        "rev-list", "--count", f"HEAD..{base_ref}", cwd=worktree,
+    )
+    if behind_result.returncode != 0:
+        log.debug(
+            "issue=#%d skipping base sync: rev-list failed: %s",
+            issue_number,
+            (behind_result.stderr or "").strip(),
+        )
+        return None
+    try:
+        return int((behind_result.stdout or "0").strip() or "0")
+    except ValueError:
+        return None
+
+
+def _sync_pre_pr_worktree(
+    spec: RepoSpec,
+    worktree: Path,
+    issue_number: int,
+    behind: int,
+) -> None:
+    """Rebase one clean pre-PR worktree and restore it on failure."""
+    base_ref = f"{spec.remote_name}/{spec.base_branch}"
+    succeeded, conflicted_files = _rebase_base_into_worktree(spec, worktree)
+    if succeeded:
+        log.info(
+            "issue=#%d rebased worktree onto %s (was %d commit(s) behind)",
+            issue_number,
+            base_ref,
+            behind,
+        )
+        return
+
+    abort_result = _git_hardened("rebase", "--abort", cwd=worktree)
+    if abort_result.returncode != 0:
+        log.warning(
+            "issue=#%d base rebase failed and abort failed: %s",
+            issue_number,
+            (abort_result.stderr or "").strip(),
+        )
+    if conflicted_files:
+        log.info(
+            "issue=#%d base rebase has %d conflict(s); aborted -- "
+            "resolving_conflict will handle it once a PR exists",
+            issue_number,
+            len(conflicted_files),
+        )
+        return
+    log.warning(
+        "issue=#%d base rebase failed without conflicted files; aborted",
+        issue_number,
     )
 
 
 def _sync_worktree_with_base(
     gh: GitHubClient, spec: RepoSpec, worktree: Path, issue_number: int,
 ) -> None:
-    """Bring a single per-issue worktree up to date with `origin/<base>`.
+    """Bring one per-issue worktree up to date with the configured base.
 
-    Pre-PR: rebase onto `origin/<base>` directly. PR-having + behind
-    base + label in {validating, documenting, in_review, fixing}: hand
-    off to `_sync_pr_worktree_to_base`, which attempts the rebase
-    locally, pushes (force-with-lease pinned to the pre-rebase SHA),
-    resets `review_round`, and relabels to `validating` on a clean
-    rebase. Only when that rebase leaves conflicted files does the
-    helper relabel to `resolving_conflict` so the existing handler
-    drives the dev agent to resolve them. Skips a dirty worktree
-    or a worktree already up to date (no pre-PR rebase attempted, no PR
-    rebase fired). On a pre-PR content conflict, aborts the rebase so
-    the worktree stays on its pre-rebase SHA -- conflict resolution
-    for pre-PR worktrees still lives in `_handle_resolving_conflict`,
-    reached only via an operator relabel until the issue earns a PR.
+    Pre-PR worktrees are rebased locally when clean. PR worktrees always
+    reach the PR-aware coordinator so a pinned crash-recovery anchor is
+    honored even when local HEAD already contains the latest base.
     """
-    try:
-        issue = gh.get_issue(issue_number)
-    except Exception:
-        log.debug(
-            "issue=#%d not retrievable; skipping base sync", issue_number,
-        )
+    issue = _base_sync_issue(gh, issue_number)
+    if issue is None or _issue_skips_base_sync(issue, issue_number):
         return
-    skip_label = hard_skip_control_label(issue)
-    if skip_label is not None:
-        # Match the dispatcher's hard-skip: `backlog` / `paused` mean "the
-        # orchestrator should not touch this issue at all", so refresh must
-        # not rebase base, post a PR comment, or detour the issue to
-        # `resolving_conflict` before `_process_issue` would have skipped it.
-        log.debug(
-            "issue=#%d has %r; skipping base sync",
-            issue_number, skip_label,
-        )
-        return
-    # `question`-labeled issues are read-only: the question agent
-    # must not commit, and `_handle_question` already tears down the
-    # per-issue worktree on every safe exit. The only worktrees that
-    # survive across ticks under this label are the unsafe-park
-    # cases (`question_commits`, `question_dirty`, `question_timeout`)
-    # where the operator is supposed to inspect what the agent did
-    # before resetting; merging `origin/<base>` over that inspection
-    # state would mask it. Skip base sync entirely while the label
-    # is `question` so the read-only contract holds even if the
-    # handler ever leaves the worktree on disk unexpectedly.
-    if issue_has_label(issue, "question"):
-        log.debug(
-            "issue=#%d has 'question' label; skipping base sync "
-            "(read-only stage)", issue_number,
-        )
-        return
+
     state = gh.read_pinned_state(issue)
     pr_number = state.get("pr_number")
-
-    # Pre-PR worktrees hard-skip on dirty: no remote anchor to recover
-    # towards, and no crash-recovery flag to honor. PR-having worktrees
-    # defer the dirty check into `_sync_pr_worktree_to_base` so a crash
-    # mid-rebase that left BOTH `pending_auto_base_rebase_push_sha` set
-    # AND uncommitted edits on the worktree still reaches
-    # `_recover_pending_auto_base_rebase`'s reset+clean+park path
-    # instead of being silently skipped here (which would leave the
-    # same-tick stage handler reading a local HEAD that is NOT on the
-    # PR).
     if pr_number is None and _worktree_dirty_files(worktree):
         log.debug(
             "issue=#%d skipping base sync: worktree has uncommitted changes",
@@ -856,68 +1069,16 @@ def _sync_worktree_with_base(
         )
         return
 
-    base_ref = f"{spec.remote_name}/{spec.base_branch}"
-    behind_r = _git(
-        "rev-list", "--count", f"HEAD..{base_ref}", cwd=worktree,
-    )
-    if behind_r.returncode != 0:
-        log.debug(
-            "issue=#%d skipping base sync: rev-list failed: %s",
-            issue_number, (behind_r.stderr or "").strip(),
-        )
+    behind = _worktree_behind_base(spec, worktree, issue_number)
+    if behind is None:
         return
-    try:
-        behind = int((behind_r.stdout or "0").strip() or "0")
-    except ValueError:
-        return
-
     if pr_number is not None:
-        # PR-having worktrees route here even when `behind == 0` -- the
-        # crash-recovery check inside `_sync_pr_worktree_to_base` keys
-        # off the pinned `pending_auto_base_rebase_push_sha` anchor,
-        # which is set on a normal tick BEFORE the rebase. A crash
-        # between rebase and push (or between push and relabel/state
-        # write) leaves local HEAD ahead of (or matching) the remote
-        # PR head AT a SHA that contains base, so the rev-list
-        # `HEAD..<base>` reports 0 even though the PR has not received
-        # the rewrite yet. Skipping here on `behind == 0` would leave
-        # validating reviewing a local SHA not on the PR (scenario 1)
-        # or in_review / documenting / fixing parked on stale state
-        # after a branch rewrite (scenario 2).
         _sync_pr_worktree_to_base(
             gh, spec, issue, state, worktree, int(pr_number), behind,
         )
         return
-
-    if behind == 0:
-        return
-
-    succeeded, conflicted = _rebase_base_into_worktree(spec, worktree)
-    if succeeded:
-        log.info(
-            "issue=#%d rebased worktree onto %s (was %d commit(s) behind)",
-            issue_number, base_ref, behind,
-        )
-        return
-
-    abort = _git_hardened("rebase", "--abort", cwd=worktree)
-    if abort.returncode != 0:
-        log.warning(
-            "issue=#%d base rebase failed and abort failed: %s",
-            issue_number, (abort.stderr or "").strip(),
-        )
-    if conflicted:
-        log.info(
-            "issue=#%d base rebase has %d conflict(s); aborted -- "
-            "resolving_conflict will handle it once a PR exists",
-            issue_number, len(conflicted),
-        )
-    else:
-        log.warning(
-            "issue=#%d base rebase failed without conflicted files; aborted",
-            issue_number,
-        )
-
+    if behind:
+        _sync_pre_pr_worktree(spec, worktree, issue_number, behind)
 
 def _auto_rebase_label_is_eligible(context: _AutoRebaseContext) -> bool:
     """Clear stale recovery state and reject labels refresh does not drive."""
@@ -1195,10 +1356,7 @@ def _park_unreadable_post_rebase_head(
         context.issue.number,
     )
     _reset_clear_and_park(
-        context.gh,
-        context.issue,
-        context.state,
-        context.worktree,
+        context,
         before_sha,
         message=(
             f"{config.HITL_MENTIONS} PR #{context.pr_number} is "
@@ -1242,10 +1400,7 @@ def _park_dirty_auto_rebase(
         len(dirty_files),
     )
     _reset_clear_and_park(
-        context.gh,
-        context.issue,
-        context.state,
-        context.worktree,
+        context,
         before_sha,
         message=(
             f"{config.HITL_MENTIONS} PR #{context.pr_number} is "
@@ -1271,10 +1426,7 @@ def _park_failed_auto_rebase_push(
 ) -> None:
     """Reset and park after a force-with-lease rejection or push failure."""
     _reset_clear_and_park(
-        context.gh,
-        context.issue,
-        context.state,
-        context.worktree,
+        context,
         before_sha,
         message=(
             f"{config.HITL_MENTIONS} PR #{context.pr_number} is "

--- a/orchestrator/branch_publication.py
+++ b/orchestrator/branch_publication.py
@@ -61,6 +61,7 @@ import os
 import re
 import subprocess
 from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -98,6 +99,198 @@ _CONVENTIONAL_RE = re.compile(
 # anchor keeps prose like `Note: ...` or a bare `TODO:` from matching.
 _PREFIXED_RE = re.compile(r"^[a-z][a-z0-9-]*(?:\([^)]+\))?!?:\s+\S")
 _PREFIX_TOKEN_RE = re.compile(r"^([a-z][a-z0-9-]*)(?:\([^)]+\))?!?:\s+\S")
+
+
+class _SquashPreparationError(RuntimeError):
+    """A pre-rewrite probe failed while the original branch was intact."""
+
+
+@dataclass(frozen=True)
+class _SquashPlan:
+    """Inputs that remain stable across the destructive squash rewrite."""
+
+    base_sha: str
+    original_head: str
+    subjects: tuple[str, ...]
+    message: str
+
+
+def _squash_base_sha(spec: RepoSpec, worktree: Path) -> str:
+    """Return the topic branch merge base or raise a preparation error."""
+    base_ref = f"{spec.remote_name}/{spec.base_branch}"
+    merge_base_result = _git("merge-base", base_ref, "HEAD", cwd=worktree)
+    if merge_base_result.returncode != 0:
+        detail = (merge_base_result.stderr or "").strip()
+        raise _SquashPreparationError(f"merge-base failed: {detail}")
+    base_sha = (merge_base_result.stdout or "").strip()
+    if not base_sha:
+        raise _SquashPreparationError("merge-base returned empty")
+    return base_sha
+
+
+def _squash_subjects(worktree: Path, base_sha: str) -> tuple[str, ...]:
+    """Return ordered topic-commit subjects or raise on an unreadable log."""
+    log_result = _git(
+        "log", "--reverse", "--pretty=%s", f"{base_sha}..HEAD",
+        cwd=worktree,
+    )
+    if log_result.returncode != 0:
+        detail = (log_result.stderr or "").strip()
+        raise _SquashPreparationError(f"git log failed: {detail}")
+    return tuple(
+        output_line
+        for output_line in (log_result.stdout or "").splitlines()
+        if output_line.strip()
+    )
+
+
+def _squash_message(
+    spec: RepoSpec,
+    worktree: Path,
+    issue: Issue,
+    subjects: tuple[str, ...],
+) -> str:
+    """Build the subject-only message for a multi-commit squash."""
+    first_subject = subjects[0]
+    if _is_prefixed_subject(first_subject):
+        return first_subject + "\n"
+    fallback_prefix = _infer_subject_prefix(spec, worktree, issue)
+    subject = _pr_title_from_commit_or_issue(
+        issue, first_subject, fallback_prefix,
+    )
+    return subject + "\n"
+
+
+def _prepare_squash(
+    spec: RepoSpec, worktree: Path, issue: Issue,
+) -> _SquashPlan:
+    """Collect every precondition before the branch rewrite begins."""
+    base_sha = _squash_base_sha(spec, worktree)
+    original_head = _head_sha(worktree)
+    if not original_head:
+        raise _SquashPreparationError("could not read original HEAD")
+    if _worktree_dirty_files(worktree):
+        raise _SquashPreparationError("worktree has uncommitted changes")
+    subjects = _squash_subjects(worktree, base_sha)
+    message = (
+        _squash_message(spec, worktree, issue, subjects)
+        if len(subjects) > 1
+        else ""
+    )
+    return _SquashPlan(base_sha, original_head, subjects, message)
+
+
+def _squash_failure(
+    error: str,
+) -> Tuple[bool, Optional[str], int, Optional[str]]:
+    """Return the uniform failure result while leaving commits intact."""
+    return False, None, 0, error
+
+
+def _squash_commit_env() -> dict[str, str]:
+    """Return the hardened agent identity used for the squash commit."""
+    return {
+        **os.environ,
+        **_GIT_NO_PROMPT_ENV,
+        "GIT_AUTHOR_NAME": config.AGENT_GIT_NAME,
+        "GIT_AUTHOR_EMAIL": config.AGENT_GIT_EMAIL,
+        "GIT_COMMITTER_NAME": config.AGENT_GIT_NAME,
+        "GIT_COMMITTER_EMAIL": config.AGENT_GIT_EMAIL,
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_SYSTEM": os.devnull,
+        "GIT_CONFIG_NOSYSTEM": "1",
+    }
+
+
+def _rollback_squash(
+    plan: _SquashPlan,
+    worktree: Path,
+    issue: Issue,
+    reason: str,
+    error: str,
+) -> Tuple[bool, Optional[str], int, Optional[str]]:
+    """Restore the original branch after a post-reset failure."""
+    rollback_result = _git_hardened(
+        "reset", "--hard", plan.original_head, cwd=worktree,
+    )
+    if rollback_result.returncode != 0:
+        log.error(
+            "issue=#%s rollback to %s after %s failed; worktree may be "
+            "in an inconsistent state: %s",
+            issue.number,
+            plan.original_head,
+            reason,
+            (rollback_result.stderr or "").strip(),
+        )
+    return _squash_failure(error)
+
+
+def _create_squash_commit(
+    worktree: Path, message: str,
+) -> subprocess.CompletedProcess:
+    """Create the orchestrator-owned commit with hooks and signing disabled."""
+    return subprocess.run(
+        [
+            "git",
+            "-c", "core.hooksPath=/dev/null",
+            "-c", "core.fsmonitor=",
+            "-c", "commit.gpgsign=false",
+            "commit", "-m", message,
+        ],
+        cwd=str(worktree),
+        capture_output=True,
+        text=True,
+        env=_squash_commit_env(),
+    )
+
+
+def _rewrite_squash(
+    spec: RepoSpec,
+    worktree: Path,
+    branch: str,
+    issue: Issue,
+    plan: _SquashPlan,
+) -> Tuple[bool, Optional[str], int, Optional[str]]:
+    """Apply a prepared squash and force-publish it with a pinned lease."""
+    reset_result = _git_hardened(
+        "reset", "--soft", plan.base_sha, cwd=worktree,
+    )
+    if reset_result.returncode != 0:
+        detail = (reset_result.stderr or "").strip()
+        return _squash_failure(f"reset --soft failed: {detail}")
+
+    commit_result = _create_squash_commit(worktree, plan.message)
+    if commit_result.returncode != 0:
+        detail = (commit_result.stderr or "").strip()
+        return _rollback_squash(
+            plan,
+            worktree,
+            issue,
+            "squash commit",
+            f"squash commit failed: {detail}",
+        )
+
+    new_sha = _head_sha(worktree)
+    if not new_sha:
+        return _rollback_squash(
+            plan,
+            worktree,
+            issue,
+            "post-commit head read",
+            "could not read new HEAD after squash",
+        )
+    if not _push_branch(
+        spec, worktree, branch, force_with_lease=plan.original_head,
+    ):
+        return _rollback_squash(
+            plan,
+            worktree,
+            issue,
+            "force-push",
+            "force-push with lease rejected (concurrent update on the "
+            "remote, or lease violation); see orchestrator logs",
+        )
+    return True, new_sha, len(plan.subjects), None
 
 
 def _branch_ahead_behind(
@@ -281,153 +474,10 @@ def _squash_and_force_push(
     authored under the AGENT_GIT_* identity (via env vars) so attribution
     matches the per-step commits this squash replaces.
     """
-    def _fail(error: str) -> Tuple[bool, Optional[str], int, Optional[str]]:
-        """Uniform failure result -- original commits left on the branch."""
-        return False, None, 0, error
-
-    base_ref = f"{spec.remote_name}/{spec.base_branch}"
-    mb = _git("merge-base", base_ref, "HEAD", cwd=worktree)
-    if mb.returncode != 0:
-        return _fail(f"merge-base failed: {(mb.stderr or '').strip()}")
-    base_sha = (mb.stdout or "").strip()
-    if not base_sha:
-        return _fail("merge-base returned empty")
-
-    # Snapshot the original HEAD BEFORE any destructive step. Every
-    # post-reset failure path below restores the branch to this SHA so
-    # the original commits are still on the branch (as the issue spec
-    # requires), and we use it as the pinned lease value for the
-    # force-push (the remote was last set to this SHA by the dev's plain
-    # push, so a remote drift between then and now means an out-of-band
-    # update we must NOT clobber).
-    original_head = _head_sha(worktree)
-    if not original_head:
-        return _fail("could not read original HEAD")
-
-    # Dirty-tree refusal is a hard precondition for the whole helper, NOT
-    # just the rewrite path: the issue spec lists "dirty tree" alongside
-    # push rejection / lease violation as a failure that must park
-    # awaiting_human and leave the original commits in place. A
-    # one-commit branch whose worktree happens to carry uncommitted
-    # changes (operator scratch, agent side-effect) must still surface
-    # to a human -- handing off to in_review with the dirty state
-    # invisible would let the merge land an incomplete head.
-    # (`_worktree_dirty_files` is hardened against a planted
-    # `core.fsmonitor`, the same vector the squash resets and commit
-    # below guard against.)
-    if _worktree_dirty_files(worktree):
-        return _fail("worktree has uncommitted changes")
-
-    log_r = _git(
-        "log", "--reverse", "--pretty=%s", f"{base_sha}..HEAD",
-        cwd=worktree,
-    )
-    if log_r.returncode != 0:
-        return _fail(f"git log failed: {(log_r.stderr or '').strip()}")
-    subjects = [
-        line for line in (log_r.stdout or "").splitlines() if line.strip()
-    ]
-    if len(subjects) <= 1:
-        # Nothing to squash.
-        return True, original_head, 0, None
-
-    if _is_prefixed_subject(subjects[0]):
-        subject = subjects[0]
-    else:
-        fallback_prefix = _infer_subject_prefix(spec, worktree, issue)
-        subject = _pr_title_from_commit_or_issue(
-            issue, subjects[0], fallback_prefix
-        )
-
-    # Subject-only message: the repo's Conventional Commits rule
-    # forbids bodies and trailers on orchestrator-authored commits
-    # (see CLAUDE.md). The per-step commit subjects this squash
-    # replaces are still visible via `git log <branch>@{1}` until the
-    # local ref is reaped, and the squashed PR carries the same
-    # context in its description; aggregating them into the commit
-    # body would just trip the next reviewer's commit-style check.
-    message = subject + "\n"
-
-    # `_git_hardened`, not `_git`: `reset --soft` refreshes the index and
-    # would otherwise execute an agent-planted `core.fsmonitor` helper with
-    # our process environment (ambient secrets) attached. The AGENT_GIT
-    # identity it also injects is inert here -- only HEAD moves, no commit.
-    reset_r = _git_hardened("reset", "--soft", base_sha, cwd=worktree)
-    if reset_r.returncode != 0:
-        return _fail(f"reset --soft failed: {(reset_r.stderr or '').strip()}")
-
-    def _fail_and_rollback(
-        reason: str, error: str
-    ) -> Tuple[bool, Optional[str], int, Optional[str]]:
-        """Restore the branch to original_head, then report `error`.
-
-        Every post-reset failure routes through here so the dev's original
-        commits survive a squash/push that did not complete. Best-effort:
-        a rollback failure leaves the worktree in an inconsistent state,
-        logged loudly so an operator notices.
-
-        `_git_hardened` for the same reason as the squash soft-reset above:
-        this index-touching `reset --hard` must not execute an agent-planted
-        `core.fsmonitor` with our process environment attached.
-        """
-        rb = _git_hardened("reset", "--hard", original_head, cwd=worktree)
-        if rb.returncode != 0:
-            log.error(
-                "issue=#%s rollback to %s after %s failed; worktree may be "
-                "in an inconsistent state: %s",
-                issue.number, original_head, reason,
-                (rb.stderr or "").strip(),
-            )
-        return _fail(error)
-
-    # Hardening for the orchestrator-owned squash commit. The agent has
-    # write access to .git/hooks, .git/config (templatedir), and any
-    # global/system git config the host user owns. Without these flags a
-    # planted pre-commit hook or commit-msg hook would run during this
-    # commit and could exfiltrate secrets we hold (no GIT_TOKEN here, but
-    # ANTHROPIC_API_KEY etc. live in os.environ for the agent to use).
-    # Mirrors the same hardening _push_branch applies.
-    commit_env = {
-        **os.environ,
-        **_GIT_NO_PROMPT_ENV,
-        "GIT_AUTHOR_NAME": config.AGENT_GIT_NAME,
-        "GIT_AUTHOR_EMAIL": config.AGENT_GIT_EMAIL,
-        "GIT_COMMITTER_NAME": config.AGENT_GIT_NAME,
-        "GIT_COMMITTER_EMAIL": config.AGENT_GIT_EMAIL,
-        "GIT_CONFIG_GLOBAL": os.devnull,
-        "GIT_CONFIG_SYSTEM": os.devnull,
-        "GIT_CONFIG_NOSYSTEM": "1",
-    }
-    commit_r = subprocess.run(
-        [
-            "git",
-            "-c", "core.hooksPath=/dev/null",
-            "-c", "core.fsmonitor=",
-            "-c", "commit.gpgsign=false",
-            "commit", "-m", message,
-        ],
-        cwd=str(worktree),
-        capture_output=True,
-        text=True,
-        env=commit_env,
-    )
-    if commit_r.returncode != 0:
-        return _fail_and_rollback(
-            "squash commit",
-            f"squash commit failed: {(commit_r.stderr or '').strip()}",
-        )
-
-    new_sha = _head_sha(worktree)
-    if not new_sha:
-        return _fail_and_rollback(
-            "post-commit head read", "could not read new HEAD after squash"
-        )
-
-    if not _push_branch(spec, worktree, branch, force_with_lease=original_head):
-        return _fail_and_rollback(
-            "force-push",
-            "force-push with lease rejected (concurrent update on the "
-            "remote, or lease violation); see orchestrator logs",
-        )
-
-    return True, new_sha, len(subjects), None
+    try:
+        plan = _prepare_squash(spec, worktree, issue)
+    except _SquashPreparationError as error:
+        return _squash_failure(str(error))
+    if len(plan.subjects) <= 1:
+        return True, plan.original_head, 0, None
+    return _rewrite_squash(spec, worktree, branch, issue, plan)

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -18,6 +18,7 @@ import sys
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -32,6 +33,16 @@ _SECRET_KEYS = frozenset({
     "GITHUB_ENTERPRISE_TOKEN",
     "GIT_TOKEN",
 })
+_DOTENV_TRUE_VALUES = frozenset({"1", "true", "on", "yes"})
+
+
+def _has_matched_outer_quotes(value: str) -> bool:
+    if len(value) < 2:
+        return False
+    quote = value[0]
+    if quote not in ('"', "'"):
+        return False
+    return value[-1] == quote
 
 
 def _strip_dotenv_quotes(value: str) -> str:
@@ -50,37 +61,54 @@ def _strip_dotenv_quotes(value: str) -> str:
     anything else is returned verbatim so quoted segments inside the
     value survive untouched.
     """
-    v = value.strip()
-    if len(v) >= 2 and v[0] == v[-1] and v[0] in ('"', "'"):
-        return v[1:-1]
-    return v
+    stripped_value = value.strip()
+    if _has_matched_outer_quotes(stripped_value):
+        return stripped_value[1:-1]
+    return stripped_value
+
+
+def _dotenv_loading_disabled() -> bool:
+    setting = os.environ.get("ORCHESTRATOR_SKIP_DOTENV", "")
+    return setting.strip().lower() in _DOTENV_TRUE_VALUES
+
+
+def _parse_dotenv_entry(raw_line: str) -> Optional[tuple[str, str]]:
+    line = raw_line.strip()
+    if not line or line.startswith("#"):
+        return None
+    key, _, value = line.partition("=")
+    return key.strip(), _strip_dotenv_quotes(value)
+
+
+def _warn_ignored_dotenv_secret(key: str, env_path: Path) -> None:
+    print(
+        f"orchestrator: ignoring {key} in {env_path}; the implementer "
+        f"agent can read this file. Move the token to "
+        f"~/.config/<owner>/<repo>/token (path derived from REPO) "
+        f"or export {key} before launching.",
+        file=sys.stderr,
+    )
+
+
+def _load_dotenv_entry(raw_line: str, env_path: Path) -> None:
+    entry = _parse_dotenv_entry(raw_line)
+    if entry is None:
+        return
+    key, value = entry
+    if key in _SECRET_KEYS:
+        _warn_ignored_dotenv_secret(key, env_path)
+        return
+    os.environ.setdefault(key, value)
 
 
 def _load_dotenv() -> None:
-    if os.environ.get("ORCHESTRATOR_SKIP_DOTENV", "").strip().lower() in (
-        "1", "true", "on", "yes",
-    ):
+    if _dotenv_loading_disabled():
         return
     env_path = REPO_ROOT / ".env"
     if not env_path.exists():
         return
-    for raw in env_path.read_text().splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        key, _, value = line.partition("=")
-        key = key.strip()
-        value = _strip_dotenv_quotes(value)
-        if key in _SECRET_KEYS:
-            print(
-                f"orchestrator: ignoring {key} in {env_path}; the implementer "
-                f"agent can read this file. Move the token to "
-                f"~/.config/<owner>/<repo>/token (path derived from REPO) "
-                f"or export {key} before launching.",
-                file=sys.stderr,
-            )
-            continue
-        os.environ.setdefault(key, value)
+    for raw_line in env_path.read_text().splitlines():
+        _load_dotenv_entry(raw_line, env_path)
 
 
 def _resolve_github_token(repo: str) -> str:

--- a/orchestrator/dashboard.py
+++ b/orchestrator/dashboard.py
@@ -37,21 +37,20 @@ file stays the Streamlit orchestration layer:
   per-skill trigger matrix, the backend-efficiency card, the
   cost-coverage bar, and the reliability-tile strip.
 
-`main()` is a thin orchestrator: it delegates the static-metadata read
-(`_read_static_metadata`), the staged widget fan-out (`_widget_readers`
-+ `_dispatch_reads`), the load-timing log (`_log_dashboard_load`), the
-empty / error states (`_render_no_data`, `_render_empty_window`), and
-every filter / widget section (the `_render_*` helpers) to focused
-module-level helpers, so it reads as a top-to-bottom sequence of calls
-rather than a single 1000-line function.
+`main()` is the lazy Streamlit entrypoint. The page pipeline below it
+groups the imported dashboard modules, resolved filters, read waves,
+and KPI results into small immutable state objects. Focused helpers own
+static metadata, controls, staged reads, empty states, and card sections,
+so the two-wave render order remains explicit without one oversized
+entrypoint.
 
 Every pure helper from those three modules is re-exported below under
 its original name so `streamlit run orchestrator/dashboard.py`, the
 historical `orchestrator.dashboard.*` helper surface, and the existing
 dashboard tests keep working without touching the extracted modules.
-The `main()`-support helpers (the read / dispatch / logging helpers and
-the `_render_*` render helpers) are defined in this module, are not
-re-exported, and stay module-private.
+The page-pipeline helpers are module-private. `_render_drilldown` is the
+one exception: its historical signature remains on the explicit export
+surface and delegates to the typed internal drill-down renderer.
 
 Reads go through `orchestrator.analytics.read` (which already
 handles unset DB, connection errors, and lazy psycopg import) and
@@ -74,8 +73,8 @@ write runs on the main thread.
 
 Streamlit (and its transitive pandas), `plotly`, the chart builders
 in `orchestrator.dashboard_charts`, and the theme tokens in
-`orchestrator.dashboard_theme` are imported *lazily* inside `main()`
-so the polling tick's `orchestrator.*` import surface stays free of
+`orchestrator.dashboard_theme` are imported *lazily* on the `main()`
+call path so the polling tick's `orchestrator.*` import surface stays free of
 the dashboard's dependency footprint. The module loads without
 `streamlit` or `plotly` installed -- only `streamlit run
 orchestrator/dashboard.py` (or a direct `main()` call) materializes
@@ -90,7 +89,9 @@ Run:
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import date, timedelta
+from functools import partial
 from time import perf_counter
 from typing import Any, Callable, Optional, Sequence
 
@@ -312,262 +313,417 @@ EMPTY_WINDOW_MESSAGE = (
 
 
 def main() -> None:
-    """Streamlit entrypoint.
-
-    Imports Streamlit, pandas, plotly, the chart builders, and the
-    theme tokens lazily so the orchestrator polling path never pulls
-    them in. Run via `streamlit run orchestrator/dashboard.py`;
-    Streamlit invokes the script with `__name__ == "__main__"`, which
-    falls through to the sentinel at the bottom of this file.
-    """
-    import pandas as pd
+    """Run the Streamlit analytics page with lazily loaded dependencies."""
     import streamlit as st
 
-    from orchestrator import dashboard_charts, dashboard_theme as theme
+    _run_dashboard(st)
 
-    st.set_page_config(
+
+@dataclass(frozen=True)
+class _DashboardModules:
+    st: Any
+    pd: Any
+    charts: Any
+    theme: Any
+
+
+@dataclass(frozen=True)
+class _SidebarSelections:
+    repo: str
+    events: Sequence[str]
+    stages: Sequence[str]
+    issue_input: str
+
+
+@dataclass(frozen=True)
+class _DashboardFilters:
+    window: DateWindow
+    repo: Optional[str]
+    issue_input: Optional[int]
+    events: Optional[Sequence[str]]
+    stages: Optional[Sequence[str]]
+
+    @property
+    def issue(self) -> Optional[int]:
+        if self.repo is None:
+            return None
+        return self.issue_input
+
+    @property
+    def days(self) -> int:
+        return max((self.window.end - self.window.start).days, 1)
+
+
+@dataclass(frozen=True)
+class _DashboardControls:
+    filters: _DashboardFilters
+    topbar_slot: Any
+    meta_slot: Any
+    timezone_offset: int
+
+
+@dataclass(frozen=True)
+class _DashboardReadPlan:
+    first_wave: Sequence[tuple[str, Callable[[], Any]]]
+    second_wave: Sequence[tuple[str, Callable[[], Any]]]
+    parallel: bool
+    started_at: float
+
+    @property
+    def total_reads(self) -> int:
+        return len(self.first_wave) + len(self.second_wave)
+
+
+@dataclass(frozen=True)
+class _DashboardPage:
+    extent: DataExtent
+    controls: _DashboardControls
+    reads: _DashboardReadPlan
+
+
+@dataclass(frozen=True)
+class _DashboardKpis:
+    items: Sequence[dict[str, Any]]
+    resolved: int
+    rejected: int
+
+
+@dataclass(frozen=True)
+class _LoadedDashboard:
+    results: dict[str, Any]
+    kpis: _DashboardKpis
+
+
+@dataclass(frozen=True)
+class _ReliabilityPanelData:
+    repos: Sequence[Any]
+    summary: Summary
+    throughput: Sequence[Any]
+    window: DateWindow
+    resolved: int
+    rejected: int
+
+
+def _load_dashboard_modules(st: Any) -> _DashboardModules:
+    import pandas as pd
+
+    from orchestrator import dashboard_charts, dashboard_theme
+
+    return _DashboardModules(
+        st=st,
+        pd=pd,
+        charts=dashboard_charts,
+        theme=dashboard_theme,
+    )
+
+
+def _configure_dashboard(modules: _DashboardModules) -> None:
+    modules.st.set_page_config(
         page_title="Orchestrator Analytics",
         layout="wide",
     )
-    st.markdown(theme.PAGE_CSS, unsafe_allow_html=True)
+    modules.st.markdown(modules.theme.PAGE_CSS, unsafe_allow_html=True)
 
-    unset = db_unconfigured_message()
-    if unset:
-        st.warning(unset)
-        st.stop()
 
-    extent, options = _read_static_metadata(st=st)
-
-    if extent.min_ts is None or extent.max_ts is None:
-        _render_no_data(st=st, extent=extent, theme=theme)
+def _stop_if_dashboard_unconfigured(modules: _DashboardModules) -> None:
+    message = db_unconfigured_message()
+    if not message:
         return
+    modules.st.warning(message)
+    modules.st.stop()
 
-    extent_min_d = extent.min_ts.date()
-    extent_max_d = extent.max_ts.date()
 
-    repo_choice, event_choice, stage_choice, issue_input = (
-        _render_sidebar_filters(st=st, options=options)
+def _run_dashboard(st: Any) -> None:
+    modules = _load_dashboard_modules(st)
+    _configure_dashboard(modules)
+    _stop_if_dashboard_unconfigured(modules)
+    _render_dashboard(
+        modules,
+        *_read_static_metadata(st=modules.st),
     )
 
-    # Timezone selector lives inside the "When agents run" block (see
-    # the heatmap card below), but the offset is read here so the
-    # second-wave fan-out can bucket the heatmap in the chosen zone.
-    # Seeding session_state on first render lets the selectbox default
-    # to UTC+7 while subsequent renders read whatever the operator
-    # picked. The widget is wired with `key="tz_offset_hours"` further
-    # down so it round-trips through this same session_state slot.
+
+def _render_dashboard(
+    modules: _DashboardModules,
+    extent: DataExtent,
+    options: Any,
+) -> None:
+    if extent.min_ts is None or extent.max_ts is None:
+        _render_no_data(st=modules.st, extent=extent, theme=modules.theme)
+        return
+    page = _prepare_dashboard_page(modules, extent, options)
+    loaded = _load_dashboard_data(modules, page)
+    if loaded is None:
+        return
+    _render_dashboard_widgets(modules, page, loaded)
+
+
+def _timezone_choice(st: Any) -> int:
     if "tz_offset_hours" not in st.session_state:
         st.session_state.tz_offset_hours = DEFAULT_TZ_OFFSET_HOURS
-    tz_offset_choice = int(st.session_state.tz_offset_hours)
+    return int(st.session_state.tz_offset_hours)
 
-    # Topbar: title + spend pill. We render a placeholder spend now
-    # so it occupies the right slot; we replace it after the summary
-    # query lands below.
-    topbar_slot = st.empty()
 
-    # Filter bar: presets + date inputs + range meta inside a bordered
-    # container styled as the "Date range" card. `meta_slot` is filled
-    # after the summary read lands (the run count is not known yet);
-    # `window` feeds every downstream read.
-    window, meta_slot = _render_date_filter_bar(
-        st=st,
+def _resolve_dashboard_filters(
+    window: DateWindow,
+    selections: _SidebarSelections,
+    options: Any,
+) -> _DashboardFilters:
+    repo = None
+    if selections.repo != "All":
+        repo = selections.repo
+    return _DashboardFilters(
+        window=window,
+        repo=repo,
+        issue_input=parse_issue_number(selections.issue_input),
+        events=list(selections.events),
+        stages=resolve_stage_filter(selections.stages, options.stages),
+    )
+
+
+def _render_dashboard_controls(
+    modules: _DashboardModules,
+    extent: DataExtent,
+    options: Any,
+) -> _DashboardControls:
+    selections = _render_sidebar_filters(st=modules.st, options=options)
+    timezone_offset = _timezone_choice(modules.st)
+    topbar_slot = modules.st.empty()
+    window_meta = _render_date_filter_bar(
+        st=modules.st,
         extent=extent,
-        extent_min_d=extent_min_d,
-        extent_max_d=extent_max_d,
+        extent_min_d=extent.min_ts.date(),
+        extent_max_d=extent.max_ts.date(),
+    )
+    return _DashboardControls(
+        filters=_resolve_dashboard_filters(window_meta[0], selections, options),
+        topbar_slot=topbar_slot,
+        meta_slot=window_meta[1],
+        timezone_offset=timezone_offset,
     )
 
-    repo_filter = None if repo_choice == "All" else repo_choice
-    issue_input_parsed = parse_issue_number(issue_input)
-    issue_filter = None
-    if repo_filter:
-        issue_filter = issue_input_parsed
-    event_filter = list(event_choice)
-    stage_filter = resolve_stage_filter(stage_choice, options.stages)
 
-    key, prev_key = _build_read_keys(
-        window=window,
-        repo_filter=repo_filter,
-        event_filter=event_filter,
-        stage_filter=stage_filter,
-        issue_filter=issue_filter,
+def _prepare_dashboard_page(
+    modules: _DashboardModules,
+    extent: DataExtent,
+    options: Any,
+) -> _DashboardPage:
+    controls = _render_dashboard_controls(modules, extent, options)
+    keys = _build_read_keys(
+        window=controls.filters.window,
+        repo_filter=controls.filters.repo,
+        event_filter=controls.filters.events,
+        stage_filter=controls.filters.stages,
+        issue_filter=controls.filters.issue,
+    )
+    readers = _widget_readers(
+        st=modules.st,
+        key=keys[0],
+        prev_key=keys[1],
+        tz_offset_choice=controls.timezone_offset,
+    )
+    return _DashboardPage(
+        extent=extent,
+        controls=controls,
+        reads=_DashboardReadPlan(
+            first_wave=readers[0],
+            second_wave=readers[1],
+            parallel=dashboard_parallel_reads_enabled(),
+            started_at=perf_counter(),
+        ),
     )
 
-    first_wave_readers, second_wave_readers = _widget_readers(
-        st=st,
-        key=key,
-        prev_key=prev_key,
-        tz_offset_choice=tz_offset_choice,
-    )
-    total_reads = len(first_wave_readers) + len(second_wave_readers)
-    parallel = dashboard_parallel_reads_enabled()
-    load_start = perf_counter()
-    # Single inline spinner spans both waves -- the topbar / KPI
-    # strip rendered between waves provides progressive feedback
-    # while the second wave finishes, and the spinner clears once
-    # every widget has its data. UI writes always run on this main
-    # thread (the worker threads `_fan_out_reads` spawns only return
-    # data back through the futures), so the staged renders below
-    # never reach Streamlit from a worker.
-    with st.spinner(LOADING_INDICATOR_MESSAGE):
-        results = _dispatch_reads(
-            first_wave_readers, st=st, parallel=parallel,
-        )
-        summary = results["summary"]
-        prev_summary = results["prev_summary"]
-        ts_points = results["ts_points"]
-        review_round_rows = results["review_round_rows"]
-        throughput_rows = results["throughput_rows"]
-        cost_coverage_rows = results["cost_coverage_rows"]
 
-        # Topbar / filter meta paint on the first-wave results so the
-        # user sees real content before the second wave fires.
-        topbar_slot.markdown(
-            _topbar_html(
-                extent=extent,
-                distinct_repos=summary.distinct_repos,
-                total_events=summary.total_events,
-                spend_in_range=summary.total_cost_usd,
-                fmt_money_exact=theme.fmt_money_exact,
-                fmt_num=theme.fmt_num,
-            ),
-            unsafe_allow_html=True,
-        )
-        days_in_window = max((window.end - window.start).days, 1)
-        meta_slot.markdown(
-            _filter_meta_html(
-                from_d=window.start.date(),
-                to_d=(window.end - timedelta(days=1)).date(),
-                days=days_in_window,
-                runs=summary.total_agent_runs,
-                fmt_num=theme.fmt_num,
-            ),
-            unsafe_allow_html=True,
-        )
-
-        if summary.total_events == 0:
-            # Empty window -- skip the second wave entirely; the
-            # remaining reads would only paint empty cards.
-            _render_empty_window(
-                st=st,
-                pd=pd,
-                load_start=load_start,
-                reads=len(first_wave_readers),
-                parallel=parallel,
-                window=window,
-                repo_filter=repo_filter,
-                issue_input_parsed=issue_input_parsed,
-                event_filter=event_filter,
-                stage_filter=stage_filter,
-            )
-            return
-
-        # Insights + KPI strip ---------------------------------------
-        banners = compute_insights(
-            summary,
-            cost_coverage_rows=cost_coverage_rows,
-        )
-        if banners:
-            st.markdown(_insights_html(banners), unsafe_allow_html=True)
-        kpis, resolved, rejected = _build_kpi_strip_data(
-            theme=theme,
-            summary=summary,
-            prev_summary=prev_summary,
-            ts_points=ts_points,
-            throughput_rows=throughput_rows,
-            review_round_rows=review_round_rows,
-            days_in_window=days_in_window,
-        )
-        st.markdown(_kpi_strip_html(kpis), unsafe_allow_html=True)
-
-        # Second wave -- the remaining widget reads. The KPI strip
-        # already painted above, so the user has real content on
-        # screen while the second wave finishes.
-        results.update(_dispatch_reads(
-            second_wave_readers, st=st, parallel=parallel,
-        ))
-    _log_dashboard_load(
-        load_start=load_start, reads=total_reads, parallel=parallel,
+def _render_topbar_and_meta(
+    modules: _DashboardModules,
+    page: _DashboardPage,
+    summary: Summary,
+) -> None:
+    page.controls.topbar_slot.markdown(
+        _topbar_html(
+            extent=page.extent,
+            distinct_repos=summary.distinct_repos,
+            total_events=summary.total_events,
+            spend_in_range=summary.total_cost_usd,
+            fmt_money_exact=modules.theme.fmt_money_exact,
+            fmt_num=modules.theme.fmt_num,
+        ),
+        unsafe_allow_html=True,
     )
-    stage_rows = results["stage_rows"]
-    agent_exits = results["agent_exits"]
-    issues_rows = results["issues_rows"]
-    backend_rows = results["backend_rows"]
-    repo_rows = results["repo_rows"]
-    heatmap_rows = results["heatmap_rows"]
-    backend_daily_rows = results["backend_daily_rows"]
-    skill_rows = results["skill_rows"]
-    skill_matrix_rows = results["skill_matrix_rows"]
-
-    _render_hero_usage(
-        st=st,
-        dashboard_charts=dashboard_charts,
-        ts_points=ts_points,
-        backend_daily_rows=backend_daily_rows,
-    )
-    _render_stage_review_bars(
-        st=st,
-        dashboard_charts=dashboard_charts,
-        stage_rows=stage_rows,
-        review_round_rows=review_round_rows,
-    )
-    _render_issues_and_backends(
-        st=st,
-        theme=theme,
-        issues_rows=issues_rows,
-        backend_rows=backend_rows,
-        cost_coverage_rows=cost_coverage_rows,
-    )
-    _render_repo_and_reliability(
-        st=st,
-        dashboard_charts=dashboard_charts,
-        theme=theme,
-        repo_rows=repo_rows,
-        summary=summary,
-        throughput_rows=throughput_rows,
-        window=window,
-        resolved=resolved,
-        rejected=rejected,
-    )
-    _render_activity_heatmap(
-        st=st,
-        dashboard_charts=dashboard_charts,
-        heatmap_rows=heatmap_rows,
-        tz_offset_choice=tz_offset_choice,
-    )
-
-    _render_skill_triggers(
-        st=st,
-        skill_rows=skill_rows,
-        skill_matrix_rows=skill_matrix_rows,
-    )
-
-    _render_recent_runs(
-        st=st,
-        pd=pd,
-        agent_exits=agent_exits,
-        tz_offset_choice=tz_offset_choice,
-    )
-
-    _render_drilldown(
-        st=st,
-        pd=pd,
-        window=window,
-        repo_filter=repo_filter,
-        issue_input_parsed=issue_input_parsed,
-        event_filter=event_filter,
-        stage_filter=stage_filter,
-    )
-
-    st.markdown(
-        '<div class="orch-foot">'
-        f'Real data · window {window.start.date().isoformat()} → '
-        f'{(window.end - timedelta(days=1)).date().isoformat()} · '
-        f'{theme.fmt_num(summary.total_agent_runs)} agent runs'
-        '</div>',
+    page.controls.meta_slot.markdown(
+        _filter_meta_html(
+            from_d=page.controls.filters.window.start.date(),
+            to_d=(
+                page.controls.filters.window.end - timedelta(days=1)
+            ).date(),
+            days=page.controls.filters.days,
+            runs=summary.total_agent_runs,
+            fmt_num=modules.theme.fmt_num,
+        ),
         unsafe_allow_html=True,
     )
 
 
+def _render_dashboard_insights(
+    modules: _DashboardModules,
+    summary: Summary,
+    cost_coverage_rows: Sequence[CostCoverageRow],
+) -> None:
+    banners = compute_insights(
+        summary,
+        cost_coverage_rows=cost_coverage_rows,
+    )
+    if banners:
+        modules.st.markdown(_insights_html(banners), unsafe_allow_html=True)
+
+
+def _render_first_wave(
+    modules: _DashboardModules,
+    page: _DashboardPage,
+    results: dict[str, Any],
+) -> Optional[_DashboardKpis]:
+    summary = results["summary"]
+    _render_topbar_and_meta(modules, page, summary)
+    if summary.total_events == 0:
+        _render_empty_window(modules, page)
+        return None
+    _render_dashboard_insights(
+        modules,
+        summary,
+        results["cost_coverage_rows"],
+    )
+    kpi_values = _build_kpi_strip_data(_KpiInputs(
+        theme=modules.theme,
+        summary=summary,
+        prev_summary=results["prev_summary"],
+        ts_points=results["ts_points"],
+        throughput_rows=results["throughput_rows"],
+        review_round_rows=results["review_round_rows"],
+        days_in_window=page.controls.filters.days,
+    ))
+    modules.st.markdown(
+        _kpi_strip_html(kpi_values[0]),
+        unsafe_allow_html=True,
+    )
+    return _DashboardKpis(*kpi_values)
+
+
+def _load_dashboard_data(
+    modules: _DashboardModules,
+    page: _DashboardPage,
+) -> Optional[_LoadedDashboard]:
+    with modules.st.spinner(LOADING_INDICATOR_MESSAGE):
+        results = _dispatch_reads(
+            page.reads.first_wave,
+            st=modules.st,
+            parallel=page.reads.parallel,
+        )
+        kpis = _render_first_wave(modules, page, results)
+        if kpis is None:
+            return None
+        results.update(_dispatch_reads(
+            page.reads.second_wave,
+            st=modules.st,
+            parallel=page.reads.parallel,
+        ))
+    _log_dashboard_load(
+        load_start=page.reads.started_at,
+        reads=page.reads.total_reads,
+        parallel=page.reads.parallel,
+    )
+    return _LoadedDashboard(results=results, kpis=kpis)
+
+
+def _render_chart_widgets(
+    modules: _DashboardModules,
+    page: _DashboardPage,
+    loaded: _LoadedDashboard,
+) -> None:
+    _render_hero_usage(
+        st=modules.st,
+        dashboard_charts=modules.charts,
+        ts_points=loaded.results["ts_points"],
+        backend_daily_rows=loaded.results["backend_daily_rows"],
+    )
+    _render_stage_review_bars(
+        st=modules.st,
+        dashboard_charts=modules.charts,
+        stage_rows=loaded.results["stage_rows"],
+        review_round_rows=loaded.results["review_round_rows"],
+    )
+    _render_issues_and_backends(
+        st=modules.st,
+        theme=modules.theme,
+        issues_rows=loaded.results["issues_rows"],
+        backend_rows=loaded.results["backend_rows"],
+        cost_coverage_rows=loaded.results["cost_coverage_rows"],
+    )
+    _render_repo_and_reliability(
+        modules,
+        _ReliabilityPanelData(
+            repos=loaded.results["repo_rows"],
+            summary=loaded.results["summary"],
+            throughput=loaded.results["throughput_rows"],
+            window=page.controls.filters.window,
+            resolved=loaded.kpis.resolved,
+            rejected=loaded.kpis.rejected,
+        ),
+    )
+    _render_activity_heatmap(
+        st=modules.st,
+        dashboard_charts=modules.charts,
+        heatmap_rows=loaded.results["heatmap_rows"],
+        tz_offset_choice=page.controls.timezone_offset,
+    )
+
+
+def _render_remaining_widgets(
+    modules: _DashboardModules,
+    page: _DashboardPage,
+    loaded: _LoadedDashboard,
+) -> None:
+    _render_skill_triggers(
+        st=modules.st,
+        skill_rows=loaded.results["skill_rows"],
+        skill_matrix_rows=loaded.results["skill_matrix_rows"],
+    )
+    _render_recent_runs(
+        st=modules.st,
+        pd=modules.pd,
+        agent_exits=loaded.results["agent_exits"],
+        tz_offset_choice=page.controls.timezone_offset,
+    )
+    _render_drilldown_view(modules, page.controls.filters)
+    _render_dashboard_footer(
+        modules,
+        page.controls.filters,
+        loaded.results["summary"],
+    )
+
+
+def _render_dashboard_widgets(
+    modules: _DashboardModules,
+    page: _DashboardPage,
+    loaded: _LoadedDashboard,
+) -> None:
+    _render_chart_widgets(modules, page, loaded)
+    _render_remaining_widgets(modules, page, loaded)
+
+
+def _render_dashboard_footer(
+    modules: _DashboardModules,
+    filters: _DashboardFilters,
+    summary: Summary,
+) -> None:
+    end_date = (filters.window.end - timedelta(days=1)).date()
+    modules.st.markdown(
+        '<div class="orch-foot">'
+        f'Real data · window {filters.window.start.date().isoformat()} → '
+        f'{end_date.isoformat()} · '
+        f'{modules.theme.fmt_num(summary.total_agent_runs)} agent runs'
+        '</div>',
+        unsafe_allow_html=True,
+    )
 def _filter_list(values_t: Optional[Sequence[str]]) -> Optional[list[str]]:
     """Convert a cached filter tuple back to the read model's list arg.
 
@@ -655,151 +811,157 @@ def _render_no_data(*, st: Any, extent: DataExtent, theme: Any) -> None:
     st.stop()
 
 
-def _read_summary(start, end, repo, events_t, stages_t, issue):
-    return _scoped_read(
-        analytics_read.get_summary,
-        start=start, end=end, repo=repo,
-        events=_filter_list(events_t), stages=_filter_list(stages_t),
-        issue=issue,
-    )
+def _read_filter_kwargs(key: tuple) -> dict[str, Any]:
+    return {
+        "start": key[0],
+        "end": key[1],
+        "repo": key[2],
+        "events": _filter_list(key[3]),
+        "stages": _filter_list(key[4]),
+        "issue": key[5],
+    }
 
 
-def _read_prev_kpi(start, end, repo, events_t, stages_t, issue):
+def _read_filtered(
+    getter: Callable[..., Any],
+    key: tuple,
+    **extra_filters: Any,
+) -> Any:
+    filters = _read_filter_kwargs(key)
+    filters.update(extra_filters)
+    return _scoped_read(getter, **filters)
+
+
+def _read_summary(key: tuple):
+    return _read_filtered(analytics_read.get_summary, key)
+
+
+def _read_prev_kpi(key: tuple):
     # Previous-window read for the KPI delta pills and cost-trend
     # banner only. The full `get_summary` shape is never read off
     # `prev_summary`, so a thinner reader saves a `GROUP BY` follow-up
     # while leaving the cache key identical to `_read_summary`.
-    return _scoped_read(
-        analytics_read.get_kpi_prev,
-        start=start, end=end, repo=repo,
-        events=_filter_list(events_t), stages=_filter_list(stages_t),
-        issue=issue,
-    )
+    return _read_filtered(analytics_read.get_kpi_prev, key)
 
 
-def _read_time_series(start, end, repo, events_t, stages_t, issue):
-    return _scoped_read(
-        analytics_read.get_time_series,
-        start=start, end=end, repo=repo,
-        events=_filter_list(events_t), stages=_filter_list(stages_t),
-        issue=issue,
-    )
+def _read_time_series(key: tuple):
+    return _read_filtered(analytics_read.get_time_series, key)
 
 
-def _read_stage_breakdown(start, end, repo, events_t, stages_t, issue):
-    return _scoped_read(
-        analytics_read.get_stage_breakdown,
-        start=start, end=end, repo=repo,
-        events=_filter_list(events_t), stages=_filter_list(stages_t),
-        issue=issue,
-    )
+def _read_stage_breakdown(key: tuple):
+    return _read_filtered(analytics_read.get_stage_breakdown, key)
 
 
-def _read_recent_agent_exits(start, end, repo, events_t, stages_t, issue):
-    return _scoped_read(
+def _read_recent_agent_exits(key: tuple):
+    return _read_filtered(
         analytics_read.get_recent_agent_exits,
+        key,
         limit=DEFAULT_RECENT_AGENT_EXITS,
-        start=start, end=end, repo=repo,
-        events=_filter_list(events_t), stages=_filter_list(stages_t),
-        issue=issue,
     )
 
 
-def _read_top_cost_issues(start, end, repo, events_t, stages_t, issue):
+def _read_top_cost_issues(key: tuple):
     # Ask the database for the top-cost issues directly. Reading the
     # latest N issues by `last_seen` and re-sorting in Python silently
     # drops older high-cost issues that fall outside the truncated set.
-    return _scoped_read(
+    return _read_filtered(
         analytics_read.get_issues,
+        key,
         limit=DEFAULT_EXPENSIVE_LIMIT,
         sort_by=analytics_read.SORT_BY_COST,
-        start=start, end=end, repo=repo,
-        events=_filter_list(events_t), stages=_filter_list(stages_t),
-        issue=issue,
     )
 
 
-def _read_review_round(start, end, repo, events_t, stages_t, issue):
-    return _scoped_read(
-        analytics_read.get_review_round_breakdown,
-        start=start, end=end, repo=repo,
-        events=_filter_list(events_t), stages=_filter_list(stages_t),
-        issue=issue,
-    )
+def _read_review_round(key: tuple):
+    return _read_filtered(analytics_read.get_review_round_breakdown, key)
 
 
-def _read_backend_efficiency(start, end, repo, events_t, stages_t, issue):
-    return _scoped_read(
-        analytics_read.get_backend_efficiency,
-        start=start, end=end, repo=repo,
-        events=_filter_list(events_t), stages=_filter_list(stages_t),
-        issue=issue,
-    )
+def _read_backend_efficiency(key: tuple):
+    return _read_filtered(analytics_read.get_backend_efficiency, key)
 
 
-def _read_repo_breakdown(start, end, repo, events_t, stages_t, issue):
-    return _scoped_read(
-        analytics_read.get_repo_breakdown,
-        start=start, end=end, repo=repo,
-        events=_filter_list(events_t), stages=_filter_list(stages_t),
-        issue=issue,
-    )
+def _read_repo_breakdown(key: tuple):
+    return _read_filtered(analytics_read.get_repo_breakdown, key)
 
 
-def _read_cost_coverage(start, end, repo, events_t, stages_t, issue):
-    return _scoped_read(
-        analytics_read.get_cost_coverage,
-        start=start, end=end, repo=repo,
-        events=_filter_list(events_t), stages=_filter_list(stages_t),
-        issue=issue,
-    )
+def _read_cost_coverage(key: tuple):
+    return _read_filtered(analytics_read.get_cost_coverage, key)
 
 
 def _read_hourly_heatmap(
-    start, end, repo, events_t, stages_t, issue, tz_offset_hours,
+    key: tuple,
+    tz_offset_hours: int,
 ):
-    return _scoped_read(
+    return _read_filtered(
         analytics_read.get_hourly_heatmap,
-        start=start, end=end, repo=repo,
-        events=_filter_list(events_t), stages=_filter_list(stages_t),
-        issue=issue, tz_offset_hours=tz_offset_hours,
+        key,
+        tz_offset_hours=tz_offset_hours,
     )
 
 
-def _read_throughput(start, end, repo, events_t, stages_t, issue):
-    return _scoped_read(
-        analytics_read.get_throughput_breakdown,
-        start=start, end=end, repo=repo,
-        events=_filter_list(events_t), stages=_filter_list(stages_t),
-        issue=issue,
-    )
+def _read_throughput(key: tuple):
+    return _read_filtered(analytics_read.get_throughput_breakdown, key)
 
 
-def _read_backend_daily_tokens(start, end, repo, events_t, stages_t, issue):
-    return _scoped_read(
-        analytics_read.get_backend_daily_tokens,
-        start=start, end=end, repo=repo,
-        events=_filter_list(events_t), stages=_filter_list(stages_t),
-        issue=issue,
-    )
+def _read_backend_daily_tokens(key: tuple):
+    return _read_filtered(analytics_read.get_backend_daily_tokens, key)
 
 
-def _read_skill_trigger_rates(start, end, repo, events_t, stages_t, issue):
-    return _scoped_read(
-        analytics_read.get_skill_trigger_rates,
-        start=start, end=end, repo=repo,
-        events=_filter_list(events_t), stages=_filter_list(stages_t),
-        issue=issue,
-    )
+def _read_skill_trigger_rates(key: tuple):
+    return _read_filtered(analytics_read.get_skill_trigger_rates, key)
 
 
-def _read_skill_trigger_matrix(start, end, repo, events_t, stages_t, issue):
-    return _scoped_read(
-        analytics_read.get_skill_trigger_matrix,
-        start=start, end=end, repo=repo,
-        events=_filter_list(events_t), stages=_filter_list(stages_t),
-        issue=issue,
-    )
+def _read_skill_trigger_matrix(key: tuple):
+    return _read_filtered(analytics_read.get_skill_trigger_matrix, key)
+
+
+def _widget_task(
+    st: Any,
+    name: str,
+    reader: Callable[..., Any],
+    *args: Any,
+) -> tuple[str, Callable[[], Any]]:
+    cached_reader = st.cache_data(show_spinner=False, ttl=60)(reader)
+    return name, partial(cached_reader, *args)
+
+
+def _first_wave_readers(
+    st: Any,
+    key: tuple,
+    prev_key: tuple,
+) -> list[tuple[str, Callable[[], Any]]]:
+    return [
+        _widget_task(st, "summary", _read_summary, key),
+        _widget_task(st, "prev_summary", _read_prev_kpi, prev_key),
+        _widget_task(st, "ts_points", _read_time_series, key),
+        _widget_task(st, "review_round_rows", _read_review_round, key),
+        _widget_task(st, "throughput_rows", _read_throughput, key),
+        _widget_task(st, "cost_coverage_rows", _read_cost_coverage, key),
+    ]
+
+
+def _second_wave_readers(
+    st: Any,
+    key: tuple,
+    tz_offset_choice: int,
+) -> list[tuple[str, Callable[[], Any]]]:
+    return [
+        _widget_task(st, "stage_rows", _read_stage_breakdown, key),
+        _widget_task(st, "agent_exits", _read_recent_agent_exits, key),
+        _widget_task(st, "issues_rows", _read_top_cost_issues, key),
+        _widget_task(st, "backend_rows", _read_backend_efficiency, key),
+        _widget_task(st, "repo_rows", _read_repo_breakdown, key),
+        _widget_task(
+            st,
+            "heatmap_rows",
+            _read_hourly_heatmap,
+            key,
+            int(tz_offset_choice),
+        ),
+        _widget_task(st, "backend_daily_rows", _read_backend_daily_tokens, key),
+        _widget_task(st, "skill_rows", _read_skill_trigger_rates, key),
+        _widget_task(st, "skill_matrix_rows", _read_skill_trigger_matrix, key),
+    ]
 
 
 def _widget_readers(*, st: Any, key, prev_key, tz_offset_choice: int):
@@ -808,8 +970,8 @@ def _widget_readers(*, st: Any, key, prev_key, tz_offset_choice: int):
     Returns `(first_wave_readers, second_wave_readers)` -- each a list of
     `(name, zero-arg callable)` pairs `_fan_out_reads` dispatches.
 
-    Connection scoping: each wrapper delegates its read to `_scoped_read`,
-    which checks out the thread-local analytics connection via
+    Connection scoping: each wrapper delegates through `_read_filtered`
+    to `_scoped_read`, which checks out the thread-local connection via
     `analytics_connection()` and forwards it to the read helper rather
     than threading a connection through the cache key (a raw
     `psycopg.Connection` is not hashable and would crash the wrapper, and
@@ -823,87 +985,14 @@ def _widget_readers(*, st: Any, key, prev_key, tz_offset_choice: int):
     banners / KPI strip can paint as soon as their inputs are available
     instead of blocking on every widget: the first wave carries the six
     reads those above-the-fold widgets consume, the second the nine
-    remaining widget reads. The lambdas close over `key` / `prev_key` so
-    the executor never threads filter tuples through the futures, and
-    worker threads only return data -- every `st.*` write happens on the
-    caller's render thread between the waves.
+    remaining widget reads. Each task is a zero-argument `partial` bound
+    to its immutable filter tuple, and worker threads only return data --
+    every `st.*` write happens on the caller's render thread between waves.
     """
-    read_summary = st.cache_data(show_spinner=False, ttl=60)(_read_summary)
-    read_prev_kpi = st.cache_data(show_spinner=False, ttl=60)(_read_prev_kpi)
-    read_time_series = st.cache_data(show_spinner=False, ttl=60)(_read_time_series)
-    read_stage_breakdown = st.cache_data(
-        show_spinner=False, ttl=60,
-    )(_read_stage_breakdown)
-    read_recent_agent_exits = st.cache_data(
-        show_spinner=False, ttl=60,
-    )(_read_recent_agent_exits)
-    read_top_cost_issues = st.cache_data(
-        show_spinner=False, ttl=60,
-    )(_read_top_cost_issues)
-    read_review_round = st.cache_data(
-        show_spinner=False, ttl=60,
-    )(_read_review_round)
-    read_backend_efficiency = st.cache_data(
-        show_spinner=False, ttl=60,
-    )(_read_backend_efficiency)
-    read_repo_breakdown = st.cache_data(
-        show_spinner=False, ttl=60,
-    )(_read_repo_breakdown)
-    read_cost_coverage = st.cache_data(
-        show_spinner=False, ttl=60,
-    )(_read_cost_coverage)
-    read_hourly_heatmap = st.cache_data(
-        show_spinner=False, ttl=60,
-    )(_read_hourly_heatmap)
-    read_throughput = st.cache_data(show_spinner=False, ttl=60)(_read_throughput)
-    read_backend_daily_tokens = st.cache_data(
-        show_spinner=False, ttl=60,
-    )(_read_backend_daily_tokens)
-    read_skill_trigger_rates = st.cache_data(
-        show_spinner=False, ttl=60,
-    )(_read_skill_trigger_rates)
-    read_skill_trigger_matrix = st.cache_data(
-        show_spinner=False, ttl=60,
-    )(_read_skill_trigger_matrix)
-
-    # Read fan-out. Each entry is `(name, zero-arg callable)` so
-    # `_fan_out_reads` can dispatch them across worker threads when
-    # `DASHBOARD_PARALLEL_READS` is set; the sequential path stays in
-    # this thread under the existing thread-local `analytics_connection`.
-    # Lambdas close over `key` / `prev_key` so the executor never has
-    # to thread filter tuples through the futures.
-    #
-    # Split into two staged waves so the topbar / filter meta /
-    # insight banners / KPI strip paint as soon as their inputs are
-    # available instead of blocking on every widget. The first wave
-    # carries the six reads those above-the-fold widgets consume
-    # (`summary`, `prev_summary`, `ts_points`, `review_round_rows`,
-    # `throughput_rows`, `cost_coverage_rows`); the second wave runs
-    # the nine remaining widget reads. Worker threads only return
-    # data back to this render thread -- every `st.*` / placeholder
-    # write happens on the main thread between waves.
-    first_wave_readers: list[tuple[str, Callable[[], Any]]] = [
-        ("summary", lambda: read_summary(*key)),
-        ("prev_summary", lambda: read_prev_kpi(*prev_key)),
-        ("ts_points", lambda: read_time_series(*key)),
-        ("review_round_rows", lambda: read_review_round(*key)),
-        ("throughput_rows", lambda: read_throughput(*key)),
-        ("cost_coverage_rows", lambda: read_cost_coverage(*key)),
-    ]
-    second_wave_readers: list[tuple[str, Callable[[], Any]]] = [
-        ("stage_rows", lambda: read_stage_breakdown(*key)),
-        ("agent_exits", lambda: read_recent_agent_exits(*key)),
-        ("issues_rows", lambda: read_top_cost_issues(*key)),
-        ("backend_rows", lambda: read_backend_efficiency(*key)),
-        ("repo_rows", lambda: read_repo_breakdown(*key)),
-        ("heatmap_rows", lambda: read_hourly_heatmap(
-            *key, int(tz_offset_choice),
-        )),
-        ("backend_daily_rows", lambda: read_backend_daily_tokens(*key)),
-        ("skill_rows", lambda: read_skill_trigger_rates(*key)),
-        ("skill_matrix_rows", lambda: read_skill_trigger_matrix(*key)),
-    ]
-    return first_wave_readers, second_wave_readers
+    return (
+        _first_wave_readers(st, key, prev_key),
+        _second_wave_readers(st, key, tz_offset_choice),
+    )
 
 
 def _dispatch_reads(readers, *, st: Any, parallel: bool):
@@ -943,17 +1032,8 @@ def _log_dashboard_load(*, load_start: float, reads: int, parallel: bool) -> Non
 
 
 def _render_empty_window(
-    *,
-    st: Any,
-    pd: Any,
-    load_start: float,
-    reads: int,
-    parallel: bool,
-    window: DateWindow,
-    repo_filter: Optional[str],
-    issue_input_parsed: Optional[int],
-    event_filter: Optional[Sequence[str]],
-    stage_filter: Optional[Sequence[str]],
+    modules: _DashboardModules,
+    page: _DashboardPage,
 ) -> None:
     """Render the empty-window state (no events match the filters).
 
@@ -963,17 +1043,13 @@ def _render_empty_window(
     `EMPTY_WINDOW_MESSAGE`, and still renders the per-issue drill-down
     (which runs its own read).
     """
-    _log_dashboard_load(load_start=load_start, reads=reads, parallel=parallel)
-    st.info(EMPTY_WINDOW_MESSAGE)
-    _render_drilldown(
-        st=st,
-        pd=pd,
-        window=window,
-        repo_filter=repo_filter,
-        issue_input_parsed=issue_input_parsed,
-        event_filter=event_filter,
-        stage_filter=stage_filter,
+    _log_dashboard_load(
+        load_start=page.reads.started_at,
+        reads=len(page.reads.first_wave),
+        parallel=page.reads.parallel,
     )
+    modules.st.info(EMPTY_WINDOW_MESSAGE)
+    _render_drilldown_view(modules, page.controls.filters)
 
 
 def _render_sidebar_filters(*, st: Any, options: Any):
@@ -1017,7 +1093,94 @@ def _render_sidebar_filters(*, st: Any, options: Any):
                 "bottom. Requires a specific repo above."
             ),
         )
-    return repo_choice, event_choice, stage_choice, issue_input
+    return _SidebarSelections(
+        repo=repo_choice,
+        events=event_choice,
+        stages=stage_choice,
+        issue_input=issue_input,
+    )
+
+
+@dataclass(frozen=True)
+class _DateFilterColumns:
+    label: Any
+    preset: Any
+    start: Any
+    end: Any
+    meta: Any
+
+
+def _date_filter_columns(st: Any) -> _DateFilterColumns:
+    columns = st.columns(
+        [1.0, 1.7, 1.4, 1.4, 3.0],
+        vertical_alignment="bottom",
+    )
+    return _DateFilterColumns(*columns)
+
+
+def _render_date_filter_label(st: Any, column: Any) -> None:
+    with column:
+        st.markdown(
+            '<div class="orch-filterbar-anchor"></div>'
+            '<span class="orch-filter-label">Date range</span>',
+            unsafe_allow_html=True,
+        )
+
+
+def _preset_radio_index(preset: str) -> int:
+    choices = (PRESET_3D, PRESET_7D, PRESET_ALL)
+    if preset not in choices:
+        return 2
+    return choices.index(preset)
+
+
+def _render_preset_choice(st: Any, column: Any) -> str:
+    with column:
+        return st.radio(
+            "Range preset",
+            options=(PRESET_3D, PRESET_7D, PRESET_ALL),
+            format_func=lambda preset: PRESET_INLINE_LABELS[preset],
+            index=_preset_radio_index(st.session_state.preset),
+            horizontal=True,
+            label_visibility="collapsed",
+            key="_preset_radio",
+        )
+
+
+def _initial_filter_window(
+    preset_choice: str,
+    extent: DataExtent,
+    extent_min_d: date,
+    extent_max_d: date,
+) -> DateWindow:
+    return (
+        preset_window(preset_choice, extent)
+        or to_window(extent_min_d, extent_max_d)
+    )
+
+
+def _render_date_inputs(
+    st: Any,
+    columns: _DateFilterColumns,
+    initial_window: DateWindow,
+    extent_min_d: date,
+    extent_max_d: date,
+) -> tuple[date, date]:
+    with columns.start:
+        start_date = st.date_input(
+            "From",
+            value=initial_window.start.date(),
+            min_value=extent_min_d,
+            max_value=extent_max_d,
+        )
+    with columns.end:
+        end_date = st.date_input(
+            "To",
+            value=(initial_window.end - timedelta(days=1)).date(),
+            min_value=extent_min_d,
+            max_value=extent_max_d,
+        )
+    return start_date, end_date
 
 
 def _render_date_filter_bar(
@@ -1048,68 +1211,21 @@ def _render_date_filter_bar(
         st.markdown(
             '<div class="orch-cardmark"></div>', unsafe_allow_html=True
         )
-        # Single-line filter bar: label · preset switch · From · To ·
-        # range meta, all bottom-aligned so the short controls (label,
-        # radio, meta) sit on the same baseline as the taller date
-        # inputs.
-        (
-            fb_label,
-            fb_preset,
-            fb_from,
-            fb_to,
-            fb_meta,
-        ) = st.columns(
-            [1.0, 1.7, 1.4, 1.4, 3.0], vertical_alignment="bottom"
+        columns = _date_filter_columns(st)
+        _render_date_filter_label(st, columns.label)
+        preset_choice = _render_preset_choice(st, columns.preset)
+        initial_window = _initial_filter_window(
+            preset_choice, extent, extent_min_d, extent_max_d,
         )
-        with fb_label:
-            st.markdown(
-                '<div class="orch-filterbar-anchor"></div>'
-                '<span class="orch-filter-label">Date range</span>',
-                unsafe_allow_html=True,
-            )
-        with fb_preset:
-            preset_choice = st.radio(
-                "Range preset",
-                options=(PRESET_3D, PRESET_7D, PRESET_ALL),
-                format_func=lambda p: PRESET_INLINE_LABELS[p],
-                index=(
-                    (PRESET_3D, PRESET_7D, PRESET_ALL).index(
-                        st.session_state.preset
-                    )
-                    if st.session_state.preset
-                    in (PRESET_3D, PRESET_7D, PRESET_ALL)
-                    else 2
-                ),
-                horizontal=True,
-                label_visibility="collapsed",
-                key="_preset_radio",
-            )
-        initial_window = (
-            preset_window(preset_choice, extent)
-            or to_window(extent_min_d, extent_max_d)
+        dates = _render_date_inputs(
+            st, columns, initial_window, extent_min_d, extent_max_d,
         )
-        with fb_from:
-            start_date = st.date_input(
-                "From",
-                value=initial_window.start.date(),
-                min_value=extent_min_d,
-                max_value=extent_max_d,
-            )
-        with fb_to:
-            end_default = (initial_window.end - timedelta(days=1)).date()
-            end_date = st.date_input(
-                "To",
-                value=end_default,
-                min_value=extent_min_d,
-                max_value=extent_max_d,
-            )
         # The run count is not known until the summary read lands, so
         # capture the meta slot now and fill it between fan-out waves.
-        with fb_meta:
+        with columns.meta:
             meta_slot = st.empty()
-    window = to_window(start_date, end_date)
     st.session_state.preset = preset_choice
-    return window, meta_slot
+    return to_window(*dates), meta_slot
 
 
 def _build_read_keys(
@@ -1125,9 +1241,9 @@ def _build_read_keys(
     Returns `(key, prev_key)`: the `(start, end, repo, events, stages,
     issue)` tuple the fan-out reads are cached under, and the same
     tuple shifted to the immediately-preceding equal-length window for
-    the KPI delta pills. The reader lambdas splat these with `*key` /
-    `*prev_key`, so the tuple order is the read helpers' positional
-    contract.
+    the KPI delta pills. Cached readers accept the tuple as one hashable
+    key and `_read_filter_kwargs` expands its stable field order for the
+    read model.
     """
     key = cache_key(
         window, repo_filter, event_filter, stage_filter, issue_filter
@@ -1173,93 +1289,143 @@ def _throughput_totals(throughput_rows: Sequence[Any]) -> tuple[int, int]:
     return resolved, rejected
 
 
+def _daily_point_totals(
+    ts_points: Sequence[Any],
+) -> dict[date, list[float]]:
+    totals: dict[date, list[float]] = {}
+    for point in ts_points:
+        daily = totals.setdefault(point.day, [0.0, 0.0])
+        daily[0] += float(point.cost_usd or 0.0)
+        daily[1] += _time_series_total_tokens(point)
+    return totals
+
+
+@dataclass(frozen=True)
+class _DailyKpiSeries:
+    cost: Sequence[float]
+    tokens: Sequence[float]
+    done: Sequence[int]
+
+
 def _daily_kpi_series(
     *, ts_points: Sequence[Any], throughput_rows: Sequence[Any]
-) -> tuple[list[float], list[float], list[int]]:
+) -> _DailyKpiSeries:
     """Return cost/token/resolved sparkline series for KPI cards.
 
     One entry is emitted per day present in the time-series read. Daily
     tokens use the same input + output + cache_read + cache_write
     accounting as the headline token KPI.
     """
-    days = sorted({point.day for point in ts_points})
-    days_index = {day: i for i, day in enumerate(days)}
-    daily_cost = [0.0] * len(days)
-    daily_tokens = [0.0] * len(days)
-    for point in ts_points:
-        i = days_index[point.day]
-        daily_cost[i] += float(point.cost_usd or 0.0)
-        daily_tokens[i] += _time_series_total_tokens(point)
-
+    totals = _daily_point_totals(ts_points)
+    days = sorted(totals)
     done_index = {row.day: int(row.resolved or 0) for row in throughput_rows}
-    daily_done = [done_index.get(day, 0) for day in days]
-    return daily_cost, daily_tokens, daily_done
+    return _DailyKpiSeries(
+        cost=[totals[day][0] for day in days],
+        tokens=[totals[day][1] for day in days],
+        done=[done_index.get(day, 0) for day in days],
+    )
+
+
+@dataclass(frozen=True)
+class _KpiInputs:
+    theme: Any
+    summary: Summary
+    prev_summary: Summary
+    ts_points: Sequence[Any]
+    throughput_rows: Sequence[Any]
+    review_round_rows: Sequence[Any]
+    days_in_window: int
+
+
+@dataclass(frozen=True)
+class _KpiTotals:
+    cost: float
+    tokens: int
+    previous_cost: float
+    previous_tokens: int
+    resolved: int
+    rejected: int
+    review_cost: float
+    rework_cost: float
+
+
+def _kpi_totals(inputs: _KpiInputs) -> _KpiTotals:
+    throughput = _throughput_totals(inputs.throughput_rows)
+    review_costs = rework_totals(inputs.review_round_rows)
+    return _KpiTotals(
+        cost=float(inputs.summary.total_cost_usd or 0.0),
+        tokens=_summary_total_tokens(inputs.summary),
+        previous_cost=float(inputs.prev_summary.total_cost_usd or 0.0),
+        previous_tokens=_summary_total_tokens(inputs.prev_summary),
+        resolved=throughput[0],
+        rejected=throughput[1],
+        review_cost=review_costs[0],
+        rework_cost=review_costs[1],
+    )
 
 
 def _build_kpi_strip_data(
-    *,
-    theme: Any,
-    summary: Summary,
-    prev_summary: Summary,
-    ts_points: Sequence[Any],
-    throughput_rows: Sequence[Any],
-    review_round_rows: Sequence[Any],
-    days_in_window: int,
+    inputs: _KpiInputs,
 ) -> tuple[list[dict[str, Any]], int, int]:
     """Build the KPI-strip dictionaries plus throughput totals."""
-    total_cost = float(summary.total_cost_usd or 0.0)
-    total_tokens = _summary_total_tokens(summary)
-    total_cost_prev = float(prev_summary.total_cost_usd or 0.0)
-    total_tokens_prev = _summary_total_tokens(prev_summary)
-    resolved, rejected = _throughput_totals(throughput_rows)
-    rr_total_cost, rr_rework_cost = rework_totals(review_round_rows)
+    totals = _kpi_totals(inputs)
     rework_share = (
-        (rr_rework_cost / rr_total_cost) if rr_total_cost > 0 else 0.0
+        (totals.rework_cost / totals.review_cost)
+        if totals.review_cost > 0
+        else 0.0
     )
-    daily_cost, daily_tokens, daily_done = _daily_kpi_series(
-        ts_points=ts_points,
-        throughput_rows=throughput_rows,
+    daily = _daily_kpi_series(
+        ts_points=inputs.ts_points,
+        throughput_rows=inputs.throughput_rows,
     )
     cost_per_resolved = (
-        f"${total_cost / resolved:,.2f}" if resolved > 0 else "—"
+        f"${totals.cost / totals.resolved:,.2f}"
+        if totals.resolved > 0
+        else "—"
     )
     kpis = [
         {
             "label": "Total spend",
-            "value": theme.fmt_money_exact(total_cost),
-            "delta": kpi_delta(total_cost, total_cost_prev),
-            "sub": f"{theme.fmt_money(total_cost / days_in_window)}/day",
-            "spark": daily_cost,
-            "spark_color": theme.ACCENT,
+            "value": inputs.theme.fmt_money_exact(totals.cost),
+            "delta": kpi_delta(totals.cost, totals.previous_cost),
+            "sub": (
+                f"{inputs.theme.fmt_money(totals.cost / inputs.days_in_window)}"
+                "/day"
+            ),
+            "spark": daily.cost,
+            "spark_color": inputs.theme.ACCENT,
         },
         {
             "label": "Total tokens",
-            "value": theme.fmt_tokens(total_tokens),
-            "delta": kpi_delta(total_tokens, total_tokens_prev),
-            "sub": f"{theme.fmt_tokens(total_tokens / days_in_window)}/day",
-            "spark": daily_tokens,
-            "spark_color": theme.TOKEN_TYPE_COLORS["Input"],
+            "value": inputs.theme.fmt_tokens(totals.tokens),
+            "delta": kpi_delta(totals.tokens, totals.previous_tokens),
+            "sub": (
+                f"{inputs.theme.fmt_tokens(totals.tokens / inputs.days_in_window)}"
+                "/day"
+            ),
+            "spark": daily.tokens,
+            "spark_color": inputs.theme.TOKEN_TYPE_COLORS["Input"],
         },
         {
             "label": "Cost / resolved issue",
             "value": cost_per_resolved,
             "delta": None,
-            "sub": f"{resolved} resolved · {rejected} rejected",
-            "spark": daily_done,
-            "spark_color": theme.TOKEN_TYPE_COLORS["Cache"],
+            "sub": f"{totals.resolved} resolved · {totals.rejected} rejected",
+            "spark": daily.done,
+            "spark_color": inputs.theme.TOKEN_TYPE_COLORS["Cache"],
         },
         {
             "label": "Rework share",
             "value": f"{rework_share * 100:.0f}%",
             "delta": None,
             "sub": (
-                f"{theme.fmt_money_exact(rr_rework_cost)} in review "
+                f"{inputs.theme.fmt_money_exact(totals.rework_cost)} in review "
                 "rounds >= 1"
             ),
             "spark": None,
         },
     ]
-    return kpis, resolved, rejected
+    return kpis, totals.resolved, totals.rejected
 
 
 def _backend_tokens_by_day(
@@ -1273,6 +1439,18 @@ def _backend_tokens_by_day(
             + float(row.total_tokens or 0)
         )
     return backend_by_day
+
+
+def _stack_mode_label(mode: str) -> str:
+    if mode == "type":
+        return "By token type"
+    return "By backend"
+
+
+def _stack_mode_index(mode: str) -> int:
+    if mode == "type":
+        return 0
+    return 1
 
 
 def _render_hero_usage(
@@ -1302,10 +1480,8 @@ def _render_hero_usage(
         stack_mode = st.radio(
             "Stack mode",
             options=("type", "backend"),
-            format_func=lambda m: (
-                "By token type" if m == "type" else "By backend"
-            ),
-            index=0 if st.session_state.stack_mode == "type" else 1,
+            format_func=_stack_mode_label,
+            index=_stack_mode_index(st.session_state.stack_mode),
             horizontal=True,
             label_visibility="collapsed",
             key="_stack_mode_radio",
@@ -1343,7 +1519,7 @@ def _render_stage_review_bars(
     Both bar panels are pinned to the same height (driven by whichever
     has more bars) so the two cards line up bottom-to-bottom.
     """
-    bars_h = 40 * max(len(stage_rows), len(review_round_rows), 1) + 80
+    bars_h = _paired_bars_height(stage_rows, review_round_rows)
     col_stage, col_round = st.columns([7, 5])
     with col_stage:
         with st.container(border=True):
@@ -1375,6 +1551,11 @@ def _render_stage_review_bars(
                 use_container_width=True,
                 config=PLOTLY_CONFIG,
             )
+
+
+def _paired_bars_height(stage_rows: Sequence[Any], review_rows: Sequence[Any]) -> int:
+    row_count = max(len(stage_rows), len(review_rows), 1)
+    return 40 * row_count + 80
 
 
 def _render_issues_and_backends(
@@ -1441,16 +1622,8 @@ def _render_issues_and_backends(
 
 
 def _render_repo_and_reliability(
-    *,
-    st: Any,
-    dashboard_charts: Any,
-    theme: Any,
-    repo_rows: Any,
-    summary: Summary,
-    throughput_rows: Any,
-    window: DateWindow,
-    resolved: int,
-    rejected: int,
+    modules: _DashboardModules,
+    data: _ReliabilityPanelData,
 ) -> None:
     """Render the per-repo cost bars + reliability / throughput column.
 
@@ -1460,24 +1633,24 @@ def _render_repo_and_reliability(
     chart is passed the window so zero-resolution days the SQL elides
     still render an explicit bar against the calendar baseline.
     """
-    col_repo, col_rel = st.columns([7, 5])
+    col_repo, col_rel = modules.st.columns([7, 5])
     with col_repo:
-        with st.container(border=True):
-            st.markdown(
+        with modules.st.container(border=True):
+            modules.st.markdown(
                 _card_header_html(
                     "Cost by repository",
                     "Spend across managed repos",
                 ),
                 unsafe_allow_html=True,
             )
-            st.plotly_chart(
-                dashboard_charts.cost_by_repo(repo_rows),
+            modules.st.plotly_chart(
+                modules.charts.cost_by_repo(data.repos),
                 use_container_width=True,
                 config=PLOTLY_CONFIG,
             )
     with col_rel:
-        with st.container(border=True):
-            st.markdown(
+        with modules.st.container(border=True):
+            modules.st.markdown(
                 _card_header_html(
                     "Reliability & throughput",
                     "Run health and issues resolved per day",
@@ -1485,17 +1658,24 @@ def _render_repo_and_reliability(
                 unsafe_allow_html=True,
             )
             raw_tiles = reliability_tile_data(
-                summary, resolved=resolved, rejected=rejected,
+                data.summary,
+                resolved=data.resolved,
+                rejected=data.rejected,
             )
-            st.markdown(
-                _reliability_tiles_html(raw_tiles, fmt_num=theme.fmt_num),
+            modules.st.markdown(
+                _reliability_tiles_html(
+                    raw_tiles,
+                    fmt_num=modules.theme.fmt_num,
+                ),
                 unsafe_allow_html=True,
             )
-            st.plotly_chart(
-                dashboard_charts.done_per_day_bars(
-                    throughput_rows,
-                    window_start=window.start.date(),
-                    window_end=(window.end - timedelta(days=1)).date(),
+            modules.st.plotly_chart(
+                modules.charts.done_per_day_bars(
+                    data.throughput,
+                    window_start=data.window.start.date(),
+                    window_end=(
+                        data.window.end - timedelta(days=1)
+                    ).date(),
                     title=None,
                 ),
                 use_container_width=True,
@@ -1513,10 +1693,10 @@ def _render_activity_heatmap(
     """Render the weekday × hour token-volume heatmap card.
 
     The in-card UTC-offset selectbox binds to
-    `st.session_state["tz_offset_hours"]` (seeded in `main()` before
-    the second-wave fan-out) so the heatmap read and this widget agree
-    on the offset; on change Streamlit reruns and the next read buckets
-    in the newly-picked zone.
+    `st.session_state["tz_offset_hours"]` (seeded with the other controls
+    before the second-wave fan-out) so the heatmap read and this widget
+    agree on the offset; on change Streamlit reruns and the next read
+    buckets in the newly-picked zone.
     """
     tz_label = format_tz_offset(int(tz_offset_choice))
     with st.container(border=True):
@@ -1661,15 +1841,9 @@ def _render_recent_runs(
             st.info("No `agent_exit` rows match the current filters.")
 
 
-def _render_drilldown(
-    *,
-    st: Any,
-    pd: Any,
-    window: DateWindow,
-    repo_filter: Optional[str],
-    issue_input_parsed: Optional[int],
-    event_filter: Optional[Sequence[str]],
-    stage_filter: Optional[Sequence[str]],
+def _render_drilldown_view(
+    modules: _DashboardModules,
+    filters: _DashboardFilters,
 ) -> None:
     """Per-issue event trace section.
 
@@ -1679,11 +1853,11 @@ def _render_drilldown(
     read model are caught and surfaced inline -- a drill-down error
     must not poison the overview the operator already scrolled past.
     """
-    if issue_input_parsed is None:
+    if filters.issue_input is None:
         return
-    st.subheader(f"Issue #{issue_input_parsed} drill-down")
-    if repo_filter is None:
-        st.info(
+    modules.st.subheader(f"Issue #{filters.issue_input} drill-down")
+    if filters.repo is None:
+        modules.st.info(
             "Pick a specific repo in the sidebar before drilling "
             "into an issue number -- GitHub issue numbers repeat "
             "across repos."
@@ -1692,19 +1866,19 @@ def _render_drilldown(
     try:
         trace = _scoped_read(
             analytics_read.get_issue_events,
-            repo=repo_filter,
-            issue=issue_input_parsed,
-            start=window.start,
-            end=window.end,
-            events=_filter_list(event_filter),
-            stages=_filter_list(stage_filter),
+            repo=filters.repo,
+            issue=filters.issue_input,
+            start=filters.window.start,
+            end=filters.window.end,
+            events=_filter_list(filters.events),
+            stages=_filter_list(filters.stages),
         )
     except analytics_read.AnalyticsReadError as e:
-        st.error(f"Issue drill-down failed: {e}")
+        modules.st.error(f"Issue drill-down failed: {e}")
         return
     if trace:
-        st.dataframe(
-            pd.DataFrame([
+        modules.st.dataframe(
+            modules.pd.DataFrame([
                 {
                     "ts": ev.ts,
                     "event": ev.event,
@@ -1721,11 +1895,33 @@ def _render_drilldown(
             use_container_width=True,
         )
     else:
-        st.info(
+        modules.st.info(
             f"No analytics events recorded for "
-            f"`{repo_filter}#{issue_input_parsed}` "
+            f"`{filters.repo}#{filters.issue_input}` "
             "under the current filters."
         )
+
+
+def _render_drilldown(
+    *,
+    st: Any,
+    pd: Any,
+    window: DateWindow,
+    repo_filter: Optional[str],
+    issue_input_parsed: Optional[int],
+    event_filter: Optional[Sequence[str]],
+    stage_filter: Optional[Sequence[str]],
+) -> None:
+    """Render the drill-down through the historical dashboard helper API."""
+    modules = _DashboardModules(st=st, pd=pd, charts=None, theme=None)
+    filters = _DashboardFilters(
+        window=window,
+        repo=repo_filter,
+        issue_input=issue_input_parsed,
+        events=event_filter,
+        stages=stage_filter,
+    )
+    _render_drilldown_view(modules, filters)
 
 
 if __name__ == "__main__":

--- a/orchestrator/dashboard_charts.py
+++ b/orchestrator/dashboard_charts.py
@@ -48,6 +48,7 @@ exposed by ``orchestrator.analytics.read``.
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Optional, Sequence
 
@@ -218,31 +219,35 @@ def _horizontal_legend(*, traceorder: Optional[str] = None) -> dict[str, object]
     return legend
 
 
+@dataclass(frozen=True)
+class _HorizontalCostLayout:
+    row_count: int
+    height: Optional[int] = None
+    title: Optional[str] = None
+    barmode: Optional[str] = None
+    legend: Optional[dict[str, object]] = None
+    row_height: int = _HORIZONTAL_BAR_ROW_HEIGHT
+    extra_height: int = _HORIZONTAL_BAR_EXTRA_HEIGHT
+
+
 def _apply_horizontal_cost_layout(
     fig: go.Figure,
-    *,
-    row_count: int,
-    height: Optional[int] = None,
-    title: Optional[str] = None,
-    barmode: Optional[str] = None,
-    legend: Optional[dict[str, object]] = None,
-    row_height: int = _HORIZONTAL_BAR_ROW_HEIGHT,
-    extra_height: int = _HORIZONTAL_BAR_EXTRA_HEIGHT,
+    options: _HorizontalCostLayout,
 ) -> None:
-    layout = theme.base_layout(title=title)
-    if barmode is not None:
-        layout["barmode"] = barmode
-    if legend is not None:
-        layout["legend"] = legend
+    layout = theme.base_layout(title=options.title)
+    if options.barmode is not None:
+        layout["barmode"] = options.barmode
+    if options.legend is not None:
+        layout["legend"] = options.legend
     layout["margin"] = {
         **_HORIZONTAL_BAR_MARGIN,
         "t": layout["margin"]["t"],
     }
     layout["height"] = _horizontal_panel_height(
-        row_count,
-        height=height,
-        row_height=row_height,
-        extra_height=extra_height,
+        options.row_count,
+        height=options.height,
+        row_height=options.row_height,
+        extra_height=options.extra_height,
     )
     fig.update_layout(**layout)
     fig.update_xaxes(
@@ -252,31 +257,35 @@ def _apply_horizontal_cost_layout(
     fig.update_yaxes(automargin=True, showline=False, ticks="")
 
 
+@dataclass(frozen=True)
+class _CostBarTrace:
+    name: str
+    values: Sequence[float]
+    y_ticks: Sequence[str]
+    color: object
+    hover_label: str
+    offsetgroup: Optional[str] = None
+    totals: Optional[Sequence[float]] = None
+
+
 def _cost_bar_trace(
-    *,
-    name: str,
-    values: Sequence[float],
-    y_ticks: Sequence[str],
-    color,
-    hover_label: str,
-    offsetgroup: Optional[str] = None,
-    totals: Optional[Sequence[float]] = None,
+    options: _CostBarTrace,
 ) -> go.Bar:
     trace_kwargs = {
-        "x": list(values),
-        "y": list(y_ticks),
-        "name": name,
+        "x": list(options.values),
+        "y": list(options.y_ticks),
+        "name": options.name,
         "orientation": "h",
-        "marker_color": color,
+        "marker_color": options.color,
         "cliponaxis": False,
         "hovertemplate": (
-            "%{y}<br>" + hover_label + ": $%{x:,.2f}<extra></extra>"
+            "%{y}<br>" + options.hover_label + ": $%{x:,.2f}<extra></extra>"
         ),
     }
-    if offsetgroup is not None:
-        trace_kwargs["offsetgroup"] = offsetgroup
-    if totals is not None:
-        trace_kwargs["text"] = _money_text(totals)
+    if options.offsetgroup is not None:
+        trace_kwargs["offsetgroup"] = options.offsetgroup
+    if options.totals is not None:
+        trace_kwargs["text"] = _money_text(options.totals)
         trace_kwargs["textposition"] = "outside"
         trace_kwargs["textfont"] = _monospace_textfont()
     return go.Bar(**trace_kwargs)
@@ -358,10 +367,169 @@ def _usage_stack_totals(
 ) -> list[float]:
     if mode == "backend" and backend_rows_by_day:
         return [sum(backend_rows_by_day.get(day, {}).values()) for day in days]
-    return [
-        daily[day]["input"] + daily[day]["output"] + daily[day]["cache"]
-        for day in days
-    ]
+    return [_daily_token_total(daily[day]) for day in days]
+
+
+def _daily_token_total(bucket: dict[str, float]) -> float:
+    return sum(bucket[token_type] for token_type in ("input", "output", "cache"))
+
+
+@dataclass(frozen=True)
+class _UsageChartData:
+    daily: dict[date, dict[str, float]]
+    days: Sequence[date]
+
+
+@dataclass(frozen=True)
+class _UsageAxisRanges:
+    token_top: float
+    cost_top: float
+
+
+def _prepare_usage_data(
+    points: Sequence[TimeSeriesPoint],
+    backend_rows_by_day: Optional[dict[date, dict[str, float]]],
+    mode: str,
+) -> Optional[_UsageChartData]:
+    if not points and not backend_rows_by_day:
+        return None
+    daily = _roll_up_time_series(points)
+    if mode == "backend" and backend_rows_by_day:
+        _ensure_backend_days(daily, backend_rows_by_day)
+    days = sorted(daily)
+    if not days:
+        return None
+    return _UsageChartData(daily=daily, days=days)
+
+
+def _add_backend_usage_traces(
+    fig: go.Figure,
+    data: _UsageChartData,
+    backend_rows_by_day: dict[date, dict[str, float]],
+) -> None:
+    backends = _backend_names(backend_rows_by_day)
+    for backend in backends:
+        color = theme.color_for(
+            backend, backends, explicit=theme.BACKEND_COLORS,
+        )
+        _add_token_stack_trace(
+            fig,
+            days=data.days,
+            values=[
+                backend_rows_by_day.get(day, {}).get(backend, 0)
+                for day in data.days
+            ],
+            name=backend,
+            color=color,
+        )
+
+
+def _add_token_type_usage_traces(
+    fig: go.Figure,
+    data: _UsageChartData,
+) -> None:
+    for band, label in (
+        ("input", "Input"),
+        ("output", "Output"),
+        ("cache", "Cache"),
+    ):
+        _add_token_stack_trace(
+            fig,
+            days=data.days,
+            values=[data.daily[day][band] for day in data.days],
+            name=label,
+            color=theme.TOKEN_TYPE_COLORS[label],
+        )
+
+
+def _add_usage_stack_traces(
+    fig: go.Figure,
+    data: _UsageChartData,
+    backend_rows_by_day: Optional[dict[date, dict[str, float]]],
+    mode: str,
+) -> None:
+    if mode == "backend" and backend_rows_by_day:
+        _add_backend_usage_traces(fig, data, backend_rows_by_day)
+        return
+    _add_token_type_usage_traces(fig, data)
+
+
+def _add_usage_cost_trace(fig: go.Figure, data: _UsageChartData) -> None:
+    fig.add_trace(
+        go.Scatter(
+            x=_date_axis(data.days),
+            y=[data.daily[day]["cost"] for day in data.days],
+            name="Cost",
+            mode="lines+markers",
+            line={"color": theme.INK, "width": 2},
+            marker={"size": 5, "color": theme.INK},
+            yaxis="y2",
+            hovertemplate="%{x}<br>Cost: $%{y:.2f}<extra></extra>",
+        )
+    )
+
+
+def _usage_axis_ranges(
+    data: _UsageChartData,
+    backend_rows_by_day: Optional[dict[date, dict[str, float]]],
+    mode: str,
+) -> _UsageAxisRanges:
+    stack_totals = _usage_stack_totals(
+        data.days,
+        data.daily,
+        backend_rows_by_day=backend_rows_by_day,
+        mode=mode,
+    )
+    token_max = max(stack_totals, default=0.0)
+    cost_max = max(
+        (data.daily[day]["cost"] for day in data.days),
+        default=0.0,
+    )
+    return _UsageAxisRanges(
+        token_top=_nice_axis_max(token_max, _USAGE_GRID_STEPS),
+        cost_top=_nice_axis_max(cost_max, _USAGE_GRID_STEPS),
+    )
+
+
+def _usage_layout(
+    data: _UsageChartData,
+    backend_rows_by_day: Optional[dict[date, dict[str, float]]],
+    mode: str,
+    title: Optional[str],
+) -> dict[str, object]:
+    layout = theme.base_layout(title=title)
+    ranges = _usage_axis_ranges(data, backend_rows_by_day, mode)
+    layout["yaxis"] = {
+        **layout.get("yaxis", {}),
+        "title": {"text": "tokens"},
+        "range": [0, ranges.token_top],
+        "dtick": ranges.token_top / _USAGE_GRID_STEPS,
+        "rangemode": "tozero",
+        "showgrid": True,
+    }
+    layout["yaxis2"] = {
+        "title": {"text": "USD"},
+        "overlaying": "y",
+        "side": "right",
+        "range": [0, ranges.cost_top],
+        "dtick": ranges.cost_top / _USAGE_GRID_STEPS,
+        "rangemode": "tozero",
+        "gridcolor": theme.GRID,
+        "linecolor": theme.GRID,
+        "showgrid": False,
+        "tickprefix": "$",
+        "tickfont": {"color": theme.MUTED_TEXT},
+    }
+    layout["margin"] = {**layout.get("margin", {}), "t": 28}
+    layout["hovermode"] = "x unified"
+    layout["legend"] = {
+        **layout.get("legend", {}),
+        "orientation": "h",
+        "yanchor": "bottom", "y": 1.02,
+        "xanchor": "left", "x": 0,
+    }
+    layout["height"] = 330
+    return layout
 
 
 def usage_over_time(
@@ -400,70 +568,15 @@ def usage_over_time(
     chart. Cost ticks render in `$1.2K` shorthand via
     `dashboard_theme.fmt_money`.
     """
-    if not points and not backend_rows_by_day:
-        return _empty_figure(
-            "No events match the current filters.", height=330,
-        )
-
-    daily = _roll_up_time_series(points)
-
-    if mode == "backend" and backend_rows_by_day:
-        _ensure_backend_days(daily, backend_rows_by_day)
-
-    days = sorted(daily.keys())
-    if not days:
+    data = _prepare_usage_data(points, backend_rows_by_day, mode)
+    if data is None:
         return _empty_figure(
             "No events match the current filters.", height=330,
         )
 
     fig = go.Figure()
-    if mode == "backend" and backend_rows_by_day:
-        backends = _backend_names(backend_rows_by_day)
-        # Reverse the legend order so the first backend renders at
-        # the bottom of the stack (matching how token type is drawn).
-        for backend in backends:
-            color = theme.color_for(
-                backend, backends, explicit=theme.BACKEND_COLORS
-            )
-            _add_token_stack_trace(
-                fig,
-                days=days,
-                values=[
-                    backend_rows_by_day.get(day, {}).get(backend, 0)
-                    for day in days
-                ],
-                name=backend,
-                color=color,
-            )
-    else:
-        for band, label in (
-            ("input", "Input"),
-            ("output", "Output"),
-            ("cache", "Cache"),
-        ):
-            color = theme.TOKEN_TYPE_COLORS[label]
-            _add_token_stack_trace(
-                fig,
-                days=days,
-                values=[daily[day][band] for day in days],
-                name=label,
-                color=color,
-            )
-
-    fig.add_trace(
-        go.Scatter(
-            x=_date_axis(days),
-            y=[daily[d]["cost"] for d in days],
-            name="Cost",
-            mode="lines+markers",
-            line={"color": theme.INK, "width": 2},
-            marker={"size": 5, "color": theme.INK},
-            yaxis="y2",
-            hovertemplate="%{x}<br>Cost: $%{y:.2f}<extra></extra>",
-        )
-    )
-
-    layout = theme.base_layout(title=title)
+    _add_usage_stack_traces(fig, data, backend_rows_by_day, mode)
+    _add_usage_cost_trace(fig, data)
     # Align the two y-axes on a shared set of horizontal gridlines.
     # Both axes start at zero and split into the same number of equal
     # steps, so each tokens gridline and its USD counterpart sit on the
@@ -471,51 +584,44 @@ def usage_over_time(
     # ranges (e.g. 6 token lines from 0 to 1B vs 5 USD lines to $1000)
     # whose gridlines visually drift apart. Only the left (tokens) axis
     # draws the gridlines; the right (USD) axis ticks land on them.
-    stack_totals = _usage_stack_totals(
-        days, daily, backend_rows_by_day=backend_rows_by_day, mode=mode
-    )
-    token_max = max(stack_totals, default=0.0)
-    cost_max = max((daily[d]["cost"] for d in days), default=0.0)
-    token_top = _nice_axis_max(token_max, _USAGE_GRID_STEPS)
-    cost_top = _nice_axis_max(cost_max, _USAGE_GRID_STEPS)
-    layout["yaxis"] = {
-        **layout.get("yaxis", {}),
-        "title": {"text": "tokens"},
-        "range": [0, token_top],
-        "dtick": token_top / _USAGE_GRID_STEPS,
-        "rangemode": "tozero",
-        "showgrid": True,
-    }
-    layout["yaxis2"] = {
-        "title": {"text": "USD"},
-        "overlaying": "y",
-        "side": "right",
-        "range": [0, cost_top],
-        "dtick": cost_top / _USAGE_GRID_STEPS,
-        "rangemode": "tozero",
-        "gridcolor": theme.GRID,
-        "linecolor": theme.GRID,
-        "showgrid": False,
-        "tickprefix": "$",
-        "tickfont": {"color": theme.MUTED_TEXT},
-    }
-    # The card header already prints the chart title, so `title` is
-    # passed as None from the dashboard; keep enough top margin for the
-    # horizontal legend that floats just above the plot area.
-    layout["margin"] = {**layout.get("margin", {}), "t": 28}
-    layout["hovermode"] = "x unified"
-    layout["legend"] = {
-        **layout.get("legend", {}),
-        "orientation": "h",
-        "yanchor": "bottom", "y": 1.02,
-        "xanchor": "left", "x": 0,
-    }
-    # Hero chart: ~330px matches the standalone mock. Plotly's
-    # default 450px leaves the chart looking over-tall against the
-    # surrounding KPI strip and stage-cost cards.
-    layout["height"] = 330
-    fig.update_layout(**layout)
+    fig.update_layout(**_usage_layout(data, backend_rows_by_day, mode, title))
     return fig
+
+
+@dataclass(frozen=True)
+class _HorizontalBars:
+    labels: Sequence[str]
+    subs: Sequence[str]
+    values: Sequence[float]
+    colors: Sequence[str]
+
+
+def _reverse_horizontal_bars(data: _HorizontalBars) -> _HorizontalBars:
+    reversed_values = _reverse_lists(
+        data.labels, data.subs, data.values, data.colors,
+    )
+    return _HorizontalBars(*reversed_values)
+
+
+def _horizontal_bars_data(
+    items: Sequence[tuple[str, str, float, str]],
+    accent: Optional[str],
+    preserve_order: bool,
+) -> _HorizontalBars:
+    ordered = list(items)
+    if not preserve_order:
+        ordered.sort(key=_cost_item_sort_key)
+    return _reverse_horizontal_bars(_HorizontalBars(
+        labels=[item[0] for item in ordered],
+        subs=[item[1] for item in ordered],
+        values=[float(item[2] or 0.0) for item in ordered],
+        colors=[item[3] or accent or theme.ACCENT for item in ordered],
+    ))
+
+
+def _cost_item_sort_key(item: tuple[str, str, float, str]) -> float:
+    cost = float(item[2] or 0.0)
+    return -cost
 
 
 def cost_horizontal_bars(
@@ -550,31 +656,14 @@ def cost_horizontal_bars(
             "No data matches the current filters.",
             height=height or 120,
         )
-    ordered = (
-        list(items)
-        if preserve_order
-        else sorted(items, key=lambda it: -float(it[2] or 0.0))
-    )
-    labels = [it[0] for it in ordered]
-    subs = [it[1] for it in ordered]
-    values = [float(it[2] or 0.0) for it in ordered]
-    colors = [
-        (it[3] if (len(it) > 3 and it[3]) else (accent or theme.ACCENT))
-        for it in ordered
-    ]
-    # Plotly draws the first y-value at the bottom of a horizontal
-    # bar chart; reverse so the largest cost sits at the top.
-    labels, subs, values, colors = _reverse_lists(
-        labels, subs, values, colors
-    )
-    y_ticks = _two_line_y_ticks(labels, subs)
+    data = _horizontal_bars_data(items, accent, preserve_order)
     fig = go.Figure(
         go.Bar(
-            x=values,
-            y=y_ticks,
+            x=data.values,
+            y=_two_line_y_ticks(data.labels, data.subs),
             orientation="h",
-            marker_color=colors,
-            text=_money_text(values),
+            marker_color=data.colors,
+            text=_money_text(data.values),
             textposition="outside",
             textfont=_monospace_textfont(),
             cliponaxis=False,
@@ -587,9 +676,66 @@ def cost_horizontal_bars(
     # the same hero-chart height. An explicit `height` (e.g. to match
     # a paired panel) overrides the per-row computation.
     _apply_horizontal_cost_layout(
-        fig, title=title, row_count=len(values), height=height
+        fig,
+        _HorizontalCostLayout(
+            title=title,
+            row_count=len(data.values),
+            height=height,
+        ),
     )
     return fig
+
+
+@dataclass(frozen=True)
+class _StageCostBars:
+    labels: Sequence[str]
+    subs: Sequence[str]
+    no_cache: Sequence[float]
+    cache: Sequence[float]
+    totals: Sequence[float]
+    colors: Sequence[str]
+    cache_colors: Sequence[str]
+
+
+def _stage_no_cache_cost(row: StageBreakdown) -> float:
+    no_cache = float(row.no_cache_cost_usd or 0.0)
+    cache = float(row.cache_cost_usd or 0.0)
+    total = float(row.total_cost_usd or 0.0)
+    if no_cache == 0.0 and cache == 0.0 and total > 0.0:
+        return total
+    return no_cache
+
+
+def _reverse_stage_cost_bars(data: _StageCostBars) -> _StageCostBars:
+    reversed_values = _reverse_lists(
+        data.labels,
+        data.subs,
+        data.no_cache,
+        data.cache,
+        data.totals,
+        data.colors,
+        data.cache_colors,
+    )
+    return _StageCostBars(*reversed_values)
+
+
+def _stage_cost_bars(rows: Sequence[StageBreakdown]) -> _StageCostBars:
+    ordered = sorted(
+        rows, key=lambda row: -float(row.total_cost_usd or 0.0),
+    )
+    colors = [
+        theme.color_for(row.stage, explicit=theme.STAGE_COLORS)
+        for row in ordered
+    ]
+    return _reverse_stage_cost_bars(_StageCostBars(
+        labels=[row.stage for row in ordered],
+        subs=[f"{int(row.runs or 0):,} runs" for row in ordered],
+        no_cache=[_stage_no_cache_cost(row) for row in ordered],
+        cache=[float(row.cache_cost_usd or 0.0) for row in ordered],
+        totals=[float(row.total_cost_usd or 0.0) for row in ordered],
+        colors=colors,
+        cache_colors=[_lighten_hex(color, 0.45) for color in colors],
+    ))
 
 
 def cost_by_stage(
@@ -620,48 +766,8 @@ def cost_by_stage(
             "No stage data matches the current filters.",
             height=height or 120,
         )
-    # Sort by total cost descending so the largest spend sits at the
-    # top -- matching the prior `cost_horizontal_bars` layout.
-    ordered = sorted(
-        rows, key=lambda r: -float(r.total_cost_usd or 0.0)
-    )
-    labels = [r.stage for r in ordered]
-    subs = [f"{int(r.runs or 0):,} runs" for r in ordered]
-    no_cache = [float(r.no_cache_cost_usd or 0.0) for r in ordered]
-    cache = [float(r.cache_cost_usd or 0.0) for r in ordered]
-    # When the rollup carries no cache split (legacy fixture with
-    # cache_cost + no_cache_cost both zero) fall back to plotting the
-    # full total as no-cache so the bar length still reads correctly.
-    totals = [
-        float(r.total_cost_usd or 0.0) for r in ordered
-    ]
-    for row_index, (no_cache_cost, cache_cost, total_cost) in enumerate(
-        zip(no_cache, cache, totals)
-    ):
-        if no_cache_cost == 0.0 and cache_cost == 0.0 and total_cost > 0.0:
-            no_cache[row_index] = total_cost
-    colors = [
-        theme.color_for(r.stage, explicit=theme.STAGE_COLORS)
-        for r in ordered
-    ]
-    # 0.45 alpha keeps the cache segment legible on the page
-    # background while leaving the no-cache portion as the dominant
-    # stage color -- mirroring `cost_by_review_round`.
-    cache_colors = [_lighten_hex(stage_color, 0.45) for stage_color in colors]
-    # Plotly draws the first y-value at the bottom of a horizontal
-    # bar chart; reverse so the largest cost sits at the top.
-    (
-        labels,
-        subs,
-        no_cache,
-        cache,
-        totals,
-        colors,
-        cache_colors,
-    ) = _reverse_lists(
-        labels, subs, no_cache, cache, totals, colors, cache_colors
-    )
-    y_ticks = _two_line_y_ticks(labels, subs)
+    data = _stage_cost_bars(rows)
+    y_ticks = _two_line_y_ticks(data.labels, data.subs)
     fig = go.Figure()
     # No-cache trace is added first so it reads as the base segment
     # and cache stacks outward -- matching the issue's "with and
@@ -670,29 +776,35 @@ def cost_by_stage(
     # per bar instead of duplicating on each segment.
     fig.add_trace(
         _cost_bar_trace(
-            name="No cache",
-            values=no_cache,
-            y_ticks=y_ticks,
-            color=colors,
-            hover_label="No cache",
+            _CostBarTrace(
+                name="No cache",
+                values=data.no_cache,
+                y_ticks=y_ticks,
+                color=data.colors,
+                hover_label="No cache",
+            ),
         )
     )
     fig.add_trace(
         _cost_bar_trace(
-            name="Cache",
-            values=cache,
-            y_ticks=y_ticks,
-            color=cache_colors,
-            hover_label="Cache",
-            totals=totals,
+            _CostBarTrace(
+                name="Cache",
+                values=data.cache,
+                y_ticks=y_ticks,
+                color=data.cache_colors,
+                hover_label="Cache",
+                totals=data.totals,
+            ),
         )
     )
     _apply_horizontal_cost_layout(
         fig,
-        row_count=len(y_ticks),
-        height=height,
-        barmode="stack",
-        legend=_horizontal_legend(),
+        _HorizontalCostLayout(
+            row_count=len(y_ticks),
+            height=height,
+            barmode="stack",
+            legend=_horizontal_legend(),
+        ),
     )
     return fig
 
@@ -711,6 +823,125 @@ def _lighten_hex(hex_color: str, alpha: float) -> str:
     g = int(h[2:4], 16)
     b = int(h[4:6], 16)
     return f"rgba({r},{g},{b},{alpha:.2f})"
+
+
+@dataclass(frozen=True)
+class _ReviewCostBars:
+    labels: Sequence[str]
+    subs: Sequence[str]
+    developer_no_cache: Sequence[float]
+    developer_cache: Sequence[float]
+    reviewer_no_cache: Sequence[float]
+    reviewer_cache: Sequence[float]
+    developer_totals: Sequence[float]
+    reviewer_totals: Sequence[float]
+
+
+def _developer_cost_total(row: ReviewRoundBucketRow) -> float:
+    no_cache = float(row.developer_no_cache_cost_usd or 0.0)
+    cache = float(row.developer_cache_cost_usd or 0.0)
+    return no_cache + cache
+
+
+def _reviewer_cost_total(row: ReviewRoundBucketRow) -> float:
+    no_cache = float(row.reviewer_no_cache_cost_usd or 0.0)
+    cache = float(row.reviewer_cache_cost_usd or 0.0)
+    return no_cache + cache
+
+
+def _reverse_review_cost_bars(data: _ReviewCostBars) -> _ReviewCostBars:
+    reversed_values = _reverse_lists(
+        data.labels,
+        data.subs,
+        data.developer_no_cache,
+        data.developer_cache,
+        data.reviewer_no_cache,
+        data.reviewer_cache,
+        data.developer_totals,
+        data.reviewer_totals,
+    )
+    return _ReviewCostBars(*reversed_values)
+
+
+def _review_cost_bars(
+    rows: Sequence[ReviewRoundBucketRow],
+) -> Optional[_ReviewCostBars]:
+    by_bucket = {row.bucket: row for row in rows}
+    ordered = [
+        by_bucket[bucket]
+        for bucket in _REVIEW_ROUND_ORDER
+        if bucket in by_bucket
+    ]
+    if not ordered:
+        return None
+    return _reverse_review_cost_bars(_ReviewCostBars(
+        labels=[_REVIEW_ROUND_LABELS.get(row.bucket, row.bucket) for row in ordered],
+        subs=[
+            f"{int(row.developer_runs or 0):,} dev / "
+            f"{int(row.reviewer_runs or 0):,} review runs"
+            for row in ordered
+        ],
+        developer_no_cache=[
+            float(row.developer_no_cache_cost_usd or 0.0) for row in ordered
+        ],
+        developer_cache=[
+            float(row.developer_cache_cost_usd or 0.0) for row in ordered
+        ],
+        reviewer_no_cache=[
+            float(row.reviewer_no_cache_cost_usd or 0.0) for row in ordered
+        ],
+        reviewer_cache=[
+            float(row.reviewer_cache_cost_usd or 0.0) for row in ordered
+        ],
+        developer_totals=[_developer_cost_total(row) for row in ordered],
+        reviewer_totals=[_reviewer_cost_total(row) for row in ordered],
+    ))
+
+
+def _review_cost_traces(
+    data: _ReviewCostBars,
+    y_ticks: Sequence[str],
+) -> tuple[_CostBarTrace, ...]:
+    developer_color = theme.AGENT_ROLE_COLORS["developer"]
+    reviewer_color = theme.AGENT_ROLE_COLORS["reviewer"]
+    developer_cache_color = _lighten_hex(developer_color, 0.45)
+    reviewer_cache_color = _lighten_hex(reviewer_color, 0.45)
+    return (
+        _CostBarTrace(
+            name="Review (no cache)",
+            values=data.reviewer_no_cache,
+            y_ticks=y_ticks,
+            color=reviewer_color,
+            offsetgroup="reviewer",
+            hover_label="Review (no cache)",
+        ),
+        _CostBarTrace(
+            name="Review (cache)",
+            values=data.reviewer_cache,
+            y_ticks=y_ticks,
+            color=reviewer_cache_color,
+            offsetgroup="reviewer",
+            totals=data.reviewer_totals,
+            hover_label="Review (cache)",
+        ),
+        _CostBarTrace(
+            name="Development (no cache)",
+            values=data.developer_no_cache,
+            y_ticks=y_ticks,
+            color=developer_color,
+            offsetgroup="developer",
+            hover_label="Development (no cache)",
+        ),
+        _CostBarTrace(
+            name="Development (cache)",
+            values=data.developer_cache,
+            y_ticks=y_ticks,
+            color=developer_cache_color,
+            offsetgroup="developer",
+            totals=data.developer_totals,
+            hover_label="Development (cache)",
+        ),
+    )
 
 
 def cost_by_review_round(
@@ -738,72 +969,13 @@ def cost_by_review_round(
             "No `agent_exit` rows match the current filters.",
             height=height or 120,
         )
-    # Logical sequence before Plotly's horizontal-bar reversal:
-    # Initial -> Round 1 -> ... -> No review round.
-    by_bucket = {r.bucket: r for r in rows}
-    ordered_rows = [
-        by_bucket[bucket]
-        for bucket in _REVIEW_ROUND_ORDER
-        if bucket in by_bucket
-    ]
-    if not ordered_rows:
+    data = _review_cost_bars(rows)
+    if data is None:
         return _empty_figure(
             "No development or review runs match the current filters.",
             height=height or 120,
         )
-    labels = [
-        _REVIEW_ROUND_LABELS.get(r.bucket, r.bucket)
-        for r in ordered_rows
-    ]
-    subs = [
-        (
-            f"{int(r.developer_runs or 0):,} dev / "
-            f"{int(r.reviewer_runs or 0):,} review runs"
-        )
-        for r in ordered_rows
-    ]
-    # Each role splits into (no-cache portion, cache portion). The
-    # read model guarantees no_cache + cache == role total, so the
-    # stacked segments add back to the per-role total the previous
-    # design plotted.
-    dev_no_cache = [
-        float(r.developer_no_cache_cost_usd or 0.0) for r in ordered_rows
-    ]
-    dev_cache = [
-        float(r.developer_cache_cost_usd or 0.0) for r in ordered_rows
-    ]
-    review_no_cache = [
-        float(r.reviewer_no_cache_cost_usd or 0.0) for r in ordered_rows
-    ]
-    review_cache = [
-        float(r.reviewer_cache_cost_usd or 0.0) for r in ordered_rows
-    ]
-    dev_totals = [a + b for a, b in zip(dev_no_cache, dev_cache)]
-    review_totals = [a + b for a, b in zip(review_no_cache, review_cache)]
-
-    # Plotly draws the first y-value at the bottom of a horizontal
-    # grouped bar chart, so reverse to keep Initial at the top.
-    (
-        labels,
-        subs,
-        dev_no_cache,
-        dev_cache,
-        review_no_cache,
-        review_cache,
-        dev_totals,
-        review_totals,
-    ) = _reverse_lists(
-        labels, subs, dev_no_cache, dev_cache, review_no_cache,
-        review_cache, dev_totals, review_totals,
-    )
-    y_ticks = _two_line_y_ticks(labels, subs)
-    dev_color = theme.AGENT_ROLE_COLORS["developer"]
-    review_color = theme.AGENT_ROLE_COLORS["reviewer"]
-    # 0.45 alpha keeps the cache segment legible on the page
-    # background while leaving the no-cache portion as the dominant
-    # role color.
-    dev_cache_color = _lighten_hex(dev_color, 0.45)
-    review_cache_color = _lighten_hex(review_color, 0.45)
+    y_ticks = _two_line_y_ticks(data.labels, data.subs)
     fig = go.Figure()
     # Horizontal grouped+stacked layout: `offsetgroup` controls the
     # side-by-side offset (one for development, one for review); two
@@ -814,49 +986,26 @@ def cost_by_review_round(
     # offset, the no-cache trace is added before the cache trace so
     # no-cache reads as the base segment and cache stacks outward --
     # matching the issue's "no-cache + cache in stacked form" framing.
-    for name, values, color, offset, totals in (
-        (
-            "Review (no cache)", review_no_cache, review_color,
-            "reviewer", None,
-        ),
-        (
-            "Review (cache)", review_cache, review_cache_color,
-            "reviewer", review_totals,
-        ),
-        (
-            "Development (no cache)", dev_no_cache, dev_color,
-            "developer", None,
-        ),
-        (
-            "Development (cache)", dev_cache, dev_cache_color,
-            "developer", dev_totals,
-        ),
-    ):
+    for trace in _review_cost_traces(data, y_ticks):
         # Only the outer (cache) trace carries the per-role total
         # text so the dollar label still lands once per role bar
         # instead of duplicating on each segment.
         fig.add_trace(
-            _cost_bar_trace(
-                name=name,
-                values=values,
-                y_ticks=y_ticks,
-                color=color,
-                offsetgroup=offset,
-                totals=totals,
-                hover_label=name,
-            )
+            _cost_bar_trace(trace)
         )
     # `relative` honors `offsetgroup` so same-offset traces stack and
     # different-offset traces sit side-by-side. With all-positive
     # values this acts identically to `stack` per offset.
     _apply_horizontal_cost_layout(
         fig,
-        row_count=len(y_ticks),
-        height=height,
-        barmode="relative",
-        legend=_horizontal_legend(traceorder="reversed"),
-        row_height=_REVIEW_BAR_ROW_HEIGHT,
-        extra_height=_REVIEW_BAR_EXTRA_HEIGHT,
+        _HorizontalCostLayout(
+            row_count=len(y_ticks),
+            height=height,
+            barmode="relative",
+            legend=_horizontal_legend(traceorder="reversed"),
+            row_height=_REVIEW_BAR_ROW_HEIGHT,
+            extra_height=_REVIEW_BAR_EXTRA_HEIGHT,
+        ),
     )
     return fig
 
@@ -876,17 +1025,50 @@ def cost_by_repo(rows: Sequence[RepoBreakdownRow]) -> go.Figure:
             "No repos match the current filters.", height=120,
         )
     items = []
-    for r in rows:
-        short = r.repo.split("/")[-1] if "/" in r.repo else r.repo
+    for row in rows:
         items.append(
             (
-                short,
-                f"{int(r.agent_exits):,} runs",
-                float(r.total_cost_usd or 0.0),
+                _repo_short_name(row.repo),
+                f"{int(row.agent_exits):,} runs",
+                float(row.total_cost_usd or 0.0),
                 theme.ACCENT,
             )
         )
     return cost_horizontal_bars(items)
+
+
+def _repo_short_name(repo: str) -> str:
+    if "/" not in repo:
+        return repo
+    return repo.rsplit("/", maxsplit=1)[-1]
+
+
+def _valid_heatmap_point(point: HourlyHeatmapPoint, weekdays: int) -> bool:
+    valid_weekday = 0 <= int(point.weekday) < weekdays
+    valid_hour = 0 <= int(point.hour) < _HOURS_PER_DAY
+    return valid_weekday and valid_hour
+
+
+def _heatmap_matrix(
+    points: Sequence[HourlyHeatmapPoint],
+) -> list[list[int]]:
+    weekdays = len(_WEEKDAY_LABELS)
+    matrix = [[0] * _HOURS_PER_DAY for _ in range(weekdays)]
+    for point in points:
+        if _valid_heatmap_point(point, weekdays):
+            matrix[int(point.weekday)][int(point.hour)] = int(
+                getattr(point, "total_tokens", 0) or 0
+            )
+    return matrix
+
+
+def _heatmap_layout(title: Optional[str]) -> dict[str, object]:
+    layout = theme.base_layout(title=title)
+    top_margin = layout["margin"]["t"]
+    layout["margin"] = {"l": 48, "r": 24, "t": top_margin, "b": 32}
+    layout["height"] = 240
+    layout["plot_bgcolor"] = theme.BORDER
+    return layout
 
 
 def hour_weekday_heatmap(
@@ -911,16 +1093,9 @@ def hour_weekday_heatmap(
     caller is responsible for passing the matching offset to
     `get_hourly_heatmap` so the cells already reflect that zone.
     """
-    weekdays = len(_WEEKDAY_LABELS)
-    matrix = [[0] * _HOURS_PER_DAY for _ in range(weekdays)]
-    for p in points:
-        if 0 <= int(p.weekday) < weekdays and 0 <= int(p.hour) < _HOURS_PER_DAY:
-            matrix[int(p.weekday)][int(p.hour)] = int(
-                getattr(p, "total_tokens", 0) or 0
-            )
     fig = go.Figure(
         go.Heatmap(
-            z=matrix,
+            z=_heatmap_matrix(points),
             x=[f"{h:02d}" for h in range(_HOURS_PER_DAY)],
             y=list(_WEEKDAY_LABELS),
             colorscale=[
@@ -934,19 +1109,15 @@ def hour_weekday_heatmap(
             hovertemplate="%{y} %{x}:00 -- %{z:,} tokens<extra></extra>",
         )
     )
-    layout = theme.base_layout(title=title)
-    layout["margin"] = {"l": 48, "r": 24, "t": layout["margin"]["t"], "b": 32}
     # 7 rows x 24 columns: ~240px keeps the cells close to the
     # mock's compact squares instead of stretching them into tall
     # rectangles at the default 450px.
-    layout["height"] = 240
     # Paint the plot background the border colour so the `xgap`/`ygap`
     # between cells reads as a weekday x hour grid. Zero-volume cells
     # are white (colorscale[0] == CARD_BG), so without a contrasting
     # backdrop the gaps vanish and the sparse right-hand hours look
     # like missing data rather than empty cells.
-    layout["plot_bgcolor"] = theme.BORDER
-    fig.update_layout(**layout)
+    fig.update_layout(**_heatmap_layout(title))
     fig.update_xaxes(
         title_text=f"hour ({tz_label})", type="category", showgrid=False,
     )
@@ -958,6 +1129,37 @@ def hour_weekday_heatmap(
             font={"color": theme.MUTED_TEXT, "size": theme.FONT_SIZE},
         )
     return fig
+
+
+@dataclass(frozen=True)
+class _ThroughputSeries:
+    days: Sequence[date]
+    resolved: Sequence[int]
+
+
+def _calendar_days(window_start: date, window_end: date) -> list[date]:
+    days: list[date] = []
+    current = window_start
+    while current <= window_end:
+        days.append(current)
+        current = current + timedelta(days=1)
+    return days
+
+
+def _throughput_series(
+    rows: Sequence[ThroughputDayRow],
+    window_start: Optional[date],
+    window_end: Optional[date],
+) -> _ThroughputSeries:
+    resolved_by_day = {row.day: int(row.resolved or 0) for row in rows}
+    if window_start is not None and window_end is not None:
+        days = _calendar_days(window_start, window_end)
+    else:
+        days = sorted(resolved_by_day)
+    return _ThroughputSeries(
+        days=days,
+        resolved=[resolved_by_day.get(day, 0) for day in days],
+    )
 
 
 def done_per_day_bars(
@@ -981,32 +1183,22 @@ def done_per_day_bars(
     back to the legacy behavior (one bar per SQL row only) so
     existing callers / tests keep working.
     """
-    days_index = {r.day: int(r.resolved or 0) for r in rows}
-    if window_start is not None and window_end is not None:
-        days: list[date] = []
-        d = window_start
-        # Walk inclusive end day by day; using `timedelta` keeps the
-        # rollover safe across month / year boundaries.
-        while d <= window_end:
-            days.append(d)
-            d = d + timedelta(days=1)
-    else:
-        days = sorted(days_index)
-    if not days:
+    series = _throughput_series(rows, window_start, window_end)
+    if not series.days:
         return _empty_figure(
             "No resolved issues in the current window.", height=150,
         )
-    resolved = [days_index.get(d, 0) for d in days]
     fig = go.Figure(
         go.Bar(
-            x=days,
-            y=resolved,
+            x=series.days,
+            y=series.resolved,
             marker_color=theme.SUCCESS,
             hovertemplate="%{x}: %{y} resolved<extra></extra>",
         )
     )
     layout = theme.base_layout(title=title)
-    layout["margin"] = {"l": 40, "r": 16, "t": layout["margin"]["t"], "b": 32}
+    top_margin = layout["margin"]["t"]
+    layout["margin"] = {"l": 40, "r": 16, "t": top_margin, "b": 32}
     layout["yaxis"] = {
         **layout.get("yaxis", {}),
         "title": {"text": "resolved"},

--- a/orchestrator/dashboard_html.py
+++ b/orchestrator/dashboard_html.py
@@ -21,6 +21,7 @@ tick's import surface never touches it.
 from __future__ import annotations
 
 import html
+from dataclasses import dataclass
 from datetime import date
 from typing import Callable, Optional, Sequence
 
@@ -87,7 +88,9 @@ def _short_repo_name(repo: str) -> str:
 
 
 def _sparkline_y(value: float, *, lo: float, span: float, pad: int, h: int) -> float:
-    return pad + (1 - (value - lo) / span) * (h - pad * 2)
+    normalized_value = (value - lo) / span
+    drawable_height = h - pad * 2
+    return pad + (1 - normalized_value) * drawable_height
 
 
 def _int_or_zero(raw: object) -> int:
@@ -108,6 +111,91 @@ def _plural_s(count: int) -> str:
     return "s"
 
 
+@dataclass(frozen=True)
+class _SparklineLayout:
+    low: float
+    span: float
+    padding: int
+    height: int
+    step: float
+
+
+@dataclass(frozen=True)
+class _SparklinePaths:
+    polyline: str
+    area: str
+
+
+def _sparkline_step(width: int, padding: int, value_count: int) -> float:
+    drawable_width = width - padding * 2
+    intervals = max(value_count - 1, 1)
+    return drawable_width / intervals
+
+
+def _sparkline_layout(values: Sequence[float], *, width: int, height: int) -> _SparklineLayout:
+    low = min(values)
+    padding = 2
+    return _SparklineLayout(
+        low=low,
+        span=max(max(values) - low, 1e-9),
+        padding=padding,
+        height=height,
+        step=_sparkline_step(width, padding, len(values)),
+    )
+
+
+def _sparkline_point(index: int, value: float, layout: _SparklineLayout) -> tuple[float, float]:
+    return (
+        layout.padding + index * layout.step,
+        _sparkline_y(
+            value,
+            lo=layout.low,
+            span=layout.span,
+            pad=layout.padding,
+            h=layout.height,
+        ),
+    )
+
+
+def _sparkline_points(
+    values: Sequence[float], *, width: int, height: int,
+) -> list[tuple[float, float]]:
+    numbers = [float(value or 0) for value in values]
+    if not numbers or max(numbers) == min(numbers) == 0:
+        return []
+    layout = _sparkline_layout(numbers, width=width, height=height)
+    return [
+        _sparkline_point(index, value, layout)
+        for index, value in enumerate(numbers)
+    ]
+
+
+def _sparkline_paths(
+    points: Sequence[tuple[float, float]], *, height: int,
+) -> _SparklinePaths:
+    padding = 2
+    polyline = " ".join(map(_sparkline_point_text, points))
+    area = _sparkline_area_path(points, height=height, padding=padding)
+    return _SparklinePaths(polyline=polyline, area=area)
+
+
+def _sparkline_point_text(point: tuple[float, float]) -> str:
+    return f"{point[0]:.1f},{point[1]:.1f}"
+
+
+def _sparkline_area_path(
+    points: Sequence[tuple[float, float]],
+    *,
+    height: int,
+    padding: int,
+) -> str:
+    baseline = height - padding
+    start = f"M{points[0][0]:.1f},{baseline:.1f}"
+    line = " L" + " L".join(map(_sparkline_point_text, points))
+    end = f" L{points[-1][0]:.1f},{baseline:.1f} Z"
+    return start + line + end
+
+
 def _sparkline_svg(
     values: Sequence[float], *, color: str, w: int = 96, h: int = 26
 ) -> str:
@@ -118,31 +206,15 @@ def _sparkline_svg(
     without a chart round-trip. Empty / flat data renders an empty SVG
     so the layout slot stays consistent across KPIs.
     """
-    nums = [float(v or 0) for v in values]
-    if len(nums) == 0 or max(nums) == min(nums) == 0:
+    points = _sparkline_points(values, width=w, height=h)
+    if not points:
         return f'<svg width="{w}" height="{h}" viewBox="0 0 {w} {h}"></svg>'
-    lo, hi = min(nums), max(nums)
-    span = max(hi - lo, 1e-9)
-    pad = 2
-    step = (w - pad * 2) / max(len(nums) - 1, 1)
-    points = [
-        (
-            pad + i * step,
-            _sparkline_y(v, lo=lo, span=span, pad=pad, h=h),
-        )
-        for i, v in enumerate(nums)
-    ]
-    poly = " ".join(f"{x:.1f},{yv:.1f}" for x, yv in points)
-    area_path = (
-        "M" + f"{points[0][0]:.1f},{h - pad:.1f}"
-        + " L" + " L".join(f"{x:.1f},{yv:.1f}" for x, yv in points)
-        + f" L{points[-1][0]:.1f},{h - pad:.1f} Z"
-    )
+    paths = _sparkline_paths(points, height=h)
     return (
         f'<svg width="{w}" height="{h}" viewBox="0 0 {w} {h}" '
         f'style="display:block">'
-        f'<path d="{area_path}" fill="{color}" fill-opacity="0.18" />'
-        f'<polyline points="{poly}" fill="none" stroke="{color}" '
+        f'<path d="{paths.area}" fill="{color}" fill-opacity="0.18" />'
+        f'<polyline points="{paths.polyline}" fill="none" stroke="{color}" '
         f'stroke-width="1.6" stroke-linecap="round" '
         f'stroke-linejoin="round" />'
         "</svg>"
@@ -305,29 +377,44 @@ def _review_round_html(review_rounds: int) -> str:
     return str(review_rounds)
 
 
+@dataclass(frozen=True)
+class _IssueRowView:
+    short_repo: str
+    cost_text: str
+    bar_pct: float
+    review_rounds: int
+    retries: int
+    failed: int
+
+
+def _issue_row_view(row: IssueSummaryRow, max_cost: float) -> _IssueRowView:
+    return _IssueRowView(
+        short_repo=_short_repo_name(row.repo),
+        cost_text=_money_or_dash(row.total_cost_usd),
+        bar_pct=_relative_width_pct(float(row.total_cost_usd or 0.0), max_cost),
+        review_rounds=_int_or_zero(row.max_review_round),
+        retries=_int_or_zero(row.max_retry_count),
+        failed=int(row.failed_agent_runs or 0),
+    )
+
+
 def _issue_table_row_html(row: IssueSummaryRow, *, max_cost: float) -> str:
-    short = _short_repo_name(row.repo)
-    cost = float(row.total_cost_usd or 0.0)
-    bar_pct = _relative_width_pct(cost, max_cost)
-    cost_text = _money_or_dash(row.total_cost_usd)
-    review_rounds = _int_or_zero(row.max_review_round)
-    retries = _int_or_zero(row.max_retry_count)
-    failed = int(row.failed_agent_runs or 0)
+    view = _issue_row_view(row, max_cost)
     return (
         "<tr>"
         "<td>"
         '<div class="orch-issue-cell">'
-        f'<span><span class="orch-issue-name">{html.escape(short)}</span>'
+        f'<span><span class="orch-issue-name">{html.escape(view.short_repo)}</span>'
         f' <span class="orch-issue-num">#{int(row.issue)}</span></span>'
-        f'<span class="orch-issue-bar"><span style="width:{bar_pct:.1f}%">'
+        f'<span class="orch-issue-bar"><span style="width:{view.bar_pct:.1f}%">'
         "</span></span>"
         "</div>"
         "</td>"
-        f'<td class="r strong">{html.escape(cost_text)}</td>'
+        f'<td class="r strong">{html.escape(view.cost_text)}</td>'
         f'<td class="r">{int(row.agent_exits or 0)}</td>'
-        f'<td class="r">{_review_round_html(review_rounds)}</td>'
-        f'<td class="r">{retries}</td>'
-        f'<td class="r">{_issue_status_pill(failed)}</td>'
+        f'<td class="r">{_review_round_html(view.review_rounds)}</td>'
+        f'<td class="r">{view.retries}</td>'
+        f'<td class="r">{_issue_status_pill(view.failed)}</td>'
         "</tr>"
     )
 
@@ -467,21 +554,25 @@ _SKILL_MATRIX_EXTRA_CSS = """
   .orch-skillmatrix-sort { margin-left: 3px; color: var(--orch-accent); }
 """
 
-# Column model for the per-skill trigger matrix. Each entry is
-# `(param key, header label, right-aligned?, sort-value function)`. The
-# key is the stable identifier a clickable header encodes into the
-# `mtx_sort` query param, and the sort function pulls exactly the value
-# the column shows so a header click sorts on what the operator sees.
-_SKILL_MATRIX_COLUMNS: tuple[
-    tuple[str, str, bool, Callable[[SkillTriggerMatrixRow], object]], ...
-] = (
-    ("repo", "Repo", False, lambda r: (r.repo or "").lower()),
-    ("role", "Role", False, lambda r: (r.agent_role or "").lower()),
-    ("backend", "Backend", False, lambda r: (r.backend or "").lower()),
-    ("skill", "Skill", False, lambda r: (r.skill or "").lower()),
-    ("runs", "Runs", True, lambda r: int(r.runs)),
-    ("skill_runs", "Runs with skill", True, lambda r: int(r.skill_runs)),
-    ("rate", "Trigger rate", True, lambda r: r.rate),
+@dataclass(frozen=True)
+class _SkillMatrixColumn:
+    key: str
+    label: str
+    right_aligned: bool
+    sort_value: Callable[[SkillTriggerMatrixRow], object]
+
+
+# Column model for the per-skill trigger matrix. The key is the stable
+# identifier a clickable header encodes into the `mtx_sort` query param,
+# and the sort function pulls exactly the value the column shows.
+_SKILL_MATRIX_COLUMNS = (
+    _SkillMatrixColumn("repo", "Repo", False, lambda row: (row.repo or "").lower()),
+    _SkillMatrixColumn("role", "Role", False, lambda row: (row.agent_role or "").lower()),
+    _SkillMatrixColumn("backend", "Backend", False, lambda row: (row.backend or "").lower()),
+    _SkillMatrixColumn("skill", "Skill", False, lambda row: (row.skill or "").lower()),
+    _SkillMatrixColumn("runs", "Runs", True, lambda row: int(row.runs)),
+    _SkillMatrixColumn("skill_runs", "Runs with skill", True, lambda row: int(row.skill_runs)),
+    _SkillMatrixColumn("rate", "Trigger rate", True, lambda row: row.rate),
 )
 
 # Numeric columns default a first click to descending (largest first is
@@ -490,7 +581,7 @@ _SKILL_MATRIX_COLUMNS: tuple[
 _SKILL_MATRIX_NUMERIC_KEYS = frozenset({"runs", "skill_runs", "rate"})
 
 _SKILL_MATRIX_SORT_KEYS: dict[str, Callable[[SkillTriggerMatrixRow], object]] = {
-    key: fn for key, _label, _right, fn in _SKILL_MATRIX_COLUMNS
+    column.key: column.sort_value for column in _SKILL_MATRIX_COLUMNS
 }
 
 # Query-param names the clickable headers write and the dashboard reads
@@ -542,7 +633,55 @@ def _default_sort_skill_matrix_rows(
     tying on both keys keep the read model's order (Runs-with-skill DESC
     then Runs DESC then a stable repo/role/backend/skill tiebreak).
     """
-    return sorted(rows, key=lambda r: ((r.repo or "").lower(), -r.rate))
+    return sorted(rows, key=_skill_matrix_default_sort_key)
+
+
+def _skill_matrix_default_sort_key(
+    row: SkillTriggerMatrixRow,
+) -> tuple[str, float]:
+    repo = (row.repo or "").lower()
+    rate = -row.rate
+    return repo, rate
+
+
+@dataclass(frozen=True)
+class _SkillMatrixHeaderState:
+    direction: str
+    arrow: str
+
+
+def _skill_matrix_header_state(
+    column: _SkillMatrixColumn,
+    active_key: Optional[str],
+    descending: bool,
+) -> _SkillMatrixHeaderState:
+    if column.key == active_key:
+        direction = "asc" if descending else "desc"
+        arrow = "▼" if descending else "▲"
+        return _SkillMatrixHeaderState(direction=direction, arrow=arrow)
+    if column.key in _SKILL_MATRIX_NUMERIC_KEYS:
+        return _SkillMatrixHeaderState(direction="desc", arrow="")
+    return _SkillMatrixHeaderState(direction="asc", arrow="")
+
+
+def _skill_matrix_header_cell(
+    column: _SkillMatrixColumn,
+    active_key: Optional[str],
+    descending: bool,
+) -> str:
+    state = _skill_matrix_header_state(column, active_key, descending)
+    cell_class = ' class="r"' if column.right_aligned else ""
+    arrow_html = ""
+    if state.arrow:
+        arrow_html = f'<span class="orch-skillmatrix-sort">{state.arrow}</span>'
+    return (
+        f"<th{cell_class}>"
+        f'<a class="orch-skillmatrix-h" '
+        f'href="?{SKILL_MATRIX_SORT_PARAM}={column.key}'
+        f'&{SKILL_MATRIX_DIR_PARAM}={state.direction}" target="_self">'
+        f"{html.escape(column.label)}</a>{arrow_html}"
+        "</th>"
+    )
 
 
 def _skill_matrix_header_html(active_key: Optional[str], descending: bool) -> str:
@@ -556,31 +695,10 @@ def _skill_matrix_header_html(active_key: Optional[str], descending: bool) -> st
     `target="_self"` keeps the navigation in-tab so Streamlit reruns in
     place rather than opening a new window.
     """
-    cells: list[str] = []
-    for key, label, right, _fn in _SKILL_MATRIX_COLUMNS:
-        if key == active_key:
-            next_desc = not descending
-            arrow = "▼" if descending else "▲"
-        else:
-            next_desc = key in _SKILL_MATRIX_NUMERIC_KEYS
-            arrow = ""
-        direction = "desc" if next_desc else "asc"
-        href = (
-            f"?{SKILL_MATRIX_SORT_PARAM}={key}"
-            f"&{SKILL_MATRIX_DIR_PARAM}={direction}"
-        )
-        cls = ' class="r"' if right else ""
-        arrow_html = (
-            f'<span class="orch-skillmatrix-sort">{arrow}</span>'
-            if arrow
-            else ""
-        )
-        cells.append(
-            f"<th{cls}>"
-            f'<a class="orch-skillmatrix-h" href="{href}" target="_self">'
-            f"{html.escape(label)}</a>{arrow_html}"
-            "</th>"
-        )
+    cells = (
+        _skill_matrix_header_cell(column, active_key, descending)
+        for column in _SKILL_MATRIX_COLUMNS
+    )
     return "<thead><tr>" + "".join(cells) + "</tr></thead>"
 
 
@@ -588,30 +706,47 @@ def _muted_zero_html(value: str) -> str:
     return f'<span class="orch-skillmatrix-zero">{value}</span>'
 
 
-def _skill_matrix_row_html(row: SkillTriggerMatrixRow) -> str:
-    repo = row.repo or "unknown"
-    role = row.agent_role or "unknown"
-    backend = row.backend or "unknown"
-    skill = row.skill or "unknown"
-    runs = int(row.runs)
+@dataclass(frozen=True)
+class _SkillMatrixRowView:
+    repo: str
+    role: str
+    backend: str
+    skill: str
+    runs: int
+    skill_runs_html: str
+    rate_html: str
+
+
+def _skill_matrix_row_view(row: SkillTriggerMatrixRow) -> _SkillMatrixRowView:
     skill_runs = int(row.skill_runs)
-    skill_runs_html = (
-        _muted_zero_html("0") if skill_runs == 0 else str(skill_runs)
+    if skill_runs == 0:
+        skill_runs_html = _muted_zero_html("0")
+        rate_html = _muted_zero_html("0%")
+    else:
+        skill_runs_html = str(skill_runs)
+        rate_html = f"{row.rate * 100.0:.0f}%"
+    return _SkillMatrixRowView(
+        repo=row.repo or "unknown",
+        role=row.agent_role or "unknown",
+        backend=row.backend or "unknown",
+        skill=row.skill or "unknown",
+        runs=int(row.runs),
+        skill_runs_html=skill_runs_html,
+        rate_html=rate_html,
     )
-    rate_html = (
-        _muted_zero_html("0%")
-        if skill_runs == 0
-        else f"{row.rate * 100.0:.0f}%"
-    )
+
+
+def _skill_matrix_row_html(row: SkillTriggerMatrixRow) -> str:
+    view = _skill_matrix_row_view(row)
     return (
         "<tr>"
-        f'<td class="strong">{html.escape(repo)}</td>'
-        f'<td>{html.escape(role)}</td>'
-        f'<td>{html.escape(backend)}</td>'
-        f'<td>{html.escape(skill)}</td>'
-        f'<td class="r">{runs}</td>'
-        f'<td class="r">{skill_runs_html}</td>'
-        f'<td class="r">{rate_html}</td>'
+        f'<td class="strong">{html.escape(view.repo)}</td>'
+        f'<td>{html.escape(view.role)}</td>'
+        f'<td>{html.escape(view.backend)}</td>'
+        f'<td>{html.escape(view.skill)}</td>'
+        f'<td class="r">{view.runs}</td>'
+        f'<td class="r">{view.skill_runs_html}</td>'
+        f'<td class="r">{view.rate_html}</td>'
         "</tr>"
     )
 
@@ -755,9 +890,7 @@ def _backend_efficiency_card_html(
     handle so this module stays free of the theme import (and the
     lazy-import invariant the dashboard relies on).
     """
-    tokens, cost_per_m, cost_per_run, cache_hit_pct = (
-        _backend_efficiency_metrics(row)
-    )
+    metrics = _backend_efficiency_metrics(row)
     color = theme.color_for(
         row.backend, explicit=theme.BACKEND_COLORS
     )
@@ -774,7 +907,7 @@ def _backend_efficiency_card_html(
         f'{html.escape(row.backend)}</b>'
         f'<span style="color:{theme.MUTED_TEXT};'
         f'font-size:12px;margin-left:auto">'
-        f'{row.runs} runs · {theme.fmt_tokens(tokens)} tok'
+        f'{row.runs} runs · {theme.fmt_tokens(metrics.tokens)} tok'
         '</span>'
         '</div>'
         f'<div style="color:{theme.TEXT};font-size:20px;'
@@ -788,38 +921,44 @@ def _backend_efficiency_card_html(
         f'spend</span></div>'
         f'<div style="display:flex;gap:14px;font-size:12px;'
         f'color:{theme.MUTED_TEXT}">'
-        f'<span>${cost_per_m:.2f} / 1M tok</span>'
-        f'<span>{cache_hit_pct:.0f}% cache hit</span>'
-        f'<span>${cost_per_run:.2f} / run</span>'
+        f'<span>${metrics.cost_per_million:.2f} / 1M tok</span>'
+        f'<span>{metrics.cache_hit_pct:.0f}% cache hit</span>'
+        f'<span>${metrics.cost_per_run:.2f} / run</span>'
         '</div></div>'
     )
 
 
+@dataclass(frozen=True)
+class _BackendEfficiencyMetrics:
+    tokens: int
+    cost_per_million: float
+    cost_per_run: float
+    cache_hit_pct: float
+
+
+def _safe_ratio(numerator: float, denominator: float) -> float:
+    if denominator <= 0:
+        return 0.0
+    return numerator / denominator
+
+
 def _backend_efficiency_metrics(
     row: BackendEfficiencyRow,
-) -> tuple[int, float, float, float]:
+) -> _BackendEfficiencyMetrics:
     tokens = int(
         (row.total_input_tokens or 0)
         + (row.total_output_tokens or 0)
         + (row.total_cache_read_tokens or 0)
         + (row.total_cache_write_tokens or 0)
     )
-    cost_per_m = (
-        (row.total_cost_usd / (tokens / 1_000_000))
-        if tokens > 0 else 0.0
-    )
-    cost_per_run = (
-        (row.total_cost_usd / row.runs)
-        if row.runs > 0 else 0.0
-    )
     cache_read = int(row.total_cache_read_tokens or 0)
-    input_tok = int(row.total_input_tokens or 0)
-    cache_input_total = cache_read + input_tok
-    cache_hit_pct = (
-        (cache_read / cache_input_total * 100)
-        if cache_input_total > 0 else 0.0
+    cache_input_total = cache_read + int(row.total_input_tokens or 0)
+    return _BackendEfficiencyMetrics(
+        tokens=tokens,
+        cost_per_million=_safe_ratio(row.total_cost_usd, tokens / 1_000_000),
+        cost_per_run=_safe_ratio(row.total_cost_usd, row.runs),
+        cache_hit_pct=_safe_ratio(cache_read, cache_input_total) * 100,
     )
-    return tokens, cost_per_m, cost_per_run, cache_hit_pct
 
 
 def _cost_coverage_weights(
@@ -842,6 +981,49 @@ def _cost_source_color(
     )
 
 
+@dataclass(frozen=True)
+class _CoverageSegment:
+    bar: str
+    legend: str
+
+
+def _coverage_segment(
+    row: CostCoverageRow,
+    weight: int,
+    total: int,
+    cost_sources: Sequence[str],
+    theme,
+) -> _CoverageSegment:
+    pct = weight / total * 100
+    color = _cost_source_color(row.cost_source, cost_sources, theme)
+    return _CoverageSegment(
+        bar=(
+            f'<span style="width:{pct:.1f}%;background:{color}" '
+            f'title="{html.escape(row.cost_source)}"></span>'
+        ),
+        legend=(
+            f'<span><span class="dot" style="background:{color}"></span>'
+            f'{html.escape(row.cost_source)} '
+            f'<b style="color:{theme.TEXT};'
+            f'font-family:{theme.MONO_FONT_FAMILY}">{pct:.1f}%</b>'
+            '</span>'
+        ),
+    )
+
+
+def _coverage_segments(
+    rows: Sequence[CostCoverageRow],
+    weights: Sequence[int],
+    total: int,
+    cost_sources: Sequence[str],
+    theme,
+) -> list[_CoverageSegment]:
+    return [
+        _coverage_segment(row, weight, total, cost_sources, theme)
+        for row, weight in zip(rows, weights)
+    ]
+
+
 def _cost_coverage_bar_html(
     rows: Sequence[CostCoverageRow], *, theme
 ) -> str:
@@ -857,29 +1039,14 @@ def _cost_coverage_bar_html(
     """
     weights, total = _cost_coverage_weights(rows)
     cost_sources = [row.cost_source for row in rows]
-    segs = []
-    legend = []
-    for r, w in zip(rows, weights):
-        pct = w / total * 100
-        color = _cost_source_color(r.cost_source, cost_sources, theme)
-        segs.append(
-            f'<span style="width:{pct:.1f}%;background:{color}" '
-            f'title="{html.escape(r.cost_source)}"></span>'
-        )
-        legend.append(
-            f'<span><span class="dot" '
-            f'style="background:{color}"></span>'
-            f'{html.escape(r.cost_source)} '
-            f'<b style="color:{theme.TEXT};'
-            f'font-family:{theme.MONO_FONT_FAMILY}">'
-            f'{pct:.1f}%</b>'
-            '</span>'
-        )
+    segments = _coverage_segments(rows, weights, total, cost_sources, theme)
     return (
         '<div class="orch-cov-title">'
         'Cost attribution coverage</div>'
-        f'<div class="orch-cov-bar">{"".join(segs)}</div>'
-        f'<div class="orch-cov-legend">{"".join(legend)}</div>'
+        f'<div class="orch-cov-bar">'
+        f'{"".join(segment.bar for segment in segments)}</div>'
+        f'<div class="orch-cov-legend">'
+        f'{"".join(segment.legend for segment in segments)}</div>'
     )
 
 

--- a/orchestrator/dashboard_kpis.py
+++ b/orchestrator/dashboard_kpis.py
@@ -177,12 +177,16 @@ def top_expensive_issues(
     """Issues sorted by total cost desc for the "where did spend go" table."""
     if limit <= 0:
         return []
+    return sorted(rows, key=_expensive_issue_key)[:limit]
 
-    def _key(r: IssueSummaryRow) -> tuple:
-        cost = r.total_cost_usd if r.total_cost_usd is not None else -1.0
-        return (-cost, -int(r.event_count), r.repo, int(r.issue))
 
-    return sorted(rows, key=_key)[:limit]
+def _expensive_issue_key(row: IssueSummaryRow) -> tuple:
+    cost = row.total_cost_usd
+    if cost is None:
+        cost = -1.0
+    event_count = -int(row.event_count)
+    issue_number = int(row.issue)
+    return (-cost, event_count, row.repo, issue_number)
 
 
 def rework_totals(

--- a/orchestrator/git_plumbing.py
+++ b/orchestrator/git_plumbing.py
@@ -54,8 +54,10 @@ import os
 import subprocess
 import tempfile
 import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 from orchestrator import config
 from orchestrator.config import RepoSpec
@@ -64,6 +66,83 @@ log = logging.getLogger(__name__)
 
 # Disable git's /dev/tty fallback prompts in any subprocess we spawn.
 _GIT_NO_PROMPT_ENV = {"GIT_TERMINAL_PROMPT": "0"}
+
+_AUTHED_GIT_PREFIX = (
+    "git",
+    "-c", "core.hooksPath=/dev/null",
+    "-c", "credential.helper=",
+    "-c", "core.fsmonitor=",
+)
+
+
+@dataclass(frozen=True)
+class _GitAuthSession:
+    """Token-bearing subprocess inputs scoped to one askpass directory."""
+
+    token: str
+    auth_url: str
+    env: dict[str, str]
+
+
+def _resolved_git_token(spec: RepoSpec, operation: str) -> Optional[str]:
+    """Resolve a per-repository token and log an operation-specific error."""
+    token = config._resolve_github_token(spec.slug)
+    if token:
+        return token
+    log.error(
+        "GITHUB_TOKEN missing for %s; cannot %s", spec.slug, operation,
+    )
+    return None
+
+
+def _git_auth_env(
+    askpass: Path, token: str, *, include_identity: bool,
+) -> dict[str, str]:
+    """Build the detached environment for one token-bearing git command."""
+    auth_env = {
+        **os.environ,
+        **_GIT_NO_PROMPT_ENV,
+        "GIT_ASKPASS": str(askpass),
+        "GIT_TOKEN": token,
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_SYSTEM": os.devnull,
+        "GIT_CONFIG_NOSYSTEM": "1",
+    }
+    if include_identity:
+        auth_env.update(
+            {
+                "GIT_AUTHOR_NAME": config.AGENT_GIT_NAME,
+                "GIT_AUTHOR_EMAIL": config.AGENT_GIT_EMAIL,
+                "GIT_COMMITTER_NAME": config.AGENT_GIT_NAME,
+                "GIT_COMMITTER_EMAIL": config.AGENT_GIT_EMAIL,
+            },
+        )
+    return auth_env
+
+
+@contextmanager
+def _git_auth_session(
+    spec: RepoSpec, token: str, *, include_identity: bool = False,
+) -> Iterator[_GitAuthSession]:
+    """Keep a hardened askpass script alive for one authenticated operation."""
+    with tempfile.TemporaryDirectory(prefix="orch-askpass-") as temp_dir:
+        askpass = Path(temp_dir) / "askpass.sh"
+        askpass.write_text('#!/bin/sh\nprintf %s "$GIT_TOKEN"\n')
+        askpass.chmod(0o700)
+        yield _GitAuthSession(
+            token=token,
+            auth_url=f"https://x-access-token@github.com/{spec.slug}.git",
+            env=_git_auth_env(
+                askpass, token, include_identity=include_identity,
+            ),
+        )
+
+
+def _failed_fetch(stderr: str) -> subprocess.CompletedProcess:
+    """Return the stable failure shape shared by authenticated fetches."""
+    return subprocess.CompletedProcess(
+        args=["git", "fetch"], returncode=1, stdout="", stderr=stderr,
+    )
 
 
 # Per-target_root locks that serialize git plumbing against the parent
@@ -277,54 +356,31 @@ def _authed_fetch(
     # Mirrors `_push_branch`'s per-spec token resolution; without this,
     # `_handle_resolving_conflict` would fail conflict resolution for any
     # repo other than the legacy `REPO` (or use the wrong token).
-    token = config._resolve_github_token(spec.slug)
+    token = _resolved_git_token(spec, "fetch")
     if not token:
-        log.error("GITHUB_TOKEN missing for %s; cannot fetch", spec.slug)
-        return subprocess.CompletedProcess(
-            args=["git", "fetch"], returncode=1, stdout="",
-            stderr="GITHUB_TOKEN missing",
-        )
+        return _failed_fetch("GITHUB_TOKEN missing")
     unsafe = _unsafe_local_transport_config(cwd)
     if unsafe:
         log.error(
             "refusing to fetch into %s: worktree .git/config has "
             "transport-hijacking config: %s", cwd, unsafe,
         )
-        return subprocess.CompletedProcess(
-            args=["git", "fetch"], returncode=1, stdout="",
-            stderr="unsafe transport config in worktree .git/config",
+        return _failed_fetch(
+            "unsafe transport config in worktree .git/config",
         )
-    auth_url = f"https://x-access-token@github.com/{spec.slug}.git"
-    with tempfile.TemporaryDirectory(prefix="orch-askpass-") as td:
-        askpass = Path(td) / "askpass.sh"
-        askpass.write_text('#!/bin/sh\nprintf %s "$GIT_TOKEN"\n')
-        askpass.chmod(0o700)
-        env = {
-            **os.environ,
-            **_GIT_NO_PROMPT_ENV,
-            "GIT_ASKPASS": str(askpass),
-            "GIT_TOKEN": token,
-            "GIT_AUTHOR_NAME": config.AGENT_GIT_NAME,
-            "GIT_AUTHOR_EMAIL": config.AGENT_GIT_EMAIL,
-            "GIT_COMMITTER_NAME": config.AGENT_GIT_NAME,
-            "GIT_COMMITTER_EMAIL": config.AGENT_GIT_EMAIL,
-            "GIT_CONFIG_GLOBAL": os.devnull,
-            "GIT_CONFIG_SYSTEM": os.devnull,
-            "GIT_CONFIG_NOSYSTEM": "1",
-        }
-        git_prefix = [
-            "git",
-            "-c", "core.hooksPath=/dev/null",
-            "-c", "credential.helper=",
-            "-c", "core.fsmonitor=",
-        ]
+    with _git_auth_session(
+        spec, token, include_identity=True,
+    ) as auth_session:
         with _target_root_lock(spec.target_root):
             return subprocess.run(
-                [*git_prefix, "fetch", "--quiet", auth_url, refspec],
+                [
+                    *_AUTHED_GIT_PREFIX,
+                    "fetch", "--quiet", auth_session.auth_url, refspec,
+                ],
                 cwd=str(cwd),
                 capture_output=True,
                 text=True,
-                env=env,
+                env=auth_session.env,
             )
 
 
@@ -378,54 +434,98 @@ def _authed_target_fetch(
     holding it -- the worktree creators -- re-enters cleanly) for the
     same `.git/config.lock` reason described on `_ensure_worktree`.
     """
-    token = config._resolve_github_token(spec.slug)
+    token = _resolved_git_token(spec, "fetch")
     if not token:
-        log.error("GITHUB_TOKEN missing for %s; cannot fetch", spec.slug)
-        return subprocess.CompletedProcess(
-            args=["git", "fetch"], returncode=1, stdout="",
-            stderr="GITHUB_TOKEN missing",
-        )
+        return _failed_fetch("GITHUB_TOKEN missing")
     unsafe = _unsafe_local_transport_config(spec.target_root)
     if unsafe:
         log.error(
             "refusing to fetch into %s: target_root .git/config has "
             "transport-hijacking config: %s", spec.target_root, unsafe,
         )
-        return subprocess.CompletedProcess(
-            args=["git", "fetch"], returncode=1, stdout="",
-            stderr="unsafe transport config in target_root .git/config",
+        return _failed_fetch(
+            "unsafe transport config in target_root .git/config",
         )
-    auth_url = f"https://x-access-token@github.com/{spec.slug}.git"
     refspec = (
         f"+refs/heads/{branch}:refs/remotes/{spec.remote_name}/{branch}"
     )
-    with tempfile.TemporaryDirectory(prefix="orch-askpass-") as td:
-        askpass = Path(td) / "askpass.sh"
-        askpass.write_text('#!/bin/sh\nprintf %s "$GIT_TOKEN"\n')
-        askpass.chmod(0o700)
-        env = {
-            **os.environ,
-            **_GIT_NO_PROMPT_ENV,
-            "GIT_ASKPASS": str(askpass),
-            "GIT_TOKEN": token,
-            "GIT_CONFIG_GLOBAL": os.devnull,
-            "GIT_CONFIG_SYSTEM": os.devnull,
-            "GIT_CONFIG_NOSYSTEM": "1",
-        }
-        git_prefix = [
-            "git",
-            "-c", "core.hooksPath=/dev/null",
-            "-c", "credential.helper=",
-            "-c", "core.fsmonitor=",
-        ]
+    with _git_auth_session(spec, token) as auth_session:
         with _target_root_lock(spec.target_root):
             return subprocess.run(
-                [*git_prefix, "fetch", "--quiet", auth_url, refspec],
+                [
+                    *_AUTHED_GIT_PREFIX,
+                    "fetch", "--quiet", auth_session.auth_url, refspec,
+                ],
                 cwd=str(spec.target_root),
                 capture_output=True,
                 text=True,
-                env=env,
+                env=auth_session.env,
             )
+
+
+def _remote_branch_sha(
+    auth_session: _GitAuthSession,
+    worktree: Path,
+    branch: str,
+    ref: str,
+    force_with_lease: Optional[str],
+) -> Optional[str]:
+    """Return the expected remote SHA, or None when it cannot be read."""
+    if force_with_lease is not None:
+        return force_with_lease
+    ls_remote = subprocess.run(
+        [*_AUTHED_GIT_PREFIX, "ls-remote", auth_session.auth_url, ref],
+        cwd=str(worktree),
+        capture_output=True,
+        text=True,
+        env=auth_session.env,
+    )
+    if ls_remote.returncode != 0:
+        scrubbed = (ls_remote.stderr or "").replace(
+            auth_session.token, "***",
+        )
+        log.error("git ls-remote failed for %s: %s", branch, scrubbed)
+        return None
+    for output_line in (ls_remote.stdout or "").splitlines():
+        parts = output_line.strip().split()
+        if len(parts) >= 2 and parts[1] == ref:
+            return parts[0]
+    return ""
+
+
+def _push_with_auth(
+    auth_session: _GitAuthSession,
+    worktree: Path,
+    branch: str,
+    force_with_lease: Optional[str],
+) -> bool:
+    """Push one branch through an established askpass session."""
+    ref = f"refs/heads/{branch}"
+    remote_sha = _remote_branch_sha(
+        auth_session, worktree, branch, ref, force_with_lease,
+    )
+    if remote_sha is None:
+        return False
+    push_result = subprocess.run(
+        [
+            *_AUTHED_GIT_PREFIX,
+            "push",
+            f"--force-with-lease={ref}:{remote_sha}",
+            auth_session.auth_url,
+            f"HEAD:{ref}",
+        ],
+        cwd=str(worktree),
+        capture_output=True,
+        text=True,
+        env=auth_session.env,
+    )
+    if push_result.returncode == 0:
+        return True
+    scrubbed = (push_result.stderr or "").replace(
+        auth_session.token, "***",
+    )
+    log.error("git push failed for %s: %s", branch, scrubbed)
+    return False
 
 
 def _push_branch(
@@ -496,9 +596,8 @@ def _push_branch(
     # `~/.config/<owner>/<repo>/token` pushes with the right repo's token.
     # Single-repo deployments see identical behavior because
     # `_resolve_github_token(REPO)` returns the same value.
-    token = config._resolve_github_token(spec.slug)
+    token = _resolved_git_token(spec, "push")
     if not token:
-        log.error("GITHUB_TOKEN missing for %s; cannot push", spec.slug)
         return False
     unsafe = _unsafe_local_transport_config(worktree)
     if unsafe:
@@ -507,67 +606,9 @@ def _push_branch(
             "transport-hijacking config: %s", branch, unsafe,
         )
         return False
-    auth_url = f"https://x-access-token@github.com/{spec.slug}.git"
-    with tempfile.TemporaryDirectory(prefix="orch-askpass-") as td:
-        askpass = Path(td) / "askpass.sh"
-        askpass.write_text('#!/bin/sh\nprintf %s "$GIT_TOKEN"\n')
-        askpass.chmod(0o700)
-        env = {
-            **os.environ,
-            **_GIT_NO_PROMPT_ENV,
-            "GIT_ASKPASS": str(askpass),
-            "GIT_TOKEN": token,
-            # Detach from any agent-writable global/system git config; the
-            # only config that applies is the local worktree config (already
-            # checked above) plus our explicit -c overrides below.
-            "GIT_CONFIG_GLOBAL": os.devnull,
-            "GIT_CONFIG_SYSTEM": os.devnull,
-            "GIT_CONFIG_NOSYSTEM": "1",
-        }
-        git_prefix = [
-            "git",
-            "-c", "core.hooksPath=/dev/null",
-            "-c", "credential.helper=",
-            "-c", "core.fsmonitor=",
-        ]
-        ref = f"refs/heads/{branch}"
-        if force_with_lease is not None:
-            remote_sha = force_with_lease
-        else:
-            ls = subprocess.run(
-                [*git_prefix, "ls-remote", auth_url, ref],
-                cwd=str(worktree),
-                capture_output=True,
-                text=True,
-                env=env,
-            )
-            if ls.returncode != 0:
-                scrubbed = (ls.stderr or "").replace(token, "***")
-                log.error("git ls-remote failed for %s: %s", branch, scrubbed)
-                return False
-            remote_sha = ""
-            for line in (ls.stdout or "").splitlines():
-                parts = line.strip().split()
-                if len(parts) >= 2 and parts[1] == ref:
-                    remote_sha = parts[0]
-                    break
-        # An empty <expected> in --force-with-lease means "expect the ref to
-        # not exist", which is the right lease for the create-branch case.
-        r = subprocess.run(
-            [
-                *git_prefix,
-                "push",
-                f"--force-with-lease={ref}:{remote_sha}",
-                auth_url, f"HEAD:{ref}",
-            ],
-            cwd=str(worktree),
-            capture_output=True,
-            text=True,
-            env=env,
+    with _git_auth_session(spec, token) as auth_session:
+        # An empty expected SHA means the remote ref must not exist, which
+        # preserves the create-branch lease behavior.
+        return _push_with_auth(
+            auth_session, worktree, branch, force_with_lease,
         )
-    if r.returncode != 0:
-        # Scrub the token out of any error output before logging.
-        scrubbed = (r.stderr or "").replace(token, "***")
-        log.error("git push failed for %s: %s", branch, scrubbed)
-        return False
-    return True

--- a/orchestrator/github.py
+++ b/orchestrator/github.py
@@ -162,6 +162,25 @@ def _iter_new_non_pr_issues(
             yield issue
 
 
+def _issue_query_options(
+    *,
+    issue_state: str,
+    since: Optional[datetime],
+    label: Optional[Label] = None,
+) -> dict[str, Any]:
+    """Build the common open/closed issue query options."""
+    options: dict[str, Any] = {
+        "state": issue_state,
+        "sort": "updated",
+        "direction": "desc",
+    }
+    if label is not None:
+        options["labels"] = [label]
+    if since is not None:
+        options["since"] = since
+    return options
+
+
 def _write_event_record(event_record: dict) -> None:
     """Append one JSONL line to `config.EVENT_LOG_PATH` if configured.
 
@@ -220,6 +239,32 @@ class PinnedState:
         self.data[key] = state_value
 
 
+def _pinned_state_from_comment(
+    issue_comment: IssueComment,
+    *,
+    trusted_login: Optional[str],
+    issue_number: int,
+) -> Optional[PinnedState]:
+    """Parse one authenticated, state-only pinned comment candidate."""
+    body = issue_comment.body or ""
+    if PINNED_STATE_MARKER not in body:
+        return None
+    author_login = getattr(
+        getattr(issue_comment, "user", None), "login", None,
+    )
+    if trusted_login is not None and author_login != trusted_login:
+        return None
+    state_match = PINNED_STATE_BODY_RE.match(body)
+    if state_match is None:
+        return None
+    try:
+        data = json.loads(state_match.group(1))
+    except json.JSONDecodeError:
+        log.warning("issue=#%s pinned state JSON unparseable", issue_number)
+        data = {}
+    return PinnedState(comment_id=issue_comment.id, data=data)
+
+
 @dataclass(frozen=True)
 class _CheckSurfaceRead:
     """Normalized state and read outcome for one GitHub checks surface."""
@@ -274,6 +319,45 @@ def _fold_check_states(
     if "pending" in observed_states:
         return "pending"
     return "success"
+
+
+def _review_state_for_head(
+    review: Any, head_sha: str,
+) -> Optional[tuple[str, tuple[int, str]]]:
+    """Return a reviewer-keyed state record when a review applies to HEAD."""
+    if (getattr(review, "commit_id", "") or "") != head_sha:
+        return None
+    review_state = (review.state or "").upper()
+    if review_state not in ("APPROVED", "CHANGES_REQUESTED", "DISMISSED"):
+        return None
+    reviewer_login = review.user.login if review.user else ""
+    if not reviewer_login:
+        return None
+    review_id = getattr(review, "id", 0) or 0
+    return reviewer_login, (review_id, review_state)
+
+
+def _record_latest_review(
+    latest_per_user: dict[str, tuple[int, str]],
+    candidate: tuple[str, tuple[int, str]],
+) -> None:
+    """Retain the highest-id review record for one reviewer."""
+    reviewer_login, review_record = candidate
+    previous = latest_per_user.get(reviewer_login)
+    if previous is None or review_record[0] > previous[0]:
+        latest_per_user[reviewer_login] = review_record
+
+
+def _is_actionable_review_summary(
+    review: Any, after_id: Optional[int],
+) -> bool:
+    """Whether a review summary carries unread feedback for the developer."""
+    review_state = (review.state or "").upper()
+    if review_state not in ("CHANGES_REQUESTED", "COMMENTED"):
+        return False
+    if not (review.body or "").strip():
+        return False
+    return after_id is None or review.id > after_id
 
 
 class GitHubClient:
@@ -446,15 +530,12 @@ class GitHubClient:
         """
         seen: set[int] = set()
         self._pollable_calls += 1
-
-        kwargs: dict[str, Any] = {
-            "state": "open",
-            "sort": "updated",
-            "direction": "desc",
-        }
-        if since is not None:
-            kwargs["since"] = since
-        yield from _iter_new_non_pr_issues(self.repo.get_issues(**kwargs), seen)
+        yield from _iter_new_non_pr_issues(
+            self.repo.get_issues(
+                **_issue_query_options(issue_state="open", since=since)
+            ),
+            seen,
+        )
 
         # The closed-issue recovery sweep below issues one GET per non-terminal
         # label, per repo. That fixed cost -- paid every tick regardless of how
@@ -487,16 +568,15 @@ class GitHubClient:
             label_obj = self._cached_label(label_name)
             if label_obj is None:
                 continue
-            closed_kwargs: dict[str, Any] = {
-                "state": "closed",
-                "labels": [label_obj],
-                "sort": "updated",
-                "direction": "desc",
-            }
-            if since is not None:
-                closed_kwargs["since"] = since
             yield from _iter_new_non_pr_issues(
-                self.repo.get_issues(**closed_kwargs), seen
+                self.repo.get_issues(
+                    **_issue_query_options(
+                        issue_state="closed",
+                        since=since,
+                        label=label_obj,
+                    )
+                ),
+                seen,
             )
 
     @staticmethod
@@ -637,25 +717,13 @@ class GitHubClient:
         # still holds.
         trusted_login = getattr(self, "_bot_login", None)
         for issue_comment in issue.get_comments():
-            body = issue_comment.body or ""
-            if PINNED_STATE_MARKER not in body:
-                continue
-            if trusted_login is not None:
-                author = getattr(
-                    getattr(issue_comment, "user", None), "login", None,
-                )
-                if author != trusted_login:
-                    continue
-            state_match = PINNED_STATE_BODY_RE.match(body)
-            if state_match:
-                try:
-                    return PinnedState(
-                        comment_id=issue_comment.id,
-                        data=json.loads(state_match.group(1)),
-                    )
-                except json.JSONDecodeError:
-                    log.warning("issue=#%s pinned state JSON unparseable", issue.number)
-                    return PinnedState(comment_id=issue_comment.id, data={})
+            pinned_state = _pinned_state_from_comment(
+                issue_comment,
+                trusted_login=trusted_login,
+                issue_number=issue.number,
+            )
+            if pinned_state is not None:
+                return pinned_state
         return PinnedState()
 
     def write_pinned_state(self, issue: Issue, state: PinnedState) -> PinnedState:
@@ -842,18 +910,9 @@ class GitHubClient:
             return []
         latest_per_user: dict[str, tuple[int, str]] = {}
         for review in pr.get_reviews():
-            if (getattr(review, "commit_id", "") or "") != head_sha:
-                continue
-            state = (review.state or "").upper()
-            if state not in ("APPROVED", "CHANGES_REQUESTED", "DISMISSED"):
-                continue
-            login = review.user.login if review.user else ""
-            if not login:
-                continue
-            sub_id = getattr(review, "id", 0) or 0
-            prev = latest_per_user.get(login)
-            if prev is None or sub_id > prev[0]:
-                latest_per_user[login] = (sub_id, state)
+            candidate = _review_state_for_head(review, head_sha)
+            if candidate is not None:
+                _record_latest_review(latest_per_user, candidate)
         return [
             review_state
             for _, review_state in latest_per_user.values()
@@ -980,16 +1039,11 @@ class GitHubClient:
         inline comments only blocks the ready-ping via
         `pr_has_changes_requested` without ever reaching the dev agent.
         """
-        out: list = []
-        for candidate_review in pr.get_reviews():
-            state = (candidate_review.state or "").upper()
-            if state not in ("CHANGES_REQUESTED", "COMMENTED"):
-                continue
-            body = (candidate_review.body or "").strip()
-            if not body:
-                continue
-            if after_id is None or candidate_review.id > after_id:
-                out.append(candidate_review)
+        out = [
+            candidate_review
+            for candidate_review in pr.get_reviews()
+            if _is_actionable_review_summary(candidate_review, after_id)
+        ]
         out.sort(key=lambda review_summary: review_summary.id)
         return out
 

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -19,6 +19,7 @@ import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from typing import Optional
 
 from orchestrator import agents, analytics, config, workflow
@@ -218,46 +219,45 @@ def _self_modifying_merge_happened(start_sha: str) -> bool:
     return any(line.startswith("orchestrator/") for line in diff.splitlines())
 
 
-def main(argv: Optional[list[str]] = None) -> int:
-    p = argparse.ArgumentParser(description="Agent orchestrator polling loop.")
-    p.add_argument("--once", action="store_true", help="Run a single tick and exit.")
-    p.add_argument("--log-level", default="INFO")
-    args = p.parse_args(argv)
+@dataclass(frozen=True)
+class _MainOptions:
+    once: bool
+    log_level: str
 
-    _configure_logging(args.log_level)
-    signal.signal(signal.SIGTERM, _shutdown)
-    signal.signal(signal.SIGINT, _shutdown)
 
-    # `default_repo_specs()` returns one element for legacy single-repo
-    # deployments and N elements when `REPOS` is configured. Connecting and
-    # ensuring labels happens once per spec at startup; the polling loop
-    # then fans `workflow.tick(gh, spec)` out across the precomputed
-    # client list every tick.
-    specs = config.default_repo_specs()
+def _parse_main_options(argv: Optional[list[str]]) -> _MainOptions:
+    parser = argparse.ArgumentParser(
+        description="Agent orchestrator polling loop."
+    )
+    parser.add_argument(
+        "--once", action="store_true", help="Run a single tick and exit."
+    )
+    parser.add_argument("--log-level", default="INFO")
+    parsed = parser.parse_args(argv)
+    return _MainOptions(once=parsed.once, log_level=parsed.log_level)
+
+
+def _connect_clients() -> list[tuple[config.RepoSpec, GitHubClient]]:
+    """Connect once per configured repository and ensure workflow labels."""
     clients: list[tuple[config.RepoSpec, GitHubClient]] = []
-    for spec in specs:
+    for spec in config.default_repo_specs():
         gh = GitHubClient(repo_spec=spec)
         log.info("connected: repo=%s", spec.slug)
         gh.ensure_workflow_labels()
         clients.append((spec, gh))
+    return clients
 
-    # One `IssueScheduler` is built once at startup and reused across every
-    # tick: it owns the cross-repo in-flight cap
-    # (`MAX_PARALLEL_ISSUES_GLOBAL`), the default per-repo cap
-    # (`MAX_PARALLEL_ISSUES_PER_REPO`, overridable per spec via
-    # `parallel_limit`), the duplicate-active-issue skip, and the
-    # family-aware mutex. The polling tick submits per-issue work to
-    # this scheduler and returns immediately; worker threads run on the
-    # scheduler's internal executor. Replaces the older
-    # `BoundedSemaphore` cross-repo gate -- the scheduler's `global_cap`
-    # is the authoritative bound. Shut down in the `finally` below so
-    # in-flight workers complete cleanly (and any late failures are
-    # logged) regardless of how the loop exits.
-    scheduler = IssueScheduler(
+
+def _create_scheduler() -> IssueScheduler:
+    """Build the process-wide scheduler shared by every polling tick."""
+    return IssueScheduler(
         global_cap=config.MAX_PARALLEL_ISSUES_GLOBAL,
         per_repo_cap=config.MAX_PARALLEL_ISSUES_PER_REPO,
         thread_name_prefix="orch-issue",
     )
+
+
+def _activate_scheduler(scheduler: IssueScheduler) -> None:
     # Publish the scheduler to `_shutdown` BEFORE the first tick runs so
     # a signal that arrives during tick 1 can close the submit path
     # immediately instead of waiting for `_run_tick` to return. The
@@ -269,51 +269,76 @@ def main(argv: Optional[list[str]] = None) -> int:
     global active_scheduler
     active_scheduler = scheduler
 
-    try:
-        if args.once:
-            _run_tick(clients, scheduler)
-        else:
-            own_sha = _own_head_sha()
-            log.info("own HEAD=%s", own_sha)
 
-            while _running:
-                if own_sha and _self_modifying_merge_happened(own_sha):
-                    log.info("self-modifying merge detected; exiting for restart")
-                    return 0
-                _run_tick(clients, scheduler)
-                for _ in range(config.POLL_INTERVAL):
-                    if not _running:
-                        break
-                    time.sleep(1)
-    finally:
-        # `wait=True` so any in-flight worker (e.g. a `--once` invocation
-        # that just submitted long-running handlers) finishes before the
-        # process returns. Without this, `--once` could exit while
-        # workers were still executing and the executor's daemon threads
-        # would be torn down mid-handler; the polling loop case is the
-        # same property under SIGTERM/SIGINT shutdown. Safe to call even
-        # when `_shutdown` already ran a `wait=False` shutdown -- the
-        # scheduler's `shutdown` is documented as repeatable, the second
-        # call still waits for in-flight workers to exit, and the
-        # trailing reap drains any completion that landed in between.
-        if _received_signal is not None:
-            # Signal-initiated stop runs under systemd's `TimeoutStopSec`.
-            # Kill in-flight agent subprocesses up front so their worker
-            # threads unwind now instead of holding the drain below for up
-            # to `AGENT_TIMEOUT` -- this is what makes the common
-            # "restart while an agent is running" case exit in seconds
-            # rather than timing out into a SIGKILL. Idempotent with the
-            # watchdog's own sweep.
-            agents.terminate_all_running()
-        scheduler.shutdown(wait=True)
-        active_scheduler = None
-        # Release the watchdog: the drain is done, so a clean exit must not
-        # be pre-empted by a force-exit.
-        _shutdown_complete.set()
+def _wait_for_next_tick() -> None:
+    for _elapsed_second in range(config.POLL_INTERVAL):
+        if not _running:
+            return
+        time.sleep(1)
 
+
+def _run_polling_loop(
+    clients: list[tuple[config.RepoSpec, GitHubClient]],
+    scheduler: IssueScheduler,
+) -> Optional[int]:
+    own_sha = _own_head_sha()
+    log.info("own HEAD=%s", own_sha)
+    while _running:
+        if own_sha and _self_modifying_merge_happened(own_sha):
+            log.info("self-modifying merge detected; exiting for restart")
+            return 0
+        _run_tick(clients, scheduler)
+        _wait_for_next_tick()
+    return None
+
+
+def _drive_main_loop(
+    options: _MainOptions,
+    clients: list[tuple[config.RepoSpec, GitHubClient]],
+    scheduler: IssueScheduler,
+) -> Optional[int]:
+    if options.once:
+        _run_tick(clients, scheduler)
+        return None
+    return _run_polling_loop(clients, scheduler)
+
+
+def _drain_scheduler(scheduler: IssueScheduler) -> None:
+    """Stop agent groups when signaled, then wait for every worker."""
+    global active_scheduler
+    if _received_signal is not None:
+        # Worker threads cannot drain while their agent subprocess is still
+        # allowed to run up to `AGENT_TIMEOUT`.
+        agents.terminate_all_running()
+    # Repeatable after `_shutdown`'s `wait=False` close; this call owns the
+    # final worker wait and completion reap.
+    scheduler.shutdown(wait=True)
+    active_scheduler = None
+    _shutdown_complete.set()
+
+
+def _signal_exit_code() -> int:
     if _received_signal is not None:
         return 128 + _received_signal
     return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    options = _parse_main_options(argv)
+    _configure_logging(options.log_level)
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+    clients = _connect_clients()
+    scheduler = _create_scheduler()
+    _activate_scheduler(scheduler)
+    restart_exit_code: Optional[int] = None
+    try:
+        restart_exit_code = _drive_main_loop(options, clients, scheduler)
+    finally:
+        _drain_scheduler(scheduler)
+    if restart_exit_code is not None:
+        return restart_exit_code
+    return _signal_exit_code()
 
 
 def _tick_one_repo(

--- a/orchestrator/scheduler.py
+++ b/orchestrator/scheduler.py
@@ -54,6 +54,7 @@ import logging
 import threading
 from collections import defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
 from typing import Callable, Iterator, Optional
 
 log = logging.getLogger(__name__)
@@ -73,6 +74,22 @@ deployment without spinning up unbounded threads. A rare burst past the
 bound (e.g. many PRs merged at once) simply queues on this executor and
 drains quickly -- still never blocked by cap-counted agent work.
 """
+
+
+@dataclass(frozen=True)
+class _Submission:
+    """Normalized inputs that travel together through slot reservation."""
+
+    repo_slug: str
+    issue_number: int
+    fn: Callable[[], None]
+    family: bool
+    cap_exempt: bool
+    per_repo_cap: int
+
+    @property
+    def key(self) -> tuple[str, int]:
+        return self.repo_slug, self.issue_number
 
 
 class IssueScheduler:
@@ -216,8 +233,18 @@ class IssueScheduler:
         different caps; the default ``per_repo_cap`` set at construction
         is the fallback for repos that did not override.
         """
-        key = (repo_slug, int(issue_number))
-        cap = self._per_repo_cap if per_repo_cap is None else max(1, int(per_repo_cap))
+        submission = _Submission(
+            repo_slug=repo_slug,
+            issue_number=int(issue_number),
+            fn=fn,
+            family=family,
+            cap_exempt=cap_exempt,
+            per_repo_cap=(
+                self._per_repo_cap
+                if per_repo_cap is None
+                else max(1, int(per_repo_cap))
+            ),
+        )
         # The whole reserve → executor.submit → add_done_callback
         # sequence runs under `self._lock`. Without this, a worker
         # can complete between `executor.submit` returning and
@@ -231,85 +258,12 @@ class IssueScheduler:
         # firing of `add_done_callback` for an already-done future
         # (very-fast worker) can reacquire it in `_on_worker_done`.
         with self._lock:
-            if self._closed:
-                log.info(
-                    "scheduler skip repo=%s issue=#%s reason=closed",
-                    repo_slug, issue_number,
-                )
+            skip_reason = self._skip_reason_locked(submission)
+            if skip_reason is not None:
+                self._log_skip_locked(submission, skip_reason)
                 return False
-            if key in self._active or key in self._tracked:
-                # Common and expected when a long-running worker straddles
-                # ticks. DEBUG keeps a normal busy repo from spamming the
-                # operator log; the rarer skip reasons below stay at INFO.
-                # `_tracked` is checked alongside `_active` so a fanout
-                # submit cannot slip in for an issue the family bucket
-                # is currently processing inside `track_active`.
-                log.debug(
-                    "scheduler skip repo=%s issue=#%s reason=duplicate_active",
-                    repo_slug, issue_number,
-                )
-                return False
-            if not cap_exempt and len(self._active) >= self._global_cap:
-                log.info(
-                    "scheduler skip repo=%s issue=#%s reason=global_cap "
-                    "(active=%d cap=%d)",
-                    repo_slug, issue_number,
-                    len(self._active), self._global_cap,
-                )
-                return False
-            if (
-                not cap_exempt
-                and self._per_repo_active.get(repo_slug, 0) >= cap
-            ):
-                log.info(
-                    "scheduler skip repo=%s issue=#%s reason=per_repo_cap "
-                    "(active=%d cap=%d)",
-                    repo_slug, issue_number,
-                    self._per_repo_active.get(repo_slug, 0), cap,
-                )
-                return False
-            if family and repo_slug in self._family_active_repos:
-                # The family-slot skip is the regression the issue #326 fix
-                # targets: a stale child sitting at backlog/blocked used to
-                # take this slot and starve the parent umbrella. The
-                # dispatch layer now folds family work into one bucket
-                # task, but the skip is still possible across ticks while
-                # the previous tick's bucket is still draining -- worth
-                # surfacing in the log so operators can correlate
-                # "umbrella not advancing" with "family bucket still busy".
-                log.info(
-                    "scheduler skip repo=%s issue=#%s reason=family_slot_held",
-                    repo_slug, issue_number,
-                )
-                return False
-            if cap_exempt:
-                self._tracked.add(key)
-            else:
-                self._active.add(key)
-                self._per_repo_active[repo_slug] += 1
-            if family:
-                self._family_active_repos.add(repo_slug)
-            executor = (
-                self._exempt_executor if cap_exempt else self._executor
-            )
-            try:
-                future = executor.submit(fn)
-            except RuntimeError:
-                # Executor was shut down between the closed-check
-                # above and the submit call (the executor and the
-                # `_closed` flag are not the same gate). Roll back the
-                # reservation so the next tick can retry without a
-                # phantom in-flight marker.
-                self._release_slot_locked(
-                    key, repo_slug, family=family, cap_exempt=cap_exempt,
-                )
-                return False
-            future.add_done_callback(
-                lambda fut, _key=key, _slug=repo_slug, _family=family,
-                _exempt=cap_exempt:
-                self._on_worker_done(fut, _key, _slug, _family, _exempt)
-            )
-        return True
+            self._reserve_slot_locked(submission)
+            return self._start_worker_locked(submission)
 
     def reap(self) -> int:
         """Drain completed futures, log any worker exception. Nonblocking.
@@ -360,40 +314,125 @@ class IssueScheduler:
 
     # -- internals ---------------------------------------------------
 
-    def _release_slot_locked(
-        self,
-        key: tuple[str, int],
-        repo_slug: str,
-        *,
-        family: bool,
-        cap_exempt: bool = False,
-    ) -> None:
-        """Drop the in-flight markers for ``key``. Caller holds ``self._lock``.
+    def _cap_skip_reason_locked(
+        self, submission: _Submission,
+    ) -> Optional[str]:
+        """Return the first active cap reached by a counted submission."""
+        if len(self._active) >= self._global_cap:
+            return "global_cap"
+        repo_active = self._per_repo_active.get(submission.repo_slug, 0)
+        if repo_active >= submission.per_repo_cap:
+            return "per_repo_cap"
+        return None
 
-        ``cap_exempt`` mirrors the value passed at submit time: an
+    def _skip_reason_locked(
+        self, submission: _Submission,
+    ) -> Optional[str]:
+        """Return the first reservation gate that rejects a submission."""
+        if self._closed:
+            return "closed"
+        if submission.key in self._active or submission.key in self._tracked:
+            return "duplicate_active"
+        if not submission.cap_exempt:
+            cap_reason = self._cap_skip_reason_locked(submission)
+            if cap_reason is not None:
+                return cap_reason
+        if (
+            submission.family
+            and submission.repo_slug in self._family_active_repos
+        ):
+            return "family_slot_held"
+        return None
+
+    def _log_skip_locked(
+        self, submission: _Submission, reason: str,
+    ) -> None:
+        """Log a rejected submission with cap context where applicable."""
+        if reason == "duplicate_active":
+            # Duplicate work is expected when a worker straddles ticks; other
+            # skip reasons remain operator-visible at INFO.
+            log.debug(
+                "scheduler skip repo=%s issue=#%s reason=duplicate_active",
+                submission.repo_slug, submission.issue_number,
+            )
+            return
+        if reason == "global_cap":
+            log.info(
+                "scheduler skip repo=%s issue=#%s reason=global_cap "
+                "(active=%d cap=%d)",
+                submission.repo_slug, submission.issue_number,
+                len(self._active), self._global_cap,
+            )
+            return
+        if reason == "per_repo_cap":
+            log.info(
+                "scheduler skip repo=%s issue=#%s reason=per_repo_cap "
+                "(active=%d cap=%d)",
+                submission.repo_slug, submission.issue_number,
+                self._per_repo_active.get(submission.repo_slug, 0),
+                submission.per_repo_cap,
+            )
+            return
+        log.info(
+            "scheduler skip repo=%s issue=#%s reason=%s",
+            submission.repo_slug, submission.issue_number, reason,
+        )
+
+    def _reserve_slot_locked(self, submission: _Submission) -> None:
+        """Claim the issue, cap counters, and optional family mutex."""
+        if submission.cap_exempt:
+            self._tracked.add(submission.key)
+        else:
+            self._active.add(submission.key)
+            self._per_repo_active[submission.repo_slug] += 1
+        if submission.family:
+            self._family_active_repos.add(submission.repo_slug)
+
+    def _start_worker_locked(self, submission: _Submission) -> bool:
+        """Submit reserved work and install its atomic release callback."""
+        executor = (
+            self._exempt_executor
+            if submission.cap_exempt
+            else self._executor
+        )
+        try:
+            future = executor.submit(submission.fn)
+        except RuntimeError:
+            # Executor shutdown and the `_closed` flag are distinct gates; a
+            # failed submit must release its reservation for a later retry.
+            self._release_slot_locked(submission)
+            return False
+        future.add_done_callback(
+            lambda completed_future: self._on_worker_done(
+                completed_future, submission,
+            )
+        )
+        return True
+
+    def _release_slot_locked(
+        self, submission: _Submission,
+    ) -> None:
+        """Drop a submission's markers. Caller holds ``self._lock``.
+
+        ``submission.cap_exempt`` mirrors the value passed at submit time: an
         exempt submit lives in ``_tracked`` instead of ``_active`` /
         ``_per_repo_active``, so the release path symmetric to it
         clears that single set and leaves the cap counters alone.
         """
-        if cap_exempt:
-            self._tracked.discard(key)
+        if submission.cap_exempt:
+            self._tracked.discard(submission.key)
         else:
-            self._active.discard(key)
-            count = self._per_repo_active.get(repo_slug, 0)
+            self._active.discard(submission.key)
+            count = self._per_repo_active.get(submission.repo_slug, 0)
             if count <= 1:
-                self._per_repo_active.pop(repo_slug, None)
+                self._per_repo_active.pop(submission.repo_slug, None)
             else:
-                self._per_repo_active[repo_slug] = count - 1
-        if family:
-            self._family_active_repos.discard(repo_slug)
+                self._per_repo_active[submission.repo_slug] = count - 1
+        if submission.family:
+            self._family_active_repos.discard(submission.repo_slug)
 
     def _on_worker_done(
-        self,
-        future: Future,
-        key: tuple[str, int],
-        repo_slug: str,
-        family: bool,
-        cap_exempt: bool = False,
+        self, future: Future, submission: _Submission,
     ) -> None:
         # Marker release and completion-queue append happen in ONE
         # critical section so the transition is atomic from `reap`'s
@@ -405,9 +444,7 @@ class IssueScheduler:
         # one lock for both steps guarantees that any reap which sees
         # the cleared marker also sees the completed future.
         with self._lock:
-            self._release_slot_locked(
-                key, repo_slug, family=family, cap_exempt=cap_exempt,
-            )
+            self._release_slot_locked(submission)
             self._completed.append(future)
 
     @contextlib.contextmanager

--- a/orchestrator/skill_catalog.py
+++ b/orchestrator/skill_catalog.py
@@ -63,6 +63,16 @@ _SKILL_ROOTS = (".agents/skills", ".claude/skills")
 _SKILL_FILE = "SKILL.md"
 
 
+def _direct_skill_name(parts: list[str]) -> Optional[str]:
+    """Return the name from an exact ``<name>/SKILL.md`` suffix."""
+    if len(parts) != 2:
+        return None
+    skill_name, file_name = parts
+    if not skill_name or file_name != _SKILL_FILE:
+        return None
+    return skill_name
+
+
 def _skill_name_from_path(path: str) -> Optional[str]:
     """Return the skill name for a direct `<root>/<name>/SKILL.md` path.
 
@@ -76,9 +86,23 @@ def _skill_name_from_path(path: str) -> Optional[str]:
         if not path.startswith(prefix):
             continue
         parts = path[len(prefix):].split("/")
-        if len(parts) == 2 and parts[0] and parts[1] == _SKILL_FILE:
-            return parts[0]
+        skill_name = _direct_skill_name(parts)
+        if skill_name is not None:
+            return skill_name
     return None
+
+
+def _paths_by_skill(paths: Iterable[str]) -> dict[str, set[str]]:
+    """Group valid catalog paths by their direct skill name."""
+    paths_by_name: dict[str, set[str]] = {}
+    for raw_path in paths:
+        skill_path = raw_path.strip()
+        if not skill_path:
+            continue
+        skill_name = _skill_name_from_path(skill_path)
+        if skill_name is not None:
+            paths_by_name.setdefault(skill_name, set()).add(skill_path)
+    return paths_by_name
 
 
 def _extract_skill_catalog(
@@ -96,15 +120,7 @@ def _extract_skill_catalog(
     both roots appears once in `skills_available` while `skill_paths`
     carries both of its source paths.
     """
-    paths_by_name: dict[str, set[str]] = {}
-    for raw in paths:
-        path = raw.strip()
-        if not path:
-            continue
-        name = _skill_name_from_path(path)
-        if name is None:
-            continue
-        paths_by_name.setdefault(name, set()).add(path)
+    paths_by_name = _paths_by_skill(paths)
     skills_available = sorted(paths_by_name)
     skill_paths = {
         name: sorted(paths_by_name[name]) for name in skills_available
@@ -211,6 +227,24 @@ def _direct_skill_names(root: Path) -> list[str]:
     return sorted(names)
 
 
+def _add_skill_names(
+    seen: dict[str, None], names: Iterable[str],
+) -> None:
+    """Add names to an insertion-ordered deduplication map."""
+    for skill_name in names:
+        seen.setdefault(skill_name, None)
+
+
+def _global_codex_skill_names() -> list[str]:
+    """Collect user and built-in skill names from the global codex root."""
+    codex_home = os.environ.get("CODEX_HOME") or os.path.expanduser("~/.codex")
+    global_root = Path(codex_home) / "skills"
+    return sorted(set(
+        _direct_skill_names(global_root)
+        + _direct_skill_names(global_root / _SYSTEM_SKILL_DIR)
+    ))
+
+
 def discover_local_skills(cwd: Path) -> tuple[str, ...]:
     """Enumerate the skill names available to a codex run rooted at `cwd`.
 
@@ -231,16 +265,8 @@ def discover_local_skills(cwd: Path) -> tuple[str, ...]:
     """
     seen: dict[str, None] = {}
     for root in _SKILL_ROOTS:
-        for name in _direct_skill_names(cwd / root):
-            seen.setdefault(name, None)
-    codex_home = os.environ.get("CODEX_HOME") or os.path.expanduser("~/.codex")
-    global_root = Path(codex_home) / "skills"
-    global_names = sorted(set(
-        _direct_skill_names(global_root)
-        + _direct_skill_names(global_root / _SYSTEM_SKILL_DIR)
-    ))
-    for name in global_names:
-        seen.setdefault(name, None)
+        _add_skill_names(seen, _direct_skill_names(cwd / root))
+    _add_skill_names(seen, _global_codex_skill_names())
     return tuple(seen)
 
 

--- a/orchestrator/stages/decomposition.py
+++ b/orchestrator/stages/decomposition.py
@@ -13,13 +13,13 @@ recovery / stale manifest cleanup (`_recover_stale_manifest`), the
 DECOMPOSE kill-switch bailout (`_route_disabled_to_implementing`), the
 fresh decomposer spawn (`_spawn_fresh_decomposer`) or awaiting-human
 resume (`_resume_decomposer_on_human_reply`), the post-run settlement
-(`_settle_decomposer_run`, folds usage and parks on pause / timeout), and
-the manifest-outcome dispatch (`_dispatch_decomposer_manifest`) --
-invalid/silent park (`_park_unparsed_manifest`), `single` finalize
+(`_process_decomposer_run`, including usage, pause / timeout handling, and
+the read-only worktree guard), and the manifest-outcome dispatch
+(`_dispatch_decomposer_manifest`) -- invalid/silent park
+(`_park_unparsed_manifest`), `single` finalize
 (`_finalize_single_decision`), or `split` child creation
 (`_create_child_issues`) plus parent finalize + activation
-(`_finalize_split`). The read-only dirty-worktree park stays inline in
-`_handle_decomposing` so `keep_worktree` is set before its side effects.
+(`_finalize_split`).
 `_handle_blocked` and `_handle_umbrella` share the
 child-poll helpers (`_route_parent_drift`, `_read_child_labels`,
 `_park_rejected_children`, `_park_manually_closed_children`,
@@ -53,7 +53,7 @@ from orchestrator.state_machine import WorkflowLabel
 from orchestrator.github import GitHubClient, PinnedState
 
 
-@dataclass(frozen=True)
+@dataclass
 class _DecomposerRunPlan:
     agent_result: Optional[AgentResult]
     keep_worktree: bool = False
@@ -847,17 +847,17 @@ def _prepare_decomposer_run(
     spec: RepoSpec,
     issue: Issue,
     state: PinnedState,
-) -> Optional[_DecomposerRunPlan]:
+) -> _DecomposerRunPlan:
     # User-content drift FIRST, so it runs BEFORE the half-finished recovery:
     # otherwise recovery could finalize against a stale manifest when the issue
     # was edited during a crash window.
     _reset_decomposing_on_drift(gh, issue, state)
 
     if _recover_stale_manifest(gh, issue, state):
-        return None
+        return _DecomposerRunPlan(agent_result=None)
 
     if _route_disabled_to_implementing(gh, spec, issue, state):
-        return None
+        return _DecomposerRunPlan(agent_result=None)
 
     if state.get("awaiting_human"):
         decomposer_result = _resume_decomposer_on_human_reply(
@@ -873,66 +873,56 @@ def _prepare_decomposer_run(
     )
 
 
+def _process_decomposer_run(
+    gh: GitHubClient,
+    spec: RepoSpec,
+    issue: Issue,
+    state: PinnedState,
+    run_plan: _DecomposerRunPlan,
+) -> None:
+    from orchestrator import workflow as _wf
+
+    decomposer_result = run_plan.agent_result
+    if decomposer_result is None:
+        return
+
+    if _settle_decomposer_run(gh, issue, state, decomposer_result):
+        return
+
+    # The decomposer is read-only. Preserve a changed worktree for operator
+    # inspection, setting the cleanup policy before parking or persistence can
+    # raise and trigger the handler's finally block.
+    wt = _wf._decompose_worktree_path(spec, issue.number)
+    if _wf._has_new_commits(spec, wt) or _wf._worktree_dirty_files(wt):
+        run_plan.keep_worktree = True
+        _wf._park_awaiting_human(
+            gh, issue, state,
+            f"{config.HITL_MENTIONS} decomposer left commits or "
+            "uncommitted changes in the worktree, but it must be "
+            "read-only. Reset the worktree before resuming.",
+            reason="decomposer_dirty",
+        )
+        gh.write_pinned_state(issue, state)
+        return
+
+    # An interrupted run has no trustworthy manifest. The read-only check
+    # stays first so changes left by a killed run remain available to inspect.
+    if _wf._ignore_if_interrupted(issue, decomposer_result):
+        return
+
+    _dispatch_decomposer_manifest(gh, issue, state, decomposer_result)
+
+
 def _handle_decomposing(gh: GitHubClient, spec: RepoSpec, issue: Issue) -> None:
     from orchestrator import workflow as _wf
 
     state = gh.read_pinned_state(issue)
-
-    # Track whether to keep the decomposer worktree past this tick. Set
-    # True only in the dirty/commits park below or the awaiting-human
-    # no-reply park, where the operator may want to inspect what the agent
-    # did. Every other exit (success or park) cleans up via the finally so
-    # the next consumer of this issue number starts from current
-    # `origin/<base>`.
-    keep_worktree = False
+    run_plan = _DecomposerRunPlan(agent_result=None)
     try:
         run_plan = _prepare_decomposer_run(gh, spec, issue, state)
-        if run_plan is None:
-            return
-        keep_worktree = run_plan.keep_worktree
-        if run_plan.agent_result is None:
-            return
-        decomposer_result = run_plan.agent_result
-
-        if _settle_decomposer_run(gh, issue, state, decomposer_result):
-            return
-
-        # The decomposer is supposed to be read-only. If it committed or
-        # left uncommitted changes, something has gone wrong (prompt
-        # ignored, agent misbehaving, operator scratch). Park awaiting
-        # human and KEEP the worktree past this tick so the operator can
-        # inspect what the decomposer actually produced before resetting.
-        # Set `keep_worktree` BEFORE the park's side effects so a failing
-        # `_park_awaiting_human` / `write_pinned_state` still leaves the
-        # worktree on disk (the finally would otherwise tear it down).
-        wt = _wf._decompose_worktree_path(spec, issue.number)
-        if _wf._has_new_commits(spec, wt) or _wf._worktree_dirty_files(wt):
-            keep_worktree = True
-            _wf._park_awaiting_human(
-                gh, issue, state,
-                f"{config.HITL_MENTIONS} decomposer left commits or "
-                "uncommitted changes in the worktree, but it must be "
-                "read-only. Reset the worktree before resuming.",
-                reason="decomposer_dirty",
-            )
-            gh.write_pinned_state(issue, state)
-            return
-
-        # Shutdown-sweep interruption: a killed decomposer run has no
-        # trustworthy manifest. Its empty/partial output would otherwise
-        # fall through to the silent/invalid park and persist the session /
-        # `last_agent_action_at` mutations. Ignore it and return WITHOUT
-        # writing so the next process re-runs from durable state. Placed
-        # AFTER the read-only dirty/commits park so an interrupted run that
-        # still left changes parks for inspection (preserving the read-only
-        # semantics), and BEFORE the manifest parse so no partial
-        # `last_message` is read.
-        if _wf._ignore_if_interrupted(issue, decomposer_result):
-            return
-
-        _dispatch_decomposer_manifest(gh, issue, state, decomposer_result)
+        _process_decomposer_run(gh, spec, issue, state, run_plan)
     finally:
-        if not keep_worktree:
+        if not run_plan.keep_worktree:
             _wf._cleanup_decompose_worktree(spec, issue.number)
 
 

--- a/orchestrator/state_machine.py
+++ b/orchestrator/state_machine.py
@@ -199,6 +199,34 @@ _INTERRUPT_SOURCES: dict[WorkflowLabel, frozenset[WorkflowLabel]] = {
 }
 
 
+def _mutable_forward_transitions(
+) -> dict[Optional[WorkflowLabel], set[WorkflowLabel]]:
+    """Copy the declared forward graph into mutable target sets."""
+    return {
+        forward_source: set(forward_targets)
+        for forward_source, forward_targets in _FORWARD.items()
+    }
+
+
+def _add_interrupt_transitions(
+    allowed: dict[Optional[WorkflowLabel], set[WorkflowLabel]],
+) -> None:
+    """Fold each target's exact interrupt sources into the graph."""
+    for target, sources in _INTERRUPT_SOURCES.items():
+        for interrupt_source in sources:
+            allowed[interrupt_source].add(target)
+
+
+def _freeze_transitions(
+    allowed: dict[Optional[WorkflowLabel], set[WorkflowLabel]],
+) -> dict[Optional[WorkflowLabel], frozenset[WorkflowLabel]]:
+    """Freeze target sets so the exported transition table is immutable."""
+    return {
+        allowed_source: frozenset(edges)
+        for allowed_source, edges in allowed.items()
+    }
+
+
 def _build_allowed() -> dict[Optional[WorkflowLabel], frozenset[WorkflowLabel]]:
     """Compose the forward spine with the per-target interrupt sources.
 
@@ -208,17 +236,9 @@ def _build_allowed() -> dict[Optional[WorkflowLabel], frozenset[WorkflowLabel]]:
     outgoing edges), and the entry pseudo-state (`None`) gets no interrupt
     edge -- an unlabeled issue is never terminalized directly.
     """
-    allowed: dict[Optional[WorkflowLabel], set[WorkflowLabel]] = {
-        forward_source: set(forward_targets)
-        for forward_source, forward_targets in _FORWARD.items()
-    }
-    for target, sources in _INTERRUPT_SOURCES.items():
-        for interrupt_source in sources:
-            allowed[interrupt_source].add(target)
-    return {
-        allowed_source: frozenset(edges)
-        for allowed_source, edges in allowed.items()
-    }
+    allowed = _mutable_forward_transitions()
+    _add_interrupt_transitions(allowed)
+    return _freeze_transitions(allowed)
 
 
 ALLOWED_TRANSITIONS: dict[Optional[WorkflowLabel], frozenset[WorkflowLabel]] = (

--- a/orchestrator/trajectory_dashboard.py
+++ b/orchestrator/trajectory_dashboard.py
@@ -52,6 +52,8 @@ from __future__ import annotations
 
 import html
 import logging
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Optional, Sequence
 
 # `streamlit run orchestrator/trajectory_dashboard.py` launches this file
@@ -283,6 +285,50 @@ def _fmt_cost_usd(value: float, *, decimals: int = 2) -> str:
     return f"${value:,.{decimals}f}"
 
 
+@dataclass(frozen=True)
+class _TrajectoryKpi:
+    label: str
+    value: str
+    foot: str = ""
+
+
+def _trajectory_kpis(
+    summary: trajectory_reader.TrajectorySummary,
+) -> tuple[_TrajectoryKpi, ...]:
+    if summary.truncated_runs:
+        truncated_foot = f"{theme.fmt_num(summary.truncated_runs)} truncated"
+    else:
+        truncated_foot = "none truncated"
+    return (
+        _TrajectoryKpi("Runs", theme.fmt_num(summary.total_runs), truncated_foot),
+        _TrajectoryKpi("Issues", theme.fmt_num(summary.distinct_issues)),
+        _TrajectoryKpi("Repos", theme.fmt_num(summary.distinct_repos)),
+        _TrajectoryKpi("Tool calls", theme.fmt_num(summary.total_tool_calls)),
+        _TrajectoryKpi(
+            "Total cost",
+            _fmt_cost_usd(summary.total_cost_usd),
+            "reported + est.",
+        ),
+    )
+
+
+def _trajectory_kpi_html(kpi: _TrajectoryKpi) -> str:
+    if kpi.foot:
+        foot_html = (
+            f'<div class="kpi-foot"><span>{html.escape(kpi.foot)}</span></div>'
+        )
+    else:
+        foot_html = '<div class="kpi-foot"></div>'
+    return (
+        '<div class="orch-kpi">'
+        f'<div class="kpi-top"><span class="kpi-label">'
+        f'{html.escape(kpi.label)}</span></div>'
+        f'<div class="kpi-value">{html.escape(kpi.value)}</div>'
+        f'{foot_html}'
+        '</div>'
+    )
+
+
 def _kpi_strip_html(summary: trajectory_reader.TrajectorySummary) -> str:
     """Five-tile KPI strip reusing the dashboard's `.orch-kpi` markup.
 
@@ -290,33 +336,7 @@ def _kpi_strip_html(summary: trajectory_reader.TrajectorySummary) -> str:
     runs that recorded one (a mix of reported and estimated figures, hence
     the foot), read entirely from the file -- no Postgres.
     """
-    truncated_foot = (
-        f"{theme.fmt_num(summary.truncated_runs)} truncated"
-        if summary.truncated_runs
-        else "none truncated"
-    )
-    tiles = [
-        ("Runs", theme.fmt_num(summary.total_runs), truncated_foot),
-        ("Issues", theme.fmt_num(summary.distinct_issues), ""),
-        ("Repos", theme.fmt_num(summary.distinct_repos), ""),
-        ("Tool calls", theme.fmt_num(summary.total_tool_calls), ""),
-        ("Total cost", _fmt_cost_usd(summary.total_cost_usd), "reported + est."),
-    ]
-    cells = []
-    for label, value, foot in tiles:
-        foot_html = (
-            f'<div class="kpi-foot"><span>{html.escape(foot)}</span></div>'
-            if foot
-            else '<div class="kpi-foot"></div>'
-        )
-        cells.append(
-            '<div class="orch-kpi">'
-            f'<div class="kpi-top"><span class="kpi-label">'
-            f'{html.escape(label)}</span></div>'
-            f'<div class="kpi-value">{html.escape(value)}</div>'
-            f'{foot_html}'
-            '</div>'
-        )
+    cells = (_trajectory_kpi_html(kpi) for kpi in _trajectory_kpis(summary))
     return f'<div class="orch-kpis">{"".join(cells)}</div>'
 
 
@@ -364,6 +384,29 @@ def _labeled_chips_html(label: str, names: Sequence[str]) -> str:
     )
 
 
+def _run_table_row_html(run: TrajectoryRun) -> str:
+    round_cell = ""
+    if run.review_round is not None:
+        round_cell = str(run.review_round)
+    row_class = ' class="fixture"' if run.is_fixture else ""
+    fixture_tag = ""
+    if run.is_fixture:
+        fixture_tag = '<span class="orch-traj-fixture-tag">fixture</span>'
+    return (
+        f"<tr{row_class}>"
+        f'<td class="num">#{html.escape(str(run.issue))}</td>'
+        f"<td>{html.escape(run.repo)}{fixture_tag}</td>"
+        f"<td>{html.escape(run.stage)}</td>"
+        f"<td>{html.escape(run.agent_role)}</td>"
+        f"<td>{html.escape(run.backend)}</td>"
+        f'<td class="num">{html.escape(round_cell)}</td>'
+        f'<td class="num">{html.escape(str(run.step_count))}</td>'
+        f'<td class="num">{html.escape(str(run.tool_calls))}</td>'
+        f"<td>{html.escape(run.ts)}</td>"
+        "</tr>"
+    )
+
+
 def _runs_table_html(runs: Sequence[TrajectoryRun]) -> str:
     """Compact overview table of the (already-sliced) run list."""
     headers = (
@@ -371,28 +414,7 @@ def _runs_table_html(runs: Sequence[TrajectoryRun]) -> str:
         "Round", "Steps", "Tool calls", "Recorded",
     )
     head = "".join(f"<th>{html.escape(h)}</th>" for h in headers)
-    rows = []
-    for r in runs:
-        round_cell = "" if r.review_round is None else str(r.review_round)
-        row_class = ' class="fixture"' if r.is_fixture else ""
-        fixture_tag = (
-            '<span class="orch-traj-fixture-tag">fixture</span>'
-            if r.is_fixture
-            else ""
-        )
-        rows.append(
-            f"<tr{row_class}>"
-            f'<td class="num">#{html.escape(str(r.issue))}</td>'
-            f"<td>{html.escape(r.repo)}{fixture_tag}</td>"
-            f"<td>{html.escape(r.stage)}</td>"
-            f"<td>{html.escape(r.agent_role)}</td>"
-            f"<td>{html.escape(r.backend)}</td>"
-            f'<td class="num">{html.escape(round_cell)}</td>'
-            f'<td class="num">{html.escape(str(r.step_count))}</td>'
-            f'<td class="num">{html.escape(str(r.tool_calls))}</td>'
-            f"<td>{html.escape(r.ts)}</td>"
-            "</tr>"
-        )
+    rows = (_run_table_row_html(run) for run in runs)
     return (
         '<table class="orch-traj-table">'
         f"<thead><tr>{head}</tr></thead>"
@@ -455,6 +477,51 @@ def _timeline_entry_html(
     )
 
 
+def _usage_chip(text: str, css_class: str = "") -> str:
+    classes = f"orch-traj-chip {css_class}".rstrip()
+    return f'<span class="{classes}">{html.escape(text)}</span>'
+
+
+def _run_usage_chips(run: TrajectoryRun) -> list[str]:
+    usage = run.run_usage
+    if usage is None:
+        return []
+    chips = [_usage_chip(model) for model in usage.models]
+    chips.extend((
+        _usage_chip(f"total {theme.fmt_num(usage.total_tokens)} tok"),
+        _usage_chip(f"in {theme.fmt_num(usage.input_tokens)}"),
+        _usage_chip(f"out {theme.fmt_num(usage.output_tokens)}"),
+        _usage_chip(f"cache-read {theme.fmt_num(usage.cache_read_tokens)}"),
+        _usage_chip(f"cache-write {theme.fmt_num(usage.cache_write_tokens)}"),
+    ))
+    if usage.cached_tokens:
+        chips.append(_usage_chip(f"cached {theme.fmt_num(usage.cached_tokens)}"))
+    if usage.turns is not None:
+        chips.append(_usage_chip(f"{usage.turns} turns"))
+    source = run.cost_source or "unknown"
+    if run.cost_usd is None:
+        cost_label = source
+    else:
+        cost_label = f"{source} {_fmt_cost_usd(run.cost_usd)}"
+    chips.append(_usage_chip(cost_label, "cost"))
+    return chips
+
+
+def _run_usage_note(run: TrajectoryRun) -> str:
+    if run.turns:
+        return (
+            "Run cost is authoritative when reported. The per-turn strips in "
+            "the timeline are claude-only estimates and need not sum to it; "
+            "entries with no strip (tool results, user turns) are turn inputs, "
+            "billed on the next assistant turn."
+        )
+    return (
+        "Run cost is authoritative when reported. Per-turn usage is not "
+        "available for this backend, so the run-level summary is its only "
+        "usage surface."
+    )
+
+
 def _run_usage_html(run: TrajectoryRun) -> str:
     """Run-level usage / cost summary as a labeled chip row, plus a note.
 
@@ -468,54 +535,16 @@ def _run_usage_html(run: TrajectoryRun) -> str:
     estimates that need not sum to it -- or, when the run has no per-turn
     detail (codex), that per-turn usage is unavailable for the backend.
     """
-    usage = run.run_usage
-    if usage is None:
+    if run.run_usage is None:
         return ""
-
-    def chip(text: str, cls: str = "") -> str:
-        klass = f"orch-traj-chip {cls}".rstrip()
-        return f'<span class="{klass}">{html.escape(text)}</span>'
-
-    chips = [chip(m) for m in usage.models]
-    chips.append(chip(f"total {theme.fmt_num(usage.total_tokens)} tok"))
-    chips.append(chip(f"in {theme.fmt_num(usage.input_tokens)}"))
-    chips.append(chip(f"out {theme.fmt_num(usage.output_tokens)}"))
-    chips.append(chip(f"cache-read {theme.fmt_num(usage.cache_read_tokens)}"))
-    chips.append(chip(f"cache-write {theme.fmt_num(usage.cache_write_tokens)}"))
-    # `cached_tokens` is codex's only cache signal (it has no read/write
-    # split); it is 0 on claude, so the chip renders only when a run recorded
-    # it rather than adding an always-zero column to the claude row.
-    if usage.cached_tokens:
-        chips.append(chip(f"cached {theme.fmt_num(usage.cached_tokens)}"))
-    if usage.turns is not None:
-        chips.append(chip(f"{usage.turns} turns"))
-    source = run.cost_source or "unknown"
-    cost_label = (
-        source
-        if run.cost_usd is None
-        else f"{source} {_fmt_cost_usd(run.cost_usd)}"
-    )
-    chips.append(chip(cost_label, "cost"))
-
+    chips = _run_usage_chips(run)
     row = (
         '<div class="orch-traj-chips">'
         '<span class="lbl">Run usage</span>'
         f'{"".join(chips)}'
         '</div>'
     )
-    if run.turns:
-        note = (
-            "Run cost is authoritative when reported. The per-turn strips in "
-            "the timeline are claude-only estimates and need not sum to it; "
-            "entries with no strip (tool results, user turns) are turn inputs, "
-            "billed on the next assistant turn."
-        )
-    else:
-        note = (
-            "Run cost is authoritative when reported. Per-turn usage is not "
-            "available for this backend, so the run-level summary is its only "
-            "usage surface."
-        )
+    note = _run_usage_note(run)
     return f'{row}<p class="orch-traj-usage-note">{html.escape(note)}</p>'
 
 
@@ -602,76 +631,354 @@ def _run_picker_label(run: TrajectoryRun) -> str:
     return f"{_FIXTURE_LABEL_PREFIX}{label}" if run.is_fixture else label
 
 
+def _render_run_notices(st: Any, run: TrajectoryRun) -> None:
+    if run.is_fixture:
+        st.info(
+            "This run is flagged as a likely synthetic test fixture "
+            "(a sentinel `ignored` prompt, a `sess-*` session id, or a "
+            "Skill-only run). Such records can appear in a trajectory "
+            "file inherited from a run with the sink enabled during the "
+            "test suite."
+        )
+    if run.truncated:
+        st.warning(
+            "This trajectory was truncated by the sink's record budget; "
+            "later steps were dropped before the run finished."
+        )
+
+
+def _render_run_usage_and_chips(st: Any, run: TrajectoryRun) -> None:
+    usage_html = _run_usage_html(run)
+    if usage_html:
+        st.markdown(usage_html, unsafe_allow_html=True)
+    for label, names in (
+        ("Tools offered", run.tools),
+        ("Skills triggered", run.skills_triggered),
+        ("Skills available", run.skills_available),
+    ):
+        chips = _labeled_chips_html(label, names)
+        if chips:
+            st.markdown(chips, unsafe_allow_html=True)
+
+
+def _render_system_prompt(st: Any, run: TrajectoryRun) -> None:
+    if not run.system_prompt:
+        return
+    with st.expander("System prompt", expanded=False):
+        st.code(run.system_prompt)
+
+
+def _render_timeline_entry(
+    st: Any,
+    index: int,
+    strip: Optional[trajectory_reader.TurnUsageView],
+    entry: trajectory_reader.TimelineEntry,
+) -> None:
+    if strip is not None:
+        st.markdown(_turn_usage_html(strip), unsafe_allow_html=True)
+    st.markdown(_timeline_entry_html(entry, index), unsafe_allow_html=True)
+    if not entry.content:
+        return
+    if entry.is_output:
+        st.markdown(entry.content)
+    else:
+        st.code(entry.content)
+
+
+def _render_timeline(st: Any, run: TrajectoryRun) -> None:
+    st.markdown(
+        '<p class="orch-card-sub" style="margin-top:14px">'
+        f'Trajectory timeline · {run.step_count} steps · '
+        f'{run.tool_calls} tool calls</p>',
+        unsafe_allow_html=True,
+    )
+    if not run.timeline:
+        st.caption("No timeline entries were recorded for this run.")
+        return
+    for index, (strip, entry) in enumerate(_timeline_with_usage(run)):
+        _render_timeline_entry(st, index, strip, entry)
+
+
+def _render_run_card(st: Any, run: TrajectoryRun) -> None:
+    st.markdown('<div class="orch-cardmark"></div>', unsafe_allow_html=True)
+    st.markdown(
+        _card_header_html(
+            f"Run #{run.issue} · {run.repo or 'unknown repo'}",
+            "Ordered timeline: prompt, text turns, tool calls, output",
+        ),
+        unsafe_allow_html=True,
+    )
+    _render_run_notices(st, run)
+    st.markdown(_meta_html(run), unsafe_allow_html=True)
+    _render_run_usage_and_chips(st, run)
+    _render_system_prompt(st, run)
+    _render_timeline(st, run)
+
+
 def _render_run(*, st: Any, run: TrajectoryRun) -> None:
     """Render the detail card for one selected run."""
     with st.container(border=True):
-        st.markdown('<div class="orch-cardmark"></div>', unsafe_allow_html=True)
-        st.markdown(
-            _card_header_html(
-                f"Run #{run.issue} · {run.repo or 'unknown repo'}",
-                "Ordered timeline: prompt, text turns, tool calls, output",
+        _render_run_card(st, run)
+
+
+@dataclass(frozen=True)
+class _TrajectoryFilters:
+    repo: Optional[str]
+    backends: Optional[Sequence[str]]
+    agent_roles: Optional[Sequence[str]]
+    stages: Optional[Sequence[str]]
+    issue: Optional[int]
+    query: str
+    hide_fixtures: bool
+
+
+@dataclass(frozen=True)
+class _TrajectoryPage:
+    log_path: Optional[Path]
+    runs: Sequence[TrajectoryRun]
+    options: trajectory_reader.FilterOptions
+    fixture_total: int
+
+    @property
+    def total(self) -> int:
+        return len(self.runs)
+
+
+def _configure_page(st: Any) -> None:
+    st.set_page_config(
+        page_title="Orchestrator Trajectories",
+        layout="wide",
+    )
+    st.markdown(theme.PAGE_CSS, unsafe_allow_html=True)
+    st.markdown(EXTRA_CSS, unsafe_allow_html=True)
+
+
+def _stop_if_unconfigured(st: Any) -> None:
+    message = trajectory_reader.log_unconfigured_message()
+    if not message:
+        return
+    st.markdown(_topbar_html(0, 0), unsafe_allow_html=True)
+    st.warning(message)
+    st.stop()
+
+
+def _load_trajectory_page() -> _TrajectoryPage:
+    log_path = trajectory_reader.resolve_log_path()
+    runs = trajectory_reader.read_trajectories()
+    return _TrajectoryPage(
+        log_path=log_path,
+        runs=runs,
+        options=trajectory_reader.filter_options(runs),
+        fixture_total=sum(1 for run in runs if run.is_fixture),
+    )
+
+
+def _render_categorical_filters(
+    st: Any,
+    options: trajectory_reader.FilterOptions,
+) -> tuple[Sequence[str], Sequence[str], Sequence[str]]:
+    backends = st.multiselect(
+        "Backend",
+        list(options.backends),
+        help="Leave empty to include every backend.",
+    )
+    roles = st.multiselect(
+        "Agent role",
+        list(options.agent_roles),
+        help="Leave empty to include every role.",
+    )
+    stages = st.multiselect(
+        "Stage",
+        list(options.stages),
+        help="Leave empty to include every stage.",
+    )
+    return backends, roles, stages
+
+
+def _render_text_filters(st: Any) -> tuple[str, str]:
+    issue_input = st.text_input(
+        "Issue number",
+        value="",
+        help="Enter `123` or `#123` to narrow to one issue.",
+    )
+    query_input = st.text_input(
+        "Search",
+        value="",
+        help=(
+            "Case-insensitive substring matched across the prompt, "
+            "system prompt, output, tool names, tool payloads, and "
+            "skill names."
+        ),
+    )
+    return issue_input, query_input
+
+
+def _render_trajectory_sidebar(
+    st: Any,
+    options: trajectory_reader.FilterOptions,
+) -> _TrajectoryFilters:
+    with st.sidebar:
+        st.header("Filters")
+        repo_choice = st.selectbox("Repo", ("All", *options.repos), index=0)
+        categorical = _render_categorical_filters(st, options)
+        text_filters = _render_text_filters(st)
+        hide_fixtures = st.checkbox(
+            "Hide synthetic fixtures",
+            value=False,
+            help=(
+                "Drop records that look like test-suite fixtures -- a "
+                "sentinel `ignored` prompt, a `sess-*` session id, or a "
+                "Skill-only run. Leave off to keep them, flagged with a "
+                "`fixture` tag in the table and run picker."
             ),
-            unsafe_allow_html=True,
         )
-        if run.is_fixture:
-            st.info(
-                "This run is flagged as a likely synthetic test fixture "
-                "(a sentinel `ignored` prompt, a `sess-*` session id, or a "
-                "Skill-only run). Such records can appear in a trajectory "
-                "file inherited from a run with the sink enabled during the "
-                "test suite."
-            )
-        if run.truncated:
-            st.warning(
-                "This trajectory was truncated by the sink's record budget; "
-                "later steps were dropped before the run finished."
-            )
-        st.markdown(_meta_html(run), unsafe_allow_html=True)
+    return _TrajectoryFilters(
+        repo=None if repo_choice == "All" else repo_choice,
+        backends=categorical[0] or None,
+        agent_roles=categorical[1] or None,
+        stages=categorical[2] or None,
+        issue=dashboard_state.parse_issue_number(text_filters[0]),
+        query=text_filters[1],
+        hide_fixtures=hide_fixtures,
+    )
 
-        usage_html = _run_usage_html(run)
-        if usage_html:
-            st.markdown(usage_html, unsafe_allow_html=True)
 
-        for label, names in (
-            ("Tools offered", run.tools),
-            ("Skills triggered", run.skills_triggered),
-            ("Skills available", run.skills_available),
-        ):
-            chips = _labeled_chips_html(label, names)
-            if chips:
-                st.markdown(chips, unsafe_allow_html=True)
+def _filter_page_runs(
+    page: _TrajectoryPage,
+    filters: _TrajectoryFilters,
+) -> list[TrajectoryRun]:
+    return trajectory_reader.filter_runs(
+        page.runs,
+        repo=filters.repo,
+        backends=filters.backends,
+        agent_roles=filters.agent_roles,
+        stages=filters.stages,
+        issue=filters.issue,
+        query=filters.query,
+        exclude_fixtures=filters.hide_fixtures,
+    )
 
-        if run.system_prompt:
-            with st.expander("System prompt", expanded=False):
-                st.code(run.system_prompt)
 
+def _render_no_trajectories(st: Any, log_path: Optional[Path]) -> None:
+    st.info(NO_TRAJECTORIES_MESSAGE)
+    if log_path is not None:
+        st.caption(f"Reading `{log_path}`.")
+
+
+def _fixture_caption(fixture_total: int, hide_fixtures: bool) -> str:
+    noun = "run" if fixture_total == 1 else "runs"
+    if hide_fixtures:
+        return f"{fixture_total} synthetic fixture {noun} hidden."
+    return (
+        f"{fixture_total} synthetic fixture {noun} flagged; "
+        "tick *Hide synthetic fixtures* in the sidebar to drop them."
+    )
+
+
+def _render_run_list(
+    st: Any,
+    shown: Sequence[TrajectoryRun],
+    fixture_total: int,
+    hide_fixtures: bool,
+) -> None:
+    with st.expander("Recorded runs", expanded=True):
+        st.caption("Most recent first · pick a run below to inspect it")
         st.markdown(
-            '<p class="orch-card-sub" style="margin-top:14px">'
-            f'Trajectory timeline · {run.step_count} steps · '
-            f'{run.tool_calls} tool calls</p>',
+            _runs_table_html(shown[:RUN_TABLE_LIMIT]),
             unsafe_allow_html=True,
         )
-        timeline = run.timeline
-        if timeline:
-            for i, (strip, entry) in enumerate(_timeline_with_usage(run)):
-                if strip is not None:
-                    st.markdown(
-                        _turn_usage_html(strip), unsafe_allow_html=True
-                    )
-                st.markdown(
-                    _timeline_entry_html(entry, i), unsafe_allow_html=True
-                )
-                if entry.content:
-                    # The final answer is markdown the agent authored;
-                    # render it rich. Every other entry -- the orchestrator
-                    # prompt, tool payloads, text turns -- is raw text shown
-                    # verbatim in a code block.
-                    if entry.is_output:
-                        st.markdown(entry.content)
-                    else:
-                        st.code(entry.content)
-        else:
-            st.caption("No timeline entries were recorded for this run.")
+        if len(shown) > RUN_TABLE_LIMIT:
+            st.caption(
+                f"Table shows the {RUN_TABLE_LIMIT} most recent of "
+                f"{len(shown)} matching runs; the picker below lists all of "
+                "them. Narrow the filters to shorten the list."
+            )
+        if fixture_total:
+            st.caption(_fixture_caption(fixture_total, hide_fixtures))
+
+
+def _pick_repo(st: Any, shown: Sequence[TrajectoryRun]) -> str:
+    repos = sorted({run.repo for run in shown})
+    return st.selectbox("Repo", repos)
+
+
+def _pick_issue(
+    st: Any,
+    shown: Sequence[TrajectoryRun],
+    repo: str,
+) -> int:
+    issues = sorted({run.issue for run in shown if run.repo == repo})
+    return st.selectbox("Issue", issues, format_func=lambda issue: f"#{issue}")
+
+
+def _pick_run(
+    st: Any,
+    shown: Sequence[TrajectoryRun],
+    repo: str,
+    issue: int,
+) -> TrajectoryRun:
+    candidates = [
+        run for run in shown
+        if run.repo == repo and run.issue == issue
+    ]
+    selected = st.selectbox(
+        "Run",
+        range(len(candidates)),
+        format_func=lambda index: _run_picker_label(candidates[index]),
+    )
+    return candidates[selected]
+
+
+def _render_run_picker(st: Any, shown: Sequence[TrajectoryRun]) -> None:
+    st.markdown(
+        '<p class="orch-card-sub" style="margin:14px 0 4px">'
+        'Inspect run</p>',
+        unsafe_allow_html=True,
+    )
+    columns = st.columns(3)
+    with columns[0]:
+        repo = _pick_repo(st, shown)
+    with columns[1]:
+        issue = _pick_issue(st, shown, repo)
+    with columns[2]:
+        run = _pick_run(st, shown, repo, issue)
+    _render_run(st=st, run=run)
+
+
+def _render_trajectory_footer(
+    st: Any,
+    shown_count: int,
+    page: _TrajectoryPage,
+) -> None:
+    st.markdown(
+        '<div class="orch-foot">'
+        f'{theme.fmt_num(shown_count)} of {theme.fmt_num(page.total)} recorded '
+        f'trajectories · reading {html.escape(str(page.log_path))}'
+        '</div>',
+        unsafe_allow_html=True,
+    )
+
+
+def _render_trajectory_page(
+    st: Any,
+    page: _TrajectoryPage,
+    filters: _TrajectoryFilters,
+    shown: Sequence[TrajectoryRun],
+) -> None:
+    st.markdown(_topbar_html(page.total, len(shown)), unsafe_allow_html=True)
+    if page.total == 0:
+        _render_no_trajectories(st, page.log_path)
+        return
+    st.markdown(
+        _kpi_strip_html(trajectory_reader.summarize(shown)),
+        unsafe_allow_html=True,
+    )
+    if not shown:
+        st.info(EMPTY_FILTER_MESSAGE)
+        return
+    _render_run_list(st, shown, page.fixture_total, filters.hide_fixtures)
+    _render_run_picker(st, shown)
+    _render_trajectory_footer(st, len(shown), page)
 
 
 def main() -> None:
@@ -685,161 +992,12 @@ def main() -> None:
     """
     import streamlit as st
 
-    st.set_page_config(
-        page_title="Orchestrator Trajectories",
-        layout="wide",
-    )
-    st.markdown(theme.PAGE_CSS, unsafe_allow_html=True)
-    st.markdown(EXTRA_CSS, unsafe_allow_html=True)
-
-    unset = trajectory_reader.log_unconfigured_message()
-    if unset:
-        st.markdown(_topbar_html(0, 0), unsafe_allow_html=True)
-        st.warning(unset)
-        st.stop()
-
-    log_path = trajectory_reader.resolve_log_path()
-    runs = trajectory_reader.read_trajectories()
-    total = len(runs)
-    options = trajectory_reader.filter_options(runs)
-
-    with st.sidebar:
-        st.header("Filters")
-        repo_options = ("All", *options.repos)
-        repo_choice = st.selectbox("Repo", repo_options, index=0)
-        backend_choice = st.multiselect(
-            "Backend",
-            list(options.backends),
-            help="Leave empty to include every backend.",
-        )
-        role_choice = st.multiselect(
-            "Agent role",
-            list(options.agent_roles),
-            help="Leave empty to include every role.",
-        )
-        stage_choice = st.multiselect(
-            "Stage",
-            list(options.stages),
-            help="Leave empty to include every stage.",
-        )
-        issue_input = st.text_input(
-            "Issue number",
-            value="",
-            help="Enter `123` or `#123` to narrow to one issue.",
-        )
-        query_input = st.text_input(
-            "Search",
-            value="",
-            help=(
-                "Case-insensitive substring matched across the prompt, "
-                "system prompt, output, tool names, tool payloads, and "
-                "skill names."
-            ),
-        )
-        hide_fixtures = st.checkbox(
-            "Hide synthetic fixtures",
-            value=False,
-            help=(
-                "Drop records that look like test-suite fixtures -- a "
-                "sentinel `ignored` prompt, a `sess-*` session id, or a "
-                "Skill-only run. Leave off to keep them, flagged with a "
-                "`fixture` tag in the table and run picker."
-            ),
-        )
-
-    fixture_total = sum(1 for r in runs if r.is_fixture)
-
-    shown = trajectory_reader.filter_runs(
-        runs,
-        repo=None if repo_choice == "All" else repo_choice,
-        backends=backend_choice or None,
-        agent_roles=role_choice or None,
-        stages=stage_choice or None,
-        issue=dashboard_state.parse_issue_number(issue_input),
-        query=query_input,
-        exclude_fixtures=hide_fixtures,
-    )
-    summary = trajectory_reader.summarize(shown)
-
-    st.markdown(_topbar_html(total, len(shown)), unsafe_allow_html=True)
-
-    if total == 0:
-        st.info(NO_TRAJECTORIES_MESSAGE)
-        if log_path is not None:
-            st.caption(f"Reading `{log_path}`.")
-        return
-
-    st.markdown(_kpi_strip_html(summary), unsafe_allow_html=True)
-
-    if not shown:
-        st.info(EMPTY_FILTER_MESSAGE)
-        return
-
-    # ── Run list ────────────────────────────────
-    # A native expander so the operator can fold the overview table away
-    # and focus on the inspected run; expanded by default to preserve the
-    # at-a-glance view.
-    with st.expander("Recorded runs", expanded=True):
-        st.caption("Most recent first · pick a run below to inspect it")
-        table_runs = shown[:RUN_TABLE_LIMIT]
-        st.markdown(_runs_table_html(table_runs), unsafe_allow_html=True)
-        if len(shown) > RUN_TABLE_LIMIT:
-            st.caption(
-                f"Table shows the {RUN_TABLE_LIMIT} most recent of "
-                f"{len(shown)} matching runs; the picker below lists all of "
-                "them. Narrow the filters to shorten the list."
-            )
-        if fixture_total:
-            st.caption(
-                f"{fixture_total} synthetic fixture "
-                f"{'run' if fixture_total == 1 else 'runs'} hidden."
-                if hide_fixtures
-                else f"{fixture_total} synthetic fixture "
-                f"{'run' if fixture_total == 1 else 'runs'} flagged; "
-                "tick *Hide synthetic fixtures* in the sidebar to drop them."
-            )
-
-    # ── Selected-run detail ────────────────────────────
-    # Three cascading pickers narrow `shown` to one run: repo, then the
-    # issue within that repo, then the specific run (by `detail_label`).
-    # Streamlit resets a downstream selectbox to its first option when an
-    # upstream pick makes its prior value no longer offered.
-    st.markdown(
-        '<p class="orch-card-sub" style="margin:14px 0 4px">'
-        'Inspect run</p>',
-        unsafe_allow_html=True,
-    )
-    repo_col, issue_col, run_col = st.columns(3)
-    with repo_col:
-        inspect_repos = sorted({r.repo for r in shown})
-        picked_repo = st.selectbox("Repo", inspect_repos)
-    with issue_col:
-        inspect_issues = sorted(
-            {r.issue for r in shown if r.repo == picked_repo}
-        )
-        picked_issue = st.selectbox(
-            "Issue", inspect_issues, format_func=lambda i: f"#{i}"
-        )
-    with run_col:
-        candidates = [
-            r
-            for r in shown
-            if r.repo == picked_repo and r.issue == picked_issue
-        ]
-        selected = st.selectbox(
-            "Run",
-            range(len(candidates)),
-            format_func=lambda i: _run_picker_label(candidates[i]),
-        )
-    _render_run(st=st, run=candidates[selected])
-
-    st.markdown(
-        '<div class="orch-foot">'
-        f'{theme.fmt_num(len(shown))} of {theme.fmt_num(total)} recorded '
-        f'trajectories · reading {html.escape(str(log_path))}'
-        '</div>',
-        unsafe_allow_html=True,
-    )
+    _configure_page(st)
+    _stop_if_unconfigured(st)
+    page = _load_trajectory_page()
+    filters = _render_trajectory_sidebar(st, page.options)
+    shown = _filter_page_runs(page, filters)
+    _render_trajectory_page(st, page, filters, shown)
 
 
 if __name__ == "__main__":

--- a/orchestrator/trajectory_reader.py
+++ b/orchestrator/trajectory_reader.py
@@ -35,7 +35,14 @@ import logging
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Callable, Optional, Sequence
+from typing import (
+    Any,
+    Callable,
+    Optional,
+    Sequence,
+    TypedDict,
+    Unpack,
+)
 
 from orchestrator import analytics
 
@@ -413,6 +420,29 @@ class FilterOptions:
 
 
 @dataclass(frozen=True)
+class RunFilterOptions:
+    """Raw optional constraints accepted by `filter_runs`."""
+
+    repo: Optional[str] = None
+    backends: Optional[Sequence[str]] = None
+    agent_roles: Optional[Sequence[str]] = None
+    stages: Optional[Sequence[str]] = None
+    issue: Optional[int] = None
+    query: Optional[str] = None
+    exclude_fixtures: bool = False
+
+
+class _RunFilterOptionFields(TypedDict, total=False):
+    repo: Optional[str]
+    backends: Optional[Sequence[str]]
+    agent_roles: Optional[Sequence[str]]
+    stages: Optional[Sequence[str]]
+    issue: Optional[int]
+    query: Optional[str]
+    exclude_fixtures: bool
+
+
+@dataclass(frozen=True)
 class _RunFilters:
     """Normalized constraints for one trajectory-filtering pass."""
 
@@ -618,6 +648,28 @@ def parse_record(obj: Any, *, seq: int) -> Optional[TrajectoryRun]:
     )
 
 
+def _parse_trajectory_line(
+    line: str, *, seq: int,
+) -> Optional[TrajectoryRun]:
+    if not line.strip():
+        return None
+    try:
+        record = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    return parse_record(record, seq=seq)
+
+
+def _read_trajectory_file(path: Path) -> list[TrajectoryRun]:
+    runs: list[TrajectoryRun] = []
+    with path.open("r", encoding="utf-8") as trajectory_file:
+        for seq, line in enumerate(trajectory_file):
+            run = _parse_trajectory_line(line, seq=seq)
+            if run is not None:
+                runs.append(run)
+    return runs
+
+
 def read_trajectories(path: Optional[Path] = None) -> list[TrajectoryRun]:
     """Read every `agent_trajectory` record, newest first.
 
@@ -633,27 +685,15 @@ def read_trajectories(path: Optional[Path] = None) -> list[TrajectoryRun]:
     with the original file order as a stable tie-breaker so two records
     sharing a second-precision timestamp keep their append order.
     """
-    if path is None:
-        path = resolve_log_path()
-    if path is None:
+    log_path = path if path is not None else resolve_log_path()
+    if log_path is None:
         return []
-    runs: list[TrajectoryRun] = []
     try:
-        with path.open("r", encoding="utf-8") as fh:
-            for seq, line in enumerate(fh):
-                if not line.strip():
-                    continue
-                try:
-                    obj = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                run = parse_record(obj, seq=seq)
-                if run is not None:
-                    runs.append(run)
+        runs = _read_trajectory_file(log_path)
     except FileNotFoundError:
         return []
-    except OSError as e:
-        log.warning("could not read trajectory log %s: %s", path, e)
+    except OSError as error:
+        log.warning("could not read trajectory log %s: %s", log_path, error)
         return []
     # Sort newest-first; `-seq` keeps the most recently appended record
     # ahead of an equal-timestamp predecessor while staying a total order.
@@ -670,7 +710,12 @@ def _distinct_sorted(
     value -- a run that omitted that field -- is dropped so the sidebar never
     offers a blank choice, and the result is sorted for a stable dropdown.
     """
-    return tuple(sorted({value for value in (key(r) for r in runs) if value}))
+    values: set[str] = set()
+    for run in runs:
+        value = key(run)
+        if value:
+            values.add(value)
+    return tuple(sorted(values))
 
 
 def filter_options(runs: Sequence[TrajectoryRun]) -> FilterOptions:
@@ -727,6 +772,29 @@ def _normalize_filter_query(query: Optional[str]) -> Optional[str]:
     return normalized_query or None
 
 
+def _resolve_run_filter_options(
+    options: Optional[RunFilterOptions],
+    option_fields: _RunFilterOptionFields,
+) -> RunFilterOptions:
+    if options is not None and option_fields:
+        raise TypeError("pass either options or keyword option fields, not both")
+    if options is not None:
+        return options
+    return RunFilterOptions(**option_fields)
+
+
+def _normalize_run_filters(options: RunFilterOptions) -> _RunFilters:
+    return _RunFilters(
+        repo=options.repo,
+        backends=_normalize_filter_values(options.backends),
+        agent_roles=_normalize_filter_values(options.agent_roles),
+        stages=_normalize_filter_values(options.stages),
+        issue=options.issue,
+        query=_normalize_filter_query(options.query),
+        exclude_fixtures=options.exclude_fixtures,
+    )
+
+
 def _matches_scalar_filters(
     run: TrajectoryRun,
     run_filters: _RunFilters,
@@ -772,14 +840,8 @@ def _matches_run_filters(
 
 def filter_runs(
     runs: Sequence[TrajectoryRun],
-    *,
-    repo: Optional[str] = None,
-    backends: Optional[Sequence[str]] = None,
-    agent_roles: Optional[Sequence[str]] = None,
-    stages: Optional[Sequence[str]] = None,
-    issue: Optional[int] = None,
-    query: Optional[str] = None,
-    exclude_fixtures: bool = False,
+    options: Optional[RunFilterOptions] = None,
+    **option_fields: Unpack[_RunFilterOptionFields],
 ) -> list[TrajectoryRun]:
     """Return the subset of `runs` matching every supplied filter.
 
@@ -792,14 +854,8 @@ def filter_runs(
     drops the synthetic test-suite records `TrajectoryRun.is_fixture`
     flags. Relative order is preserved.
     """
-    run_filters = _RunFilters(
-        repo=repo,
-        backends=_normalize_filter_values(backends),
-        agent_roles=_normalize_filter_values(agent_roles),
-        stages=_normalize_filter_values(stages),
-        issue=issue,
-        query=_normalize_filter_query(query),
-        exclude_fixtures=exclude_fixtures,
+    run_filters = _normalize_run_filters(
+        _resolve_run_filter_options(options, option_fields)
     )
     return [run for run in runs if _matches_run_filters(run, run_filters)]
 

--- a/orchestrator/usage.py
+++ b/orchestrator/usage.py
@@ -288,6 +288,17 @@ def _walk_objects(value: Any) -> Iterable[dict[str, Any]]:
             yield from _walk_objects(v)
 
 
+def _coerce_reported_cost(value: Any) -> Optional[float]:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str):
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
 def _find_last_reported_cost(events: list[dict[str, Any]]) -> Optional[float]:
     """Return the final ``total_cost_usd`` observed anywhere in the stream.
 
@@ -295,20 +306,15 @@ def _find_last_reported_cost(events: list[dict[str, Any]]) -> Optional[float]:
     nests it deeper than the top level; walk every object so a deeper path
     still wins over an estimate.
     """
-    last: Optional[float] = None
-    for ev in events:
-        for obj in _walk_objects(ev):
-            value = obj.get("total_cost_usd")
-            if value is None:
-                continue
-            if isinstance(value, (int, float)):
-                last = float(value)
-            elif isinstance(value, str):
-                try:
-                    last = float(value)
-                except ValueError:
-                    pass
-    return last
+    last_cost: Optional[float] = None
+    for event in events:
+        for payload in _walk_objects(event):
+            reported_cost = _coerce_reported_cost(
+                payload.get("total_cost_usd")
+            )
+            if reported_cost is not None:
+                last_cost = reported_cost
+    return last_cost
 
 
 def _dedup_models(models: Iterable[str]) -> tuple[str, ...]:
@@ -341,30 +347,62 @@ def _select_cost(
     return None, "unknown-price"
 
 
+_ModelPath = tuple[str, ...]
+
+
+def _nested_value(payload: dict[str, Any], path: _ModelPath) -> Any:
+    current: Any = payload
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _known_model(value: Any) -> Optional[str]:
+    if isinstance(value, str) and value and value != "unknown":
+        return value
+    return None
+
+
+def _nonempty_string(value: Any) -> Optional[str]:
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _first_model_at_paths(
+    event: dict[str, Any], paths: tuple[_ModelPath, ...],
+) -> Optional[str]:
+    for path in paths:
+        model = _known_model(_nested_value(event, path))
+        if model is not None:
+            return model
+    return None
+
+
+def _first_string_at_paths(
+    event: dict[str, Any], paths: tuple[_ModelPath, ...],
+) -> Optional[str]:
+    for path in paths:
+        value = _nonempty_string(_nested_value(event, path))
+        if value is not None:
+            return value
+    return None
+
+
 # --- claude parser ----------------------------------------------------------
 
+_CLAUDE_MODEL_PATHS: tuple[_ModelPath, ...] = (
+    ("message", "model"),
+    ("event", "message", "model"),
+    ("model",),
+    ("response", "model"),
+)
+
+
 def _claude_model_name(event: dict[str, Any]) -> str:
-    msg = event.get("message")
-    if isinstance(msg, dict):
-        m = msg.get("model")
-        if isinstance(m, str) and m:
-            return m
-    nested = event.get("event")
-    if isinstance(nested, dict):
-        n_msg = nested.get("message")
-        if isinstance(n_msg, dict):
-            m = n_msg.get("model")
-            if isinstance(m, str) and m:
-                return m
-    m = event.get("model")
-    if isinstance(m, str) and m:
-        return m
-    resp = event.get("response")
-    if isinstance(resp, dict):
-        m = resp.get("model")
-        if isinstance(m, str) and m:
-            return m
-    return "unknown"
+    return _first_string_at_paths(event, _CLAUDE_MODEL_PATHS) or "unknown"
 
 
 def _claude_usage_record(usage: dict[str, Any]) -> dict[str, int]:
@@ -467,7 +505,13 @@ def _claude_usage_records(
 def _sorted_claude_usage_rows(
     by_id: dict[str, _ClaudeUsageRow],
 ) -> list[_ClaudeUsageRow]:
-    return [row for _, row in sorted(by_id.items(), key=lambda item: item[1][0])]
+    usage_rows = list(by_id.values())
+    usage_rows.sort(key=_claude_usage_row_index)
+    return usage_rows
+
+
+def _claude_usage_row_index(usage_row: _ClaudeUsageRow) -> int:
+    return usage_row[0]
 
 
 def _claude_result_usage_records(
@@ -618,16 +662,8 @@ def _codex_usage_block(event: dict[str, Any]) -> Optional[dict[str, Any]]:
     return None
 
 
-def _codex_known_model(value: Any) -> Optional[str]:
-    if isinstance(value, str) and value and value != "unknown":
-        return value
-    return None
-
-
-_CODEX_MODEL_KEYS: tuple[str, ...] = (
-    "model",
-)
-_CODEX_MODEL_NESTED: tuple[tuple[str, ...], ...] = (
+_CODEX_MODEL_PATHS: tuple[_ModelPath, ...] = (
+    ("model",),
     ("response", "model"),
     ("item", "model"),
     ("event", "model"),
@@ -642,25 +678,11 @@ _CODEX_MODEL_NESTED: tuple[tuple[str, ...], ...] = (
 def _codex_model_name(
     event: dict[str, Any], usage: Optional[dict[str, Any]]
 ) -> str:
-    for key in _CODEX_MODEL_KEYS:
-        m = _codex_known_model(event.get(key))
-        if m:
-            return m
-    for path in _CODEX_MODEL_NESTED:
-        cur: Any = event
-        for key in path:
-            if not isinstance(cur, dict):
-                cur = None
-                break
-            cur = cur.get(key)
-        m = _codex_known_model(cur)
-        if m:
-            return m
-    if usage is not None:
-        m = _codex_known_model(usage.get("model"))
-        if m:
-            return m
-    return "unknown"
+    event_model = _first_model_at_paths(event, _CODEX_MODEL_PATHS)
+    if event_model is not None:
+        return event_model
+    usage_model = _known_model(usage.get("model")) if usage else None
+    return usage_model or "unknown"
 
 
 def _codex_usage_record(usage: dict[str, Any]) -> dict[str, int]:
@@ -727,16 +749,25 @@ def _codex_select_model(
     that, the last ``model`` field seen anywhere in the stream wins, then the
     caller-supplied ``fallback_model``. ``None`` when nothing names a model.
     """
-    chosen = _codex_known_model(last_model)
-    if chosen is None:
-        for ev in events:
-            for obj in _walk_objects(ev):
-                cand = _codex_known_model(obj.get("model"))
-                if cand:
-                    chosen = cand
-        if chosen is None and fallback_model:
-            chosen = _codex_known_model(fallback_model)
-    return chosen
+    chosen_model = _known_model(last_model)
+    if chosen_model is not None:
+        return chosen_model
+    stream_model = _last_stream_model(events)
+    if stream_model is not None:
+        return stream_model
+    return _known_model(fallback_model)
+
+
+def _last_stream_model(
+    events: list[dict[str, Any]],
+) -> Optional[str]:
+    last_model: Optional[str] = None
+    for event in events:
+        for payload in _walk_objects(event):
+            model = _known_model(payload.get("model"))
+            if model is not None:
+                last_model = model
+    return last_model
 
 
 def _codex_estimate_cost(
@@ -980,6 +1011,33 @@ def _claude_skill_name(block: Any) -> Optional[str]:
     return None
 
 
+def _claude_init_field(
+    events: Iterable[dict[str, Any]], field_name: str,
+) -> Any:
+    for event in events:
+        if event.get("type") != "system":
+            continue
+        if event.get("subtype") != "init":
+            continue
+        return event.get(field_name)
+    return None
+
+
+def _ordered_unique_names(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    ordered_names: list[str] = []
+    seen_names: set[str] = set()
+    for name in value:
+        if not isinstance(name, str):
+            continue
+        if not name or name in seen_names:
+            continue
+        seen_names.add(name)
+        ordered_names.append(name)
+    return tuple(ordered_names)
+
+
 def _claude_offered_skills(events: Iterable[dict[str, Any]]) -> tuple[str, ...]:
     """Read the offered-skills set from claude's ``system``/``init`` frame.
 
@@ -991,20 +1049,7 @@ def _claude_offered_skills(events: Iterable[dict[str, Any]]) -> tuple[str, ...]:
     names are de-duplicated in first-seen order. The first ``init`` frame
     wins (a single run emits one).
     """
-    for ev in events:
-        if ev.get("type") != "system" or ev.get("subtype") != "init":
-            continue
-        skills = ev.get("skills")
-        if not isinstance(skills, list):
-            return ()
-        order: list[str] = []
-        seen: set[str] = set()
-        for name in skills:
-            if isinstance(name, str) and name and name not in seen:
-                seen.add(name)
-                order.append(name)
-        return tuple(order)
-    return ()
+    return _ordered_unique_names(_claude_init_field(events, "skills"))
 
 
 def parse_claude_skills(stdout: str) -> SkillTriggers:
@@ -1314,20 +1359,7 @@ def _claude_offered_tools(events: Iterable[dict[str, Any]]) -> tuple[str, ...]:
     renamed field, or a non-string entry, filters out rather than raising,
     and names de-duplicate in first-seen order. The first ``init`` frame wins.
     """
-    for ev in events:
-        if ev.get("type") != "system" or ev.get("subtype") != "init":
-            continue
-        tools = ev.get("tools")
-        if not isinstance(tools, list):
-            return ()
-        order: list[str] = []
-        seen: set[str] = set()
-        for name in tools:
-            if isinstance(name, str) and name and name not in seen:
-                seen.add(name)
-                order.append(name)
-        return tuple(order)
-    return ()
+    return _ordered_unique_names(_claude_init_field(events, "tools"))
 
 
 def _claude_final_output(events: Iterable[dict[str, Any]]) -> Optional[str]:

--- a/orchestrator/verify.py
+++ b/orchestrator/verify.py
@@ -204,6 +204,92 @@ def _drain_verify_output(proc: subprocess.Popen) -> tuple[str, str]:
     return drained if drained is not None else ("", "")
 
 
+def _spawn_verify_command(
+    worktree: Path, command: str, child_env: dict[str, str],
+) -> subprocess.Popen:
+    """Start one verify shell in the process group used for bounded cleanup."""
+    return subprocess.Popen(
+        command,
+        shell=True,
+        cwd=str(worktree),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+        env=child_env,
+    )
+
+
+def _timeout_verify_result(
+    proc: subprocess.Popen, command: str,
+) -> VerifyResult:
+    """Kill a timed-out verify group and retain its bounded partial output."""
+    _kill_verify_group(proc)
+    partial_output = _combine_output(*_drain_verify_output(proc))
+    return VerifyResult(
+        status="timeout",
+        command=command,
+        exit_code=None,
+        output=_truncate_verify_output(partial_output),
+    )
+
+
+def _completed_verify_result(
+    proc: subprocess.Popen,
+    command: str,
+    drained: tuple[str, str],
+    worktree: Path,
+    head_before: str,
+) -> Optional[VerifyResult]:
+    """Classify one completed command, returning None only when it passed."""
+    combined_output = _combine_output(*drained)
+    if proc.returncode != 0:
+        return VerifyResult(
+            status="failed",
+            command=command,
+            exit_code=proc.returncode,
+            output=_truncate_verify_output(combined_output),
+        )
+    dirty_files = _worktree_dirty_files(worktree)
+    if dirty_files:
+        return VerifyResult(
+            status="dirty",
+            command=command,
+            exit_code=proc.returncode,
+            output=_truncate_verify_output(combined_output),
+            dirty_files=tuple(dirty_files),
+        )
+    head_after = _head_sha(worktree)
+    if head_after == head_before:
+        return None
+    return VerifyResult(
+        status="head_changed",
+        command=command,
+        exit_code=proc.returncode,
+        output=_truncate_verify_output(combined_output),
+        head_before=head_before,
+        head_after=head_after,
+    )
+
+
+def _run_verify_command(
+    worktree: Path,
+    command: str,
+    timeout: int,
+    child_env: dict[str, str],
+    head_before: str,
+) -> Optional[VerifyResult]:
+    """Run and classify one command while registering its process group."""
+    proc = _spawn_verify_command(worktree, command, child_env)
+    with _registered(proc):
+        drained = _communicate_bounded(proc, timeout)
+        if drained is None:
+            return _timeout_verify_result(proc, command)
+        return _completed_verify_result(
+            proc, command, drained, worktree, head_before,
+        )
+
+
 def _run_verify_commands(
     worktree: Path,
     commands: tuple[str, ...],
@@ -264,88 +350,11 @@ def _run_verify_commands(
     # comment publishes `verify.command` verbatim on the issue.
     child_env = _filter_agent_env(dict(os.environ), allow_provider_auth=False)
     for command in commands:
-        # `start_new_session=True` puts the shell in its own process
-        # group (and session) so a timeout-kill can tear down EVERY
-        # descendant in one `killpg` call. Without this, the
-        # `subprocess.run(..., shell=True, timeout=...)` shape only
-        # SIGKILLs the shell; a `make -j` worker, a `pytest-xdist`
-        # forker, or a backgrounded `&` subprocess survives the shell
-        # and can keep mutating the worktree AFTER the orchestrator has
-        # already posted `verify_timeout` and parked the issue. That
-        # silently violates the bounded-timeout gate the operator
-        # configured and can race the orchestrator's own next-tick
-        # reads.
-        proc = subprocess.Popen(
-            command,
-            shell=True,
-            cwd=str(worktree),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            start_new_session=True,
-            env=child_env,
+        failure = _run_verify_command(
+            worktree, command, timeout, child_env, head_before,
         )
-        # Register the group so the orchestrator's shutdown sweep
-        # (`agents.terminate_all_running`) can SIGTERM/SIGKILL it. Without
-        # this a slow verify command is invisible to the sweep and survives
-        # the shutdown watchdog's `os._exit`, going on to mutate the worktree
-        # after the orchestrator has stopped -- the same bounded-lifetime
-        # guarantee the agent subprocesses already get. `start_new_session=
-        # True` above makes `proc.pid` the group leader the sweep targets;
-        # `_registered` clears the registry so a completed command does not
-        # leak into it.
-        with _registered(proc):
-            drained = _communicate_bounded(proc, timeout)
-            if drained is None:
-                _kill_verify_group(proc)
-                partial = _combine_output(*_drain_verify_output(proc))
-                return VerifyResult(
-                    status="timeout",
-                    command=command,
-                    exit_code=None,
-                    output=_truncate_verify_output(partial),
-                )
-            combined = _combine_output(*drained)
-            if proc.returncode != 0:
-                return VerifyResult(
-                    status="failed",
-                    command=command,
-                    exit_code=proc.returncode,
-                    output=_truncate_verify_output(combined),
-                )
-            # Check dirtiness PER COMMAND so a dirty failure can be
-            # attributed to the actual command that produced the
-            # untracked/modified files and surface that command's stdout/
-            # stderr in the park comment. A single end-of-loop check would
-            # always blame `commands[-1]` even when an earlier command was
-            # the cause, and would have already lost its captured output
-            # by the time we got here.
-            dirty = _worktree_dirty_files(worktree)
-            if dirty:
-                return VerifyResult(
-                    status="dirty",
-                    command=command,
-                    exit_code=proc.returncode,
-                    output=_truncate_verify_output(combined),
-                    dirty_files=tuple(dirty),
-                )
-            # HEAD-movement check. A verify command that `git commit`s its
-            # own auto-fix leaves `git status` clean and exits 0 -- looking
-            # identical to a passing gate -- yet the squash-on-approval +
-            # force-push that follows would publish that unreviewed commit.
-            # Fail the gate so the operator decides whether the auto-commit
-            # belongs in the PR (re-spawn the reviewer) or should be
-            # reverted before re-trying.
-            head_after = _head_sha(worktree)
-            if head_after != head_before:
-                return VerifyResult(
-                    status="head_changed",
-                    command=command,
-                    exit_code=proc.returncode,
-                    output=_truncate_verify_output(combined),
-                    head_before=head_before,
-                    head_after=head_after,
-                )
+        if failure is not None:
+            return failure
     return VerifyResult(status="ok")
 
 

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -729,14 +729,15 @@ def _accumulate_issue_usage(
     if usage is None:
         return
 
-    state.set("issue_agent_runs", int(state.get("issue_agent_runs") or 0) + 1)
+    agent_runs = int(state.get("issue_agent_runs") or 0)
+    state.set("issue_agent_runs", agent_runs + 1)
 
-    tokens = (
-        usage.input_tokens
-        + usage.output_tokens
-        + usage.cache_read_tokens
-        + usage.cache_write_tokens
-    )
+    tokens = sum((
+        usage.input_tokens,
+        usage.output_tokens,
+        usage.cache_read_tokens,
+        usage.cache_write_tokens,
+    ))
     state.set(
         "issue_total_tokens",
         int(state.get("issue_total_tokens") or 0) + tokens,

--- a/orchestrator/workflow_drift.py
+++ b/orchestrator/workflow_drift.py
@@ -33,6 +33,7 @@ import hashlib
 from typing import Optional
 
 from github.Issue import Issue
+from github.IssueComment import IssueComment
 
 from orchestrator.comment_trust import is_trusted_author
 from orchestrator.state_machine import WorkflowLabel
@@ -45,6 +46,31 @@ from orchestrator.workflow_messages import (
     _orchestrator_ids,
     _post_issue_comment,
 )
+
+
+def _comment_body_for_hash(
+    issue_comment: IssueComment,
+    orchestrator_ids: set[int],
+    *,
+    include_bare_continue: bool,
+) -> Optional[str]:
+    """Return user-authored requirements text, or None for filtered content."""
+    body = issue_comment.body or ""
+    if PINNED_STATE_MARKER in body or _ORCH_COMMENT_MARKER in body:
+        return None
+    comment_id = getattr(issue_comment, "id", None)
+    if comment_id is not None and int(comment_id) in orchestrator_ids:
+        return None
+    user = getattr(issue_comment, "user", None)
+    if user is not None and getattr(user, "type", None) == "Bot":
+        return None
+    if not is_trusted_author(user):
+        return None
+    if include_bare_continue:
+        return body
+    if _is_bare_orchestrator_continue(issue_comment):
+        return None
+    return body
 
 
 def _compute_user_content_hash(
@@ -98,25 +124,13 @@ def _compute_user_content_hash(
     """
     parts = [issue.title or "", issue.body or ""]
     for issue_comment in issue.get_comments():
-        body = issue_comment.body or ""
-        if PINNED_STATE_MARKER in body:
-            continue
-        if _ORCH_COMMENT_MARKER in body:
-            continue
-        cid = getattr(issue_comment, "id", None)
-        if cid is not None and int(cid) in orchestrator_ids:
-            continue
-        user = getattr(issue_comment, "user", None)
-        if user is not None and getattr(user, "type", None) == "Bot":
-            continue
-        if not is_trusted_author(user):
-            continue
-        if (
-            not include_bare_continue
-            and _is_bare_orchestrator_continue(issue_comment)
-        ):
-            continue
-        parts.append(body)
+        comment_body = _comment_body_for_hash(
+            issue_comment,
+            orchestrator_ids,
+            include_bare_continue=include_bare_continue,
+        )
+        if comment_body is not None:
+            parts.append(comment_body)
     return hashlib.sha256("\0".join(parts).encode("utf-8")).hexdigest()
 
 
@@ -234,6 +248,43 @@ def _mark_drift_comments_consumed(
         state.set("last_action_comment_id", latest)
 
 
+def _drift_to_decomposing_notice(orphan_children: list) -> str:
+    """Build the reroute notice, including any orphaned child numbers."""
+    if not orphan_children:
+        return (
+            ":pencil2: issue content changed; re-running decomposer "
+            "against the updated body."
+        )
+    orphan_list = ", ".join(
+        f"#{child_number}" for child_number in orphan_children
+    )
+    return (
+        ":pencil2: issue content changed; re-running decomposer "
+        "against the updated body. The previously-tracked children "
+        f"({orphan_list}) will be ORPHANED -- the orchestrator no "
+        "longer tracks them; please close any that no longer apply to "
+        "the updated requirements."
+    )
+
+
+def _reset_decomposition_for_drift(
+    state: PinnedState, new_hash: str,
+) -> None:
+    """Clear manifest/session state while retaining the locked agent spec."""
+    state.set("user_content_hash", new_hash)
+    # A fresh decomposer session must keep the pinned backend so an agent-spec
+    # configuration change cannot retarget an issue already in flight.
+    state.set("decomposer_session_id", None)
+    # Empty manifest tracking prevents half-finished decomposition recovery
+    # from treating the intentional reroute as a crashed split.
+    state.set("children", [])
+    state.set("dep_graph", {})
+    state.set("expected_children_count", None)
+    state.set("umbrella", None)
+    state.set("awaiting_human", False)
+    state.set("park_reason", None)
+
+
 def _route_drift_to_decomposing(
     gh: GitHubClient,
     issue: Issue,
@@ -255,42 +306,7 @@ def _route_drift_to_decomposing(
 
     Caller writes pinned state (`gh.write_pinned_state`) after returning.
     """
-    if orphan_children:
-        orphan_list = ", ".join(
-            f"#{child_number}" for child_number in orphan_children
-        )
-        notice = (
-            ":pencil2: issue content changed; re-running decomposer "
-            "against the updated body. The previously-tracked children "
-            f"({orphan_list}) will be ORPHANED -- the orchestrator no "
-            "longer tracks them; please close any that no longer apply to "
-            "the updated requirements."
-        )
-    else:
-        notice = (
-            ":pencil2: issue content changed; re-running decomposer "
-            "against the updated body."
-        )
+    notice = _drift_to_decomposing_notice(orphan_children)
     _post_issue_comment(gh, issue, state, notice)
-    state.set("user_content_hash", new_hash)
-    # Clear `decomposer_session_id` so the next tick spawns a FRESH
-    # decomposer session (deriving a new manifest against the updated
-    # body, not resuming the prior session with only the human's reply).
-    # Deliberately PRESERVE `decomposer_agent`: once the role's spec has
-    # been recorded on this issue it is locked for the rest of its
-    # lifecycle, even across drift events. A config flip (e.g.
-    # `DECOMPOSE_AGENT=codex -> claude`) between ticks must not retarget
-    # an in-flight issue at a different backend; `_read_decomposer_session`
-    # uses the recorded spec, so the fresh spawn picks up where the old
-    # one left off and the FullSpecPersistenceTest contract holds.
-    state.set("decomposer_session_id", None)
-    # Wipe the manifest tracking so `_handle_decomposing`'s half-finished
-    # recovery branch does not fire on the next tick (it keys on
-    # `expected_children_count` or a non-empty `children` list).
-    state.set("children", [])
-    state.set("dep_graph", {})
-    state.set("expected_children_count", None)
-    state.set("umbrella", None)
-    state.set("awaiting_human", False)
-    state.set("park_reason", None)
+    _reset_decomposition_for_drift(state, new_hash)
     gh.set_workflow_label(issue, WorkflowLabel.DECOMPOSING)

--- a/orchestrator/workflow_messages.py
+++ b/orchestrator/workflow_messages.py
@@ -263,6 +263,33 @@ _SECRET_KEY_NAMES = frozenset({
 _REDACT_MIN_VALUE_LEN = 8
 
 
+def _is_secret_environment_value(key: str, value: str) -> bool:
+    """Whether an environment entry is shaped like a usable secret."""
+    if not value or len(value) < _REDACT_MIN_VALUE_LEN:
+        return False
+    upper_key = key.upper()
+    return upper_key in _SECRET_KEY_NAMES or any(
+        upper_key.endswith(suffix) for suffix in _SECRET_KEY_SUFFIXES
+    )
+
+
+def _redact_environment_secrets(text: str) -> str:
+    """Replace every secret-shaped process environment value."""
+    redacted = text
+    for key, env_value in os.environ.items():
+        if _is_secret_environment_value(key, env_value):
+            redacted = redacted.replace(env_value, "***")
+    return redacted
+
+
+def _redact_configured_github_token(text: str) -> str:
+    """Redact the PAT even when it came from a token file, not the env."""
+    token = config.GITHUB_TOKEN
+    if token and len(token) >= _REDACT_MIN_VALUE_LEN:
+        return text.replace(token, "***")
+    return text
+
+
 def _redact_secrets(text: str) -> str:
     """Replace values of secret-shaped env vars in `text` with `***`.
 
@@ -275,24 +302,13 @@ def _redact_secrets(text: str) -> str:
     """
     if not text:
         return text
-    redacted = text
-    for key, env_value in os.environ.items():
-        if not env_value or len(env_value) < _REDACT_MIN_VALUE_LEN:
-            continue
-        upper = key.upper()
-        if upper in _SECRET_KEY_NAMES or any(
-            upper.endswith(suffix) for suffix in _SECRET_KEY_SUFFIXES
-        ):
-            redacted = redacted.replace(env_value, "***")
     # GITHUB_TOKEN may have been resolved from ORCHESTRATOR_TOKEN_FILE (or
     # the default ~/.config/<repo>/token path) rather than the process env,
-    # in which case the env loop above never sees it. Without this explicit
-    # pass, a prompt-injected command that cat'd that file -- or any git/gh
-    # subprocess stderr quoting the token -- would publish it unredacted.
-    token = config.GITHUB_TOKEN
-    if token and len(token) >= _REDACT_MIN_VALUE_LEN:
-        redacted = redacted.replace(token, "***")
-    return redacted
+    # in which case the environment scan never sees it. The explicit token
+    # pass also covers git/gh stderr that quotes a file-backed credential.
+    return _redact_configured_github_token(
+        _redact_environment_secrets(text)
+    )
 
 
 def _format_stderr_diagnostics(
@@ -590,6 +606,168 @@ _MANIFEST_RE = re.compile(
 _MAX_CHILDREN = 10
 
 
+def _extract_manifest_payload(
+    last_message: str,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Extract the one final fenced manifest payload from an agent reply."""
+    if not last_message:
+        return None, None
+    # The prompt requires exactly one final fenced block. Accepting the first
+    # match would let a quoted sample manifest override the agent's answer.
+    matches = list(_MANIFEST_RE.finditer(last_message))
+    if not matches:
+        return None, None
+    if len(matches) > 1:
+        return None, (
+            f"expected exactly one orchestrator-manifest block, "
+            f"found {len(matches)}"
+        )
+    manifest_match = matches[0]
+    if last_message[manifest_match.end():].strip():
+        return None, (
+            "orchestrator-manifest must be the final block; "
+            "found content after the closing fence"
+        )
+    return manifest_match.group(1), None
+
+
+def _decode_manifest(
+    payload: str,
+) -> Tuple[Optional[dict], Optional[str]]:
+    """Decode a manifest payload and require a JSON object."""
+    try:
+        manifest = json.loads(payload)
+    except json.JSONDecodeError as error:
+        return None, f"invalid JSON: {error.msg}"
+    if not isinstance(manifest, dict):
+        return None, "manifest is not a JSON object"
+    return manifest, None
+
+
+def _split_manifest_children(
+    manifest: dict,
+) -> Tuple[Optional[list], Optional[str]]:
+    """Return the bounded, non-empty children list for a split decision."""
+    children = manifest.get("children")
+    if not isinstance(children, list) or not children:
+        return None, "split decision requires non-empty children list"
+    if len(children) > _MAX_CHILDREN:
+        return None, f"too many children ({len(children)} > {_MAX_CHILDREN})"
+    return children, None
+
+
+def _manifest_umbrella_error(manifest: dict) -> Optional[str]:
+    """Validate the optional umbrella flag without truthy coercion."""
+    umbrella = manifest.get("umbrella")
+    if umbrella is not None and not isinstance(umbrella, bool):
+        return "umbrella must be a boolean"
+    return None
+
+
+def _is_nonempty_text(value: object) -> bool:
+    return isinstance(value, str) and bool(value)
+
+
+def _manifest_child_text_error(
+    child: object, child_index: int,
+) -> Optional[str]:
+    """Validate one child object and its required text fields."""
+    if not isinstance(child, dict):
+        return f"child {child_index} is not an object"
+    if not _is_nonempty_text(child.get("title")):
+        return f"child {child_index} missing title or body"
+    if not _is_nonempty_text(child.get("body")):
+        return f"child {child_index} missing title or body"
+    return None
+
+
+def _manifest_child_dependencies(
+    child: dict, child_index: int,
+) -> Tuple[Optional[list], Optional[str]]:
+    """Normalize null dependencies and reject every other non-list shape."""
+    dependencies = child.get("depends_on")
+    if dependencies is None:
+        return [], None
+    if not isinstance(dependencies, list):
+        return None, f"child {child_index} depends_on must be a list"
+    return dependencies, None
+
+
+def _is_valid_dependency(
+    dependency_index: object,
+    *,
+    child_index: int,
+    child_count: int,
+) -> bool:
+    """Validate type, bounds, and the no-self-edge invariant."""
+    if isinstance(dependency_index, bool):
+        return False
+    if not isinstance(dependency_index, int):
+        return False
+    if dependency_index < 0 or dependency_index >= child_count:
+        return False
+    return dependency_index != child_index
+
+
+def _manifest_child_error(
+    child: object, child_index: int, child_count: int,
+) -> Optional[str]:
+    """Return the first structural error for one split child."""
+    text_error = _manifest_child_text_error(child, child_index)
+    if text_error is not None:
+        return text_error
+    dependencies, dependency_error = _manifest_child_dependencies(
+        child, child_index,
+    )
+    if dependency_error is not None:
+        return dependency_error
+    for dependency_index in dependencies or []:
+        if not _is_valid_dependency(
+            dependency_index,
+            child_index=child_index,
+            child_count=child_count,
+        ):
+            return (
+                f"child {child_index} has invalid dependency "
+                f"{dependency_index!r}"
+            )
+    return None
+
+
+def _manifest_children_error(children: list) -> Optional[str]:
+    """Validate every child and then the dependency graph as a whole."""
+    for child_index, child in enumerate(children):
+        child_error = _manifest_child_error(
+            child, child_index, len(children),
+        )
+        if child_error is not None:
+            return child_error
+    if _has_dep_cycle(children):
+        return "dependency graph has a cycle"
+    return None
+
+
+def _split_manifest_error(manifest: dict) -> Optional[str]:
+    """Return the first split-only manifest validation error."""
+    children, children_error = _split_manifest_children(manifest)
+    if children_error is not None:
+        return children_error
+    umbrella_error = _manifest_umbrella_error(manifest)
+    if umbrella_error is not None:
+        return umbrella_error
+    return _manifest_children_error(children or [])
+
+
+def _manifest_validation_error(manifest: dict) -> Optional[str]:
+    """Validate the decision and its split-only payload when applicable."""
+    decision = manifest.get("decision")
+    if decision not in ("single", "split"):
+        return "decision must be 'single' or 'split'"
+    if decision == "single":
+        return None
+    return _split_manifest_error(manifest)
+
+
 def _parse_manifest(
     last_message: str,
 ) -> Tuple[Optional[dict], Optional[str]]:
@@ -608,98 +786,15 @@ def _parse_manifest(
       * `(None, None)` -- no fenced block at all. The caller treats this as
         "agent ended without a manifest" and parks as a question.
     """
-    if not last_message:
-        return None, None
-    matches = list(_MANIFEST_RE.finditer(last_message))
-    if not matches:
-        return None, None
-    # The decompose prompt mandates "EXACTLY ONE fenced JSON block ...
-    # and nothing else after it". `re.search` would silently accept the
-    # first fence and ignore the rest, so a decomposer that quotes a
-    # sample/template manifest before its real final answer would have
-    # the orchestrator act on the sample -- creating wrong child issues
-    # or routing the parent on a stale decision. Reject multiple fences
-    # and require the accepted one to be the final block (whitespace
-    # after the closing fence only).
-    if len(matches) > 1:
-        return None, (
-            f"expected exactly one orchestrator-manifest block, "
-            f"found {len(matches)}"
-        )
-    manifest_match = matches[0]
-    if last_message[manifest_match.end():].strip():
-        return None, (
-            "orchestrator-manifest must be the final block; "
-            "found content after the closing fence"
-        )
-    try:
-        manifest = json.loads(manifest_match.group(1))
-    except json.JSONDecodeError as error:
-        return None, f"invalid JSON: {error.msg}"
-    if not isinstance(manifest, dict):
-        return None, "manifest is not a JSON object"
-    decision = manifest.get("decision")
-    if decision not in ("single", "split"):
-        return None, "decision must be 'single' or 'split'"
-    if decision == "single":
-        return manifest, None
-    children = manifest.get("children")
-    if not isinstance(children, list) or not children:
-        return None, "split decision requires non-empty children list"
-    if len(children) > _MAX_CHILDREN:
-        return None, (
-            f"too many children ({len(children)} > {_MAX_CHILDREN})"
-        )
-    # Optional umbrella flag: when true, the parent issue itself has no
-    # implementation work -- it's a tracking issue whose only purpose is
-    # to aggregate children. Reject non-bool values rather than coercing
-    # so a typo like `"umbrella": "yes"` surfaces via the standard
-    # invalid-manifest HITL loop instead of silently being treated as
-    # truthy.
-    umbrella = manifest.get("umbrella")
-    if umbrella is not None and not isinstance(umbrella, bool):
-        return None, "umbrella must be a boolean"
-    for idx, child in enumerate(children):
-        if not isinstance(child, dict):
-            return None, f"child {idx} is not an object"
-        title = child.get("title")
-        body = child.get("body")
-        # Truthiness alone is not enough: `"body": 42` is truthy but
-        # would later blow up `create_child_issue` (which calls
-        # `body.rstrip()`) AFTER `expected_children_count` is persisted,
-        # forcing the half-finished-recovery path. Reject non-string
-        # values up front so the standard "invalid manifest" HITL/resume
-        # loop handles it cleanly.
-        if (
-            not isinstance(title, str) or not title
-            or not isinstance(body, str) or not body
-        ):
-            return None, f"child {idx} missing title or body"
-        # Treat missing key and explicit JSON null as "no dependencies"
-        # (same intent), but reject any other non-list value. The
-        # earlier `child.get("depends_on") or []` collapsed every
-        # falsy scalar (0, False, "") to [] before the list-type
-        # check, so a manifest like `{"depends_on": 0}` -- a clear
-        # malformed list -- was silently accepted as no-deps and the
-        # child activated out of dependency order.
-        deps = child.get("depends_on")
-        if deps is None:
-            deps = []
-        elif not isinstance(deps, list):
-            return None, f"child {idx} depends_on must be a list"
-        for dependency_index in deps:
-            if (
-                not isinstance(dependency_index, int)
-                or isinstance(dependency_index, bool)
-                or dependency_index < 0
-                or dependency_index >= len(children)
-                or dependency_index == idx
-            ):
-                return None, (
-                    f"child {idx} has invalid dependency {dependency_index!r}"
-                )
-    if _has_dep_cycle(children):
-        return None, "dependency graph has a cycle"
+    payload, payload_error = _extract_manifest_payload(last_message)
+    if payload is None:
+        return None, payload_error
+    manifest, decode_error = _decode_manifest(payload)
+    if manifest is None:
+        return None, decode_error
+    validation_error = _manifest_validation_error(manifest)
+    if validation_error is not None:
+        return None, validation_error
     return manifest, None
 
 
@@ -735,6 +830,18 @@ def _has_dep_cycle(children: list[dict]) -> bool:
     )
 
 
+def _prompt_comment_chunk(issue_comment: object) -> Optional[str]:
+    """Format one trusted, non-state issue comment for an agent prompt."""
+    body = getattr(issue_comment, "body", None) or ""
+    if "<!--orchestrator-state" in body:
+        return None
+    user = getattr(issue_comment, "user", None)
+    if not is_trusted_author(user):
+        return None
+    login = user.login if user else "user"
+    return f"@{login}: {body}"
+
+
 def _recent_comments_text(issue: Issue, max_chars: int = 4000) -> str:
     """Conversation text fed to every agent prompt (implement, review,
     documentation, decompose, question, and the drift-resume prompt).
@@ -748,13 +855,9 @@ def _recent_comments_text(issue: Issue, max_chars: int = 4000) -> str:
     """
     chunks: list[str] = []
     for issue_comment in issue.get_comments():
-        body = issue_comment.body or ""
-        if "<!--orchestrator-state" in body:
-            continue
-        if not is_trusted_author(getattr(issue_comment, "user", None)):
-            continue
-        login = issue_comment.user.login if issue_comment.user else "user"
-        chunks.append(f"@{login}: {body}")
+        chunk = _prompt_comment_chunk(issue_comment)
+        if chunk is not None:
+            chunks.append(chunk)
     text = "\n\n".join(chunks)
     return text[-max_chars:] if len(text) > max_chars else text
 
@@ -990,6 +1093,27 @@ def _build_decompose_prompt(
     )
 
 
+def _single_manifest_text(
+    manifest: dict, field_name: str, fallback: str = "",
+) -> str:
+    """Return one stripped optional text field with a safe fallback."""
+    raw_value = manifest.get(field_name)
+    text = raw_value.strip() if isinstance(raw_value, str) else ""
+    return text or fallback
+
+
+def _single_manifest_files(manifest: dict) -> list[str]:
+    """Return non-empty string paths from optional single-decision context."""
+    raw_files = manifest.get("affected_files")
+    if not isinstance(raw_files, list):
+        return []
+    return [
+        file_path.strip()
+        for file_path in raw_files
+        if isinstance(file_path, str) and file_path.strip()
+    ]
+
+
 def _build_single_decision_comment(manifest: dict) -> str:
     """Compose the `single`-decision comment posted on the parent issue.
 
@@ -1009,27 +1133,17 @@ def _build_single_decision_comment(manifest: dict) -> str:
     non-strings / non-lists to empty rather than parking a valid single
     decision after the agent already ran.
     """
-    raw_rationale = manifest.get("rationale")
-    if not isinstance(raw_rationale, str):
-        raw_rationale = ""
-    rationale = raw_rationale.strip() or "(no rationale provided)"
+    rationale = _single_manifest_text(
+        manifest, "rationale", "(no rationale provided)",
+    )
     lines = [f":mag: decomposer says this fits one context: {rationale}"]
 
-    raw_files = manifest.get("affected_files")
-    files = (
-        [
-            file_path.strip()
-            for file_path in raw_files
-            if isinstance(file_path, str) and file_path.strip()
-        ]
-        if isinstance(raw_files, list) else []
-    )
+    files = _single_manifest_files(manifest)
     if files:
         rendered = "\n".join(f"- `{file_path}`" for file_path in files)
         lines.append(f"**Affected files:**\n{rendered}")
 
-    raw_notes = manifest.get("notes")
-    notes = raw_notes.strip() if isinstance(raw_notes, str) else ""
+    notes = _single_manifest_text(manifest, "notes")
     if notes:
         lines.append(f"**Implementation notes:**\n{notes}")
 

--- a/orchestrator/worktree_lifecycle.py
+++ b/orchestrator/worktree_lifecycle.py
@@ -75,6 +75,13 @@ def _sanitize_slug(slug: str) -> str:
     return cleaned
 
 
+def _slug_digest(slug: str) -> str:
+    """Return the short content digest used for lossy ref rewrites."""
+    encoded_slug = (slug or "").encode("utf-8")
+    slug_hash = hashlib.sha1(encoded_slug)
+    return slug_hash.hexdigest()[:16]
+
+
 def _sanitize_branch_segment(slug: str) -> str:
     """Make a slug safe for use as a single git branch-name segment.
 
@@ -148,7 +155,7 @@ def _sanitize_branch_segment(slug: str) -> str:
     # without this, two `REPOS` entries sharing a `target_root`
     # would collide on the same branch and the slug-namespacing
     # fix would silently regress for those slug shapes.
-    digest = hashlib.sha1((slug or "").encode("utf-8")).hexdigest()[:16]
+    digest = _slug_digest(slug)
     return f"{sanitized_segment}__h{digest}"
 
 
@@ -516,39 +523,110 @@ def _branch_has_unpushed_commits(
     `RLock` re-entry keeps callers that already hold the lock
     safe.
     """
-    namespaced = _branch_name(spec, issue_number)
-    legacy = f"orchestrator/issue-{issue_number}"
-    # Probe the namespaced form first so a worktree created after
-    # slug-namespacing is named in the operator message before any
-    # surviving legacy ref. Dedup so a deployment whose sanitized
-    # slug somehow produced the legacy form does not double-probe.
-    candidates: list[str] = [namespaced]
-    if legacy != namespaced:
-        candidates.append(legacy)
+    candidates = _candidate_issue_branches(spec, issue_number)
     base_ref = f"refs/remotes/{spec.remote_name}/{spec.base_branch}"
     with _target_root_lock(spec.target_root):
         for branch in candidates:
-            have_local = _git(
-                "rev-parse", "--verify", "--quiet",
-                f"refs/heads/{branch}",
-                cwd=spec.target_root,
-            ).returncode == 0
-            if not have_local:
-                continue
-            commit_count_result = _git(
-                "rev-list", "--count",
-                f"{base_ref}..refs/heads/{branch}",
-                cwd=spec.target_root,
-            )
-            if commit_count_result.returncode != 0:
-                continue
-            try:
-                count = int((commit_count_result.stdout or "0").strip() or "0")
-            except ValueError:
-                continue
+            count = _branch_commit_count(spec, branch, base_ref)
             if count > 0:
                 return branch
     return None
+
+
+def _candidate_issue_branches(
+    spec: RepoSpec, issue_number: int,
+) -> tuple[str, ...]:
+    """Return namespaced then legacy branch candidates without duplicates."""
+    namespaced = _branch_name(spec, issue_number)
+    legacy = f"orchestrator/issue-{issue_number}"
+    if legacy == namespaced:
+        return (namespaced,)
+    return namespaced, legacy
+
+
+def _branch_commit_count(
+    spec: RepoSpec, branch: str, base_ref: str,
+) -> int:
+    """Return commits unique to a local branch, or zero on probe failure."""
+    local_ref = f"refs/heads/{branch}"
+    have_local = _git(
+        "rev-parse", "--verify", "--quiet", local_ref,
+        cwd=spec.target_root,
+    ).returncode == 0
+    if not have_local:
+        return 0
+    commit_count_result = _git(
+        "rev-list", "--count", f"{base_ref}..{local_ref}",
+        cwd=spec.target_root,
+    )
+    if commit_count_result.returncode != 0:
+        return 0
+    try:
+        return int((commit_count_result.stdout or "0").strip() or "0")
+    except ValueError:
+        return 0
+
+
+def _remove_issue_worktree(
+    spec: RepoSpec, issue_number: int, *, log_prefix: str = "",
+) -> None:
+    """Best-effort removal of one issue worktree under the parent lock."""
+    try:
+        worktree = _worktree_path(spec, issue_number)
+        if not worktree.exists():
+            return
+        with _target_root_lock(spec.target_root):
+            remove_result = _git(
+                "worktree", "remove", "--force", str(worktree),
+                cwd=spec.target_root,
+            )
+        if remove_result.returncode != 0:
+            log.warning(
+                "issue=#%d %sworktree remove failed: %s",
+                issue_number,
+                log_prefix,
+                (remove_result.stderr or "").strip(),
+            )
+    except Exception:
+        log.exception(
+            "issue=#%d %sworktree remove raised", issue_number, log_prefix,
+        )
+
+
+def _delete_local_issue_branch(
+    spec: RepoSpec,
+    issue_number: int,
+    branch: str,
+    *,
+    log_prefix: str = "",
+) -> None:
+    """Best-effort deletion of one local issue branch under the parent lock."""
+    try:
+        with _target_root_lock(spec.target_root):
+            have_local = _git(
+                "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}",
+                cwd=spec.target_root,
+            ).returncode == 0
+            if not have_local:
+                return
+            delete_result = _git(
+                "branch", "-D", branch, cwd=spec.target_root,
+            )
+        if delete_result.returncode != 0:
+            log.warning(
+                "issue=#%d %slocal branch %r delete failed: %s",
+                issue_number,
+                log_prefix,
+                branch,
+                (delete_result.stderr or "").strip(),
+            )
+    except Exception:
+        log.exception(
+            "issue=#%d %slocal branch %r delete raised",
+            issue_number,
+            log_prefix,
+            branch,
+        )
 
 
 def _cleanup_question_worktree(
@@ -590,46 +668,10 @@ def _cleanup_question_worktree(
     """
     if branch is None:
         branch = _branch_name(spec, issue_number)
-    try:
-        wt = _worktree_path(spec, issue_number)
-        if wt.exists():
-            with _target_root_lock(spec.target_root):
-                remove_result = _git(
-                    "worktree", "remove", "--force", str(wt),
-                    cwd=spec.target_root,
-                )
-            if remove_result.returncode != 0:
-                log.warning(
-                    "issue=#%d question worktree remove failed: %s",
-                    issue_number, (remove_result.stderr or "").strip(),
-                )
-    except Exception:
-        log.exception(
-            "issue=#%d question worktree remove raised", issue_number,
-        )
-
-    try:
-        with _target_root_lock(spec.target_root):
-            have_local = _git(
-                "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}",
-                cwd=spec.target_root,
-            ).returncode == 0
-            if have_local:
-                delete_result = _git(
-                    "branch", "-D", branch, cwd=spec.target_root,
-                )
-                if delete_result.returncode != 0:
-                    log.warning(
-                        "issue=#%d question local branch %r delete failed: %s",
-                        issue_number,
-                        branch,
-                        (delete_result.stderr or "").strip(),
-                    )
-    except Exception:
-        log.exception(
-            "issue=#%d question local branch %r delete raised",
-            issue_number, branch,
-        )
+    _remove_issue_worktree(spec, issue_number, log_prefix="question ")
+    _delete_local_issue_branch(
+        spec, issue_number, branch, log_prefix="question ",
+    )
 
 
 def _cleanup_terminal_branch(
@@ -676,50 +718,10 @@ def _cleanup_terminal_branch(
     if branch is None:
         branch = _branch_name(spec, issue_number)
 
-    # Each step is wrapped individually: a raise from `_git` (missing
-    # `spec.target_root`, missing `git` binary, OSError) or from the
-    # `Path.exists()` probe must not skip the later steps, since the
-    # caller has already written the terminal pinned state and expects
-    # cleanup to never propagate.
-    try:
-        wt = _worktree_path(spec, issue_number)
-        if wt.exists():
-            with _target_root_lock(spec.target_root):
-                remove_result = _git(
-                    "worktree", "remove", "--force", str(wt),
-                    cwd=spec.target_root,
-                )
-            if remove_result.returncode != 0:
-                log.warning(
-                    "issue=#%d worktree remove failed: %s",
-                    issue_number, (remove_result.stderr or "").strip(),
-                )
-    except Exception:
-        log.exception(
-            "issue=#%d worktree remove raised", issue_number,
-        )
-
-    try:
-        with _target_root_lock(spec.target_root):
-            have_local = _git(
-                "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}",
-                cwd=spec.target_root,
-            ).returncode == 0
-            if have_local:
-                delete_result = _git(
-                    "branch", "-D", branch, cwd=spec.target_root,
-                )
-                if delete_result.returncode != 0:
-                    log.warning(
-                        "issue=#%d local branch %r delete failed: %s",
-                        issue_number,
-                        branch,
-                        (delete_result.stderr or "").strip(),
-                    )
-    except Exception:
-        log.exception(
-            "issue=#%d local branch %r delete raised", issue_number, branch,
-        )
+    # Each helper contains its own exception boundary so a local failure
+    # cannot skip the next cleanup surface.
+    _remove_issue_worktree(spec, issue_number)
+    _delete_local_issue_branch(spec, issue_number, branch)
 
     try:
         gh.delete_remote_branch(branch)

--- a/plans/linter-remediation.md
+++ b/plans/linter-remediation.md
@@ -41,7 +41,7 @@ Do not mark a stage complete until its completion gate is satisfied.
 |---|---|---:|---:|
 | 1 | Concrete formatting and correctness cleanup | 9/9 | [x] |
 | 2 | Extreme production complexity hotspots | 8/8 | [x] |
-| 3 | Remaining production complexity | 2/6 | [ ] |
+| 3 | Remaining production complexity | 3/6 | [ ] |
 | 4 | Remaining production style and structure | 0/5 | [ ] |
 | 5 | Test structure and complexity | 0/7 | [ ] |
 | 6 | Test literals and naming | 0/7 | [ ] |
@@ -249,8 +249,8 @@ Apply this sequence in every package:
 
 ### Package 3.3 — Agent, usage, configuration, and trajectory code
 
-- [ ] Simplify `agents.py`, `usage.py`, `main.py`, `config.py`, and `trajectory_reader.py`.
-- [ ] Preserve provider payload compatibility and subprocess-cleanup behavior.
+- [x] Simplify `agents.py`, `usage.py`, `main.py`, `config.py`, and `trajectory_reader.py`.
+- [x] Preserve provider payload compatibility and subprocess-cleanup behavior.
 
 ### Package 3.4 — Git and worktree infrastructure
 
@@ -525,10 +525,11 @@ Add one row for every implementation session, including partial sessions.
 | 2026-07-12 | 2.8 | Complete | WPS210/WPS231, 10 focused; Ruff/diff; 2099 passed, 3 skipped | None | Package 3.1 |
 | 2026-07-12 | 3.1 | Complete | Target WPS; focused; Ruff/diff; full suite | Not committed | Package 3.2 |
 | 2026-07-12 | 3.2 | Complete | Target WPS; Ruff/diff; full suite | Not committed | Package 3.3 |
+| 2026-07-13 | 3.3 | Complete | Target WPS; 360 focused; Ruff/diff; 2100 passed, 3 skipped | Not committed | Package 3.4 |
 
 Package 3.1 retained 18 reviewed API findings and passed 2,099 tests, 3 skips, and 627 subtests.
 
 Package 3.2 retained two reviewed `WPS211` compatibility findings. All 246 focused tests and 2,100 full tests passed;
 3 live-Postgres tests were skipped because `ANALYTICS_TEST_DB_URL` was unset.
 
-Packages 2.8 and 3.2 ran `tests/` because root collection was blocked by the unreadable ignored database volume.
+Packages 2.8, 3.2, and 3.3 ran `tests/` because root collection was blocked by the unreadable ignored database volume.

--- a/plans/linter-remediation.md
+++ b/plans/linter-remediation.md
@@ -41,7 +41,7 @@ Do not mark a stage complete until its completion gate is satisfied.
 |---|---|---:|---:|
 | 1 | Concrete formatting and correctness cleanup | 9/9 | [x] |
 | 2 | Extreme production complexity hotspots | 8/8 | [x] |
-| 3 | Remaining production complexity | 1/6 | [ ] |
+| 3 | Remaining production complexity | 2/6 | [ ] |
 | 4 | Remaining production style and structure | 0/5 | [ ] |
 | 5 | Test structure and complexity | 0/7 | [ ] |
 | 6 | Test literals and naming | 0/7 | [ ] |
@@ -62,7 +62,7 @@ signal between scans.
 | Standard `E...` findings | 29 | 29 | 0 |
 
 Minimum acceptable fallback: reduce the total by at least 90%, leave no production correctness or formatting
-findings, and explain every retained finding in the accepted-remainder table.
+findings, and explain every retained finding in the accepted-remainder register.
 
 ## Initial rule inventory
 
@@ -243,9 +243,9 @@ Apply this sequence in every package:
 
 ### Package 3.2 — Dashboard rendering
 
-- [ ] Simplify `dashboard.py`, `dashboard_charts.py`, `dashboard_html.py`, `dashboard_kpis.py`,
+- [x] Simplify `dashboard.py`, `dashboard_charts.py`, `dashboard_html.py`, `dashboard_kpis.py`,
   `dashboard_state.py`, `dashboard_theme.py`, and `trajectory_dashboard.py`.
-- [ ] Keep the optional dashboard dependency boundary intact.
+- [x] Keep the optional dashboard dependency boundary intact.
 
 ### Package 3.3 — Agent, usage, configuration, and trajectory code
 
@@ -271,7 +271,7 @@ Apply this sequence in every package:
 - [ ] Update the matching focused stage tests and documentation pointers after helper moves.
 
 Completion gate: no production function remains above the selected complexity limits unless recorded in the
-accepted-remainder table with a concrete contract or readability reason.
+accepted-remainder register with a concrete contract or readability reason.
 
 ## Stage 4 — Remaining production style and structure
 
@@ -423,7 +423,8 @@ Completion gate: high-volume test rules are cleared while individual test scenar
 
 ### Package 7.4 — Review accepted remainder
 
-- [ ] Challenge every entry in the accepted-remainder table and remove it if a clear implementation is now available.
+- [ ] Challenge every entry in the accepted-remainder register and remove it if a clear implementation is now
+  available.
 - [ ] Confirm each retained entry protects readability or a documented compatibility contract rather than convenience.
 
 ### Package 7.5 — Final repository validation
@@ -437,15 +438,67 @@ unexplained remainder and no production correctness or formatting findings.
 
 ## Accepted remainder
 
-Use this table only when a finding cannot be removed safely. Do not add an entry until a concrete refactor has been
+Use this register only when a finding cannot be removed safely. Do not add an entry until a concrete refactor has been
 considered.
 
-| File and symbol | Rule | Reason it must remain | Tests or contract protecting it | Reviewed |
-|---|---|---|---|---:|
-| `orchestrator/analytics/__init__.py: record_agent_exit` | `WPS211` | The explicit keyword-only run context is called by workflow code and tests; replacing it with a request object breaks the established call contract, while `**kwargs` would discard useful typing and validation. Its implementation delegates to cohesive context-based helpers. | `tests/test_analytics.py`; tracked-agent workflow callers | [x] |
-| `orchestrator/analytics/read_raw.py: get_event_breakdown, get_recent_agent_exits, get_issues, get_issue_events` | `WPS211` | These public facade readers expose one consistent keyword filter contract. A request object would break callers and `**kwargs` would weaken the API; each function delegates to a small filter/query helper. | `orchestrator/analytics/read.py`; `tests/test_analytics_read_*.py` | [x] |
-| `orchestrator/analytics/read_rollup.py: get_summary, get_kpi_prev, get_time_series, get_stage_breakdown, get_backend_efficiency, get_repo_breakdown, get_throughput_breakdown` | `WPS211` | These public facade readers expose one consistent keyword filter contract. A request object would break callers and `**kwargs` would weaken the API; each function delegates to a small filter/query helper. | `orchestrator/analytics/read.py`; `tests/test_analytics_read_*.py` | [x] |
-| `orchestrator/analytics/read_dashboard.py: get_review_round_breakdown, get_skill_trigger_rates, get_skill_trigger_matrix, get_cost_coverage, get_backend_daily_tokens, get_hourly_heatmap` | `WPS211` | These public facade readers expose one consistent keyword filter contract. A request object would break callers and `**kwargs` would weaken the API; each function delegates to a small filter/query helper. | `orchestrator/analytics/read.py`; `tests/test_analytics_read_*.py` | [x] |
+### Agent-exit analytics context
+
+- File and symbol: `orchestrator/analytics/__init__.py: record_agent_exit`
+- Rule: `WPS211`
+- Reason: The explicit keyword-only run context is called by workflow code and tests. A request object would break the
+  established call contract, while `**kwargs` would discard useful typing and validation. Cohesive context helpers own
+  the implementation.
+- Protected by: `tests/test_analytics.py` and tracked-agent workflow callers.
+- Reviewed: [x]
+
+### Raw analytics facade readers
+
+- File and symbols: `orchestrator/analytics/read_raw.py`: `get_event_breakdown`, `get_recent_agent_exits`, `get_issues`,
+  and `get_issue_events`.
+- Rule: `WPS211`
+- Reason: These public readers expose one consistent keyword filter contract. A request object would break callers and
+  `**kwargs` would weaken the API; each function delegates to a small filter/query helper.
+- Protected by: `orchestrator/analytics/read.py` and `tests/test_analytics_read_*.py`.
+- Reviewed: [x]
+
+### Rollup analytics facade readers
+
+- File and symbols: `orchestrator/analytics/read_rollup.py`: `get_summary`, `get_kpi_prev`, `get_time_series`,
+  `get_stage_breakdown`, `get_backend_efficiency`, `get_repo_breakdown`, and `get_throughput_breakdown`.
+- Rule: `WPS211`
+- Reason: These public readers expose one consistent keyword filter contract. A request object would break callers and
+  `**kwargs` would weaken the API; each function delegates to a small filter/query helper.
+- Protected by: `orchestrator/analytics/read.py` and `tests/test_analytics_read_*.py`.
+- Reviewed: [x]
+
+### Dashboard analytics facade readers
+
+- File and symbols: `orchestrator/analytics/read_dashboard.py`: `get_review_round_breakdown`,
+  `get_skill_trigger_rates`, `get_skill_trigger_matrix`, `get_cost_coverage`, `get_backend_daily_tokens`, and
+  `get_hourly_heatmap`.
+- Rule: `WPS211`
+- Reason: These public readers expose one consistent keyword filter contract. A request object would break callers and
+  `**kwargs` would weaken the API; each function delegates to a small filter/query helper.
+- Protected by: `orchestrator/analytics/read.py` and `tests/test_analytics_read_*.py`.
+- Reviewed: [x]
+
+### Dashboard topbar compatibility helper
+
+- File and symbol: `orchestrator/dashboard_html.py: _topbar_html`
+- Rule: `WPS211`
+- Reason: The six explicit keyword arguments are part of the historical `orchestrator.dashboard` export surface. A
+  request object would break callers and `**kwargs` would weaken the formatter contract.
+- Protected by: `orchestrator.dashboard.__all__` and `tests/test_dashboard.py`.
+- Reviewed: [x]
+
+### Dashboard drill-down compatibility helper
+
+- File and symbol: `orchestrator/dashboard.py: _render_drilldown`
+- Rule: `WPS211`
+- Reason: The seven explicit keyword arguments are part of the historical `orchestrator.dashboard` export surface. The
+  adapter preserves that call contract while delegating implementation to typed page/filter state.
+- Protected by: `orchestrator.dashboard.__all__` and `tests/test_dashboard.py`.
+- Reviewed: [x]
 
 ## Session log
 
@@ -470,6 +523,12 @@ Add one row for every implementation session, including partial sessions.
 | 2026-07-11 | 2.6 | Complete | Target WPS, 113 focused; Ruff/diff; 2096 passed, 3 skipped | Not committed | 2.7 |
 | 2026-07-12 | 2.7 | Complete | Target WPS, 90 focused; Ruff/diff; 2096 passed, 3 skipped | Not committed | 2.8 |
 | 2026-07-12 | 2.8 | Complete | WPS210/WPS231, 10 focused; Ruff/diff; 2099 passed, 3 skipped | None | Package 3.1 |
-| 2026-07-12 | 3.1 | Complete | Target WPS (18 reviewed API remainders); focused suites; Ruff/diff; 2099 passed, 3 skipped, 627 subtests | Not committed | Package 3.2 |
+| 2026-07-12 | 3.1 | Complete | Target WPS; focused; Ruff/diff; full suite | Not committed | Package 3.2 |
+| 2026-07-12 | 3.2 | Complete | Target WPS; Ruff/diff; full suite | Not committed | Package 3.3 |
 
-Package 2.8 ran `tests/` because root collection was blocked by the unreadable ignored database volume.
+Package 3.1 retained 18 reviewed API findings and passed 2,099 tests, 3 skips, and 627 subtests.
+
+Package 3.2 retained two reviewed `WPS211` compatibility findings. All 246 focused tests and 2,100 full tests passed;
+3 live-Postgres tests were skipped because `ANALYTICS_TEST_DB_URL` was unset.
+
+Packages 2.8 and 3.2 ran `tests/` because root collection was blocked by the unreadable ignored database volume.

--- a/plans/linter-remediation.md
+++ b/plans/linter-remediation.md
@@ -265,7 +265,8 @@ Apply this sequence in every package:
 
 ### Package 3.6 — Stage handlers
 
-- [ ] Simplify the handlers under `orchestrator/stages/` one stage at a time.
+- [x] Simplify `orchestrator/stages/decomposition.py`.
+- [ ] Simplify the remaining handlers under `orchestrator/stages/` one stage at a time.
 - [ ] Keep cross-module calls late-bound through `from .. import workflow as _wf`.
 - [ ] Keep stage-private helpers private and explicitly alias every facade re-export.
 - [ ] Update the matching focused stage tests and documentation pointers after helper moves.
@@ -567,7 +568,8 @@ Add one row for every implementation session, including partial sessions.
 | 2026-07-12 | 3.2 | Complete | Target WPS; Ruff/diff; full suite | Not committed | Package 3.3 |
 | 2026-07-13 | 3.3 | Complete | Target WPS; 360 focused; full gate | Not committed | Package 3.4 |
 | 2026-07-13 | 3.4 | Complete | WPS (3 retained); 221 focused; full gate | Not committed | Package 3.5 |
-| 2026-07-13 | 3.5 | Complete | WPS (1 retained); 217 focused; Ruff/diff; 2100 passed, 3 skipped | Not committed | Package 3.6 |
+| 2026-07-13 | 3.5 | Complete | WPS (1 retained); 217 focused; full gate | Not committed | Package 3.6 |
+| 2026-07-13 | 3.6/decomposition | Complete | Target WPS; 104 focused; full gate | Not committed | `implementing.py` |
 
 Package 3.1 retained 18 reviewed API findings and passed 2,099 tests, 3 skips, and 627 subtests.
 

--- a/plans/linter-remediation.md
+++ b/plans/linter-remediation.md
@@ -41,7 +41,7 @@ Do not mark a stage complete until its completion gate is satisfied.
 |---|---|---:|---:|
 | 1 | Concrete formatting and correctness cleanup | 9/9 | [x] |
 | 2 | Extreme production complexity hotspots | 8/8 | [x] |
-| 3 | Remaining production complexity | 4/6 | [ ] |
+| 3 | Remaining production complexity | 5/6 | [ ] |
 | 4 | Remaining production style and structure | 0/5 | [ ] |
 | 5 | Test structure and complexity | 0/7 | [ ] |
 | 6 | Test literals and naming | 0/7 | [ ] |
@@ -260,7 +260,7 @@ Apply this sequence in every package:
 
 ### Package 3.5 — GitHub, scheduling, state, and shared workflow helpers
 
-- [ ] Simplify `github.py`, `scheduler.py`, `skill_catalog.py`, `state_machine.py`, `workflow_drift.py`,
+- [x] Simplify `github.py`, `scheduler.py`, `skill_catalog.py`, `state_machine.py`, `workflow_drift.py`,
   `workflow_messages.py`, and non-facade logic still present in `workflow.py`.
 
 ### Package 3.6 — Stage handlers
@@ -441,6 +441,17 @@ unexplained remainder and no production correctness or formatting findings.
 Use this register only when a finding cannot be removed safely. Do not add an entry until a concrete refactor has been
 considered.
 
+### Issue scheduler submission API
+
+- File and symbol: `orchestrator/scheduler.py: IssueScheduler.submit`
+- Rule: `WPS211`
+- Reason: The documented submission API accepts the issue identity and callback plus three independent keyword-only
+  scheduling controls. Replacing those controls with an options object would break workflow dispatch callers and the
+  direct scheduler API used throughout its regression suite while making the common call sites less explicit. The
+  implementation immediately groups the values in `_Submission` and delegates reservation, logging, and dispatch.
+- Protected by: `orchestrator/workflow.py`, `tests/test_scheduler.py`, and `tests/test_workflow_scheduler_routing.py`.
+- Reviewed: [x]
+
 ### Agent-exit analytics context
 
 - File and symbol: `orchestrator/analytics/__init__.py: record_agent_exit`
@@ -556,6 +567,7 @@ Add one row for every implementation session, including partial sessions.
 | 2026-07-12 | 3.2 | Complete | Target WPS; Ruff/diff; full suite | Not committed | Package 3.3 |
 | 2026-07-13 | 3.3 | Complete | Target WPS; 360 focused; full gate | Not committed | Package 3.4 |
 | 2026-07-13 | 3.4 | Complete | WPS (3 retained); 221 focused; full gate | Not committed | Package 3.5 |
+| 2026-07-13 | 3.5 | Complete | WPS (1 retained); 217 focused; Ruff/diff; 2100 passed, 3 skipped | Not committed | Package 3.6 |
 
 Package 3.1 retained 18 reviewed API findings and passed 2,099 tests, 3 skips, and 627 subtests.
 
@@ -565,5 +577,8 @@ Package 3.2 retained two reviewed `WPS211` compatibility findings. All 246 focus
 Package 3.4 retained three reviewed `WPS211` compatibility findings. All 221 focused tests and 2,100 full tests
 passed; 3 live-Postgres tests were skipped because `ANALYTICS_TEST_DB_URL` was unset.
 
-Packages 2.8, 3.2, 3.3, and 3.4 ran `tests/` because root collection was blocked by the unreadable ignored database
-volume.
+Package 3.5 retained one reviewed `WPS211` compatibility finding. All 217 focused tests and 2,100 full tests passed;
+3 live-Postgres tests were skipped because `ANALYTICS_TEST_DB_URL` was unset.
+
+Packages 2.8, 3.2, 3.3, 3.4, and 3.5 ran `tests/` because root collection was blocked by the unreadable ignored
+database volume.

--- a/plans/linter-remediation.md
+++ b/plans/linter-remediation.md
@@ -41,7 +41,7 @@ Do not mark a stage complete until its completion gate is satisfied.
 |---|---|---:|---:|
 | 1 | Concrete formatting and correctness cleanup | 9/9 | [x] |
 | 2 | Extreme production complexity hotspots | 8/8 | [x] |
-| 3 | Remaining production complexity | 3/6 | [ ] |
+| 3 | Remaining production complexity | 4/6 | [ ] |
 | 4 | Remaining production style and structure | 0/5 | [ ] |
 | 5 | Test structure and complexity | 0/7 | [ ] |
 | 6 | Test literals and naming | 0/7 | [ ] |
@@ -254,9 +254,9 @@ Apply this sequence in every package:
 
 ### Package 3.4 — Git and worktree infrastructure
 
-- [ ] Simplify `base_sync.py`, `branch_publication.py`, `git_plumbing.py`, `verify.py`, and
+- [x] Simplify `base_sync.py`, `branch_publication.py`, `git_plumbing.py`, `verify.py`, and
   `worktree_lifecycle.py`.
-- [ ] Preserve authentication envelopes, lock boundaries, command order, and recovery routes.
+- [x] Preserve authentication envelopes, lock boundaries, command order, and recovery routes.
 
 ### Package 3.5 — GitHub, scheduling, state, and shared workflow helpers
 
@@ -500,6 +500,35 @@ considered.
 - Protected by: `orchestrator.dashboard.__all__` and `tests/test_dashboard.py`.
 - Reviewed: [x]
 
+### Auto-rebase recovery compatibility helper
+
+- File and symbol: `orchestrator/base_sync.py: _recover_pending_auto_base_rebase`
+- Rule: `WPS211`
+- Reason: The explicit positional and keyword-only arguments are re-exported from `orchestrator.worktrees`. Replacing
+  them with the typed recovery context would break direct callers and patch targets; the compatibility helper builds
+  that context immediately and delegates the recovery flow.
+- Protected by: `orchestrator.worktrees.__all__` and `tests/test_workflow_base_sync_unit.py`.
+- Reviewed: [x]
+
+### PR worktree synchronization compatibility helper
+
+- File and symbol: `orchestrator/base_sync.py: _sync_pr_worktree_to_base`
+- Rule: `WPS211`
+- Reason: The explicit synchronization contract is re-exported through both `orchestrator.worktrees` and
+  `orchestrator.workflow`. A request object would break existing callers and patch targets; the helper already groups
+  its implementation state in `_AutoRebaseContext`.
+- Protected by: the two compatibility facades and `tests/test_workflow_base_sync_unit.py`.
+- Reviewed: [x]
+
+### PR conflict-routing compatibility helper
+
+- File and symbol: `orchestrator/base_sync.py: _route_pr_worktree_to_resolving_conflict`
+- Rule: `WPS211`
+- Reason: The explicit routing inputs are part of the `orchestrator.worktrees` compatibility surface and map directly
+  to the persisted state and event fields. Replacing them with a request object would break callers and patch targets.
+- Protected by: `orchestrator.worktrees.__all__`, the base-sync tests, and conflict event-emission tests.
+- Reviewed: [x]
+
 ## Session log
 
 Add one row for every implementation session, including partial sessions.
@@ -525,11 +554,16 @@ Add one row for every implementation session, including partial sessions.
 | 2026-07-12 | 2.8 | Complete | WPS210/WPS231, 10 focused; Ruff/diff; 2099 passed, 3 skipped | None | Package 3.1 |
 | 2026-07-12 | 3.1 | Complete | Target WPS; focused; Ruff/diff; full suite | Not committed | Package 3.2 |
 | 2026-07-12 | 3.2 | Complete | Target WPS; Ruff/diff; full suite | Not committed | Package 3.3 |
-| 2026-07-13 | 3.3 | Complete | Target WPS; 360 focused; Ruff/diff; 2100 passed, 3 skipped | Not committed | Package 3.4 |
+| 2026-07-13 | 3.3 | Complete | Target WPS; 360 focused; full gate | Not committed | Package 3.4 |
+| 2026-07-13 | 3.4 | Complete | WPS (3 retained); 221 focused; full gate | Not committed | Package 3.5 |
 
 Package 3.1 retained 18 reviewed API findings and passed 2,099 tests, 3 skips, and 627 subtests.
 
 Package 3.2 retained two reviewed `WPS211` compatibility findings. All 246 focused tests and 2,100 full tests passed;
 3 live-Postgres tests were skipped because `ANALYTICS_TEST_DB_URL` was unset.
 
-Packages 2.8, 3.2, and 3.3 ran `tests/` because root collection was blocked by the unreadable ignored database volume.
+Package 3.4 retained three reviewed `WPS211` compatibility findings. All 221 focused tests and 2,100 full tests
+passed; 3 live-Postgres tests were skipped because `ANALYTICS_TEST_DB_URL` was unset.
+
+Packages 2.8, 3.2, 3.3, and 3.4 ran `tests/` because root collection was blocked by the unreadable ignored database
+volume.

--- a/plans/linter-remediation.md
+++ b/plans/linter-remediation.md
@@ -41,7 +41,7 @@ Do not mark a stage complete until its completion gate is satisfied.
 |---|---|---:|---:|
 | 1 | Concrete formatting and correctness cleanup | 9/9 | [x] |
 | 2 | Extreme production complexity hotspots | 8/8 | [x] |
-| 3 | Remaining production complexity | 0/6 | [ ] |
+| 3 | Remaining production complexity | 1/6 | [ ] |
 | 4 | Remaining production style and structure | 0/5 | [ ] |
 | 5 | Test structure and complexity | 0/7 | [ ] |
 | 6 | Test literals and naming | 0/7 | [ ] |
@@ -238,7 +238,7 @@ Apply this sequence in every package:
 
 ### Package 3.1 — Analytics reads and synchronization
 
-- [ ] Simplify `orchestrator/analytics/__init__.py`, `connection.py`, `predicates.py`, `query.py`,
+- [x] Simplify `orchestrator/analytics/__init__.py`, `connection.py`, `predicates.py`, `query.py`,
   `read_dashboard.py`, `read_raw.py`, `read_rollup.py`, and `sync.py`.
 
 ### Package 3.2 — Dashboard rendering
@@ -442,7 +442,10 @@ considered.
 
 | File and symbol | Rule | Reason it must remain | Tests or contract protecting it | Reviewed |
 |---|---|---|---|---:|
-| | | | | [ ] |
+| `orchestrator/analytics/__init__.py: record_agent_exit` | `WPS211` | The explicit keyword-only run context is called by workflow code and tests; replacing it with a request object breaks the established call contract, while `**kwargs` would discard useful typing and validation. Its implementation delegates to cohesive context-based helpers. | `tests/test_analytics.py`; tracked-agent workflow callers | [x] |
+| `orchestrator/analytics/read_raw.py: get_event_breakdown, get_recent_agent_exits, get_issues, get_issue_events` | `WPS211` | These public facade readers expose one consistent keyword filter contract. A request object would break callers and `**kwargs` would weaken the API; each function delegates to a small filter/query helper. | `orchestrator/analytics/read.py`; `tests/test_analytics_read_*.py` | [x] |
+| `orchestrator/analytics/read_rollup.py: get_summary, get_kpi_prev, get_time_series, get_stage_breakdown, get_backend_efficiency, get_repo_breakdown, get_throughput_breakdown` | `WPS211` | These public facade readers expose one consistent keyword filter contract. A request object would break callers and `**kwargs` would weaken the API; each function delegates to a small filter/query helper. | `orchestrator/analytics/read.py`; `tests/test_analytics_read_*.py` | [x] |
+| `orchestrator/analytics/read_dashboard.py: get_review_round_breakdown, get_skill_trigger_rates, get_skill_trigger_matrix, get_cost_coverage, get_backend_daily_tokens, get_hourly_heatmap` | `WPS211` | These public facade readers expose one consistent keyword filter contract. A request object would break callers and `**kwargs` would weaken the API; each function delegates to a small filter/query helper. | `orchestrator/analytics/read.py`; `tests/test_analytics_read_*.py` | [x] |
 
 ## Session log
 
@@ -467,5 +470,6 @@ Add one row for every implementation session, including partial sessions.
 | 2026-07-11 | 2.6 | Complete | Target WPS, 113 focused; Ruff/diff; 2096 passed, 3 skipped | Not committed | 2.7 |
 | 2026-07-12 | 2.7 | Complete | Target WPS, 90 focused; Ruff/diff; 2096 passed, 3 skipped | Not committed | 2.8 |
 | 2026-07-12 | 2.8 | Complete | WPS210/WPS231, 10 focused; Ruff/diff; 2099 passed, 3 skipped | None | Package 3.1 |
+| 2026-07-12 | 3.1 | Complete | Target WPS (18 reviewed API remainders); focused suites; Ruff/diff; 2099 passed, 3 skipped, 627 subtests | Not committed | Package 3.2 |
 
 Package 2.8 ran `tests/` because root collection was blocked by the unreadable ignored database volume.

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -282,19 +282,14 @@ def _sleep_then_return(delay: float, value: str) -> str:
 
 
 class _MainSourceTest(unittest.TestCase):
-    """Base for tests that inspect `dashboard.main`'s source (and the
-    focused read / render helpers it dispatches through) under a
-    configured DB URL.
+    """Base for source checks over the lazy entrypoint and page helpers.
 
     Streamlit / Plotly are opt-in (not installed for the default
     `uv sync --locked`), so these read the rendered function source
-    rather than driving the page under Streamlit. `main()` delegates
-    the staged read fan-out (`_widget_readers` / `_dispatch_reads`),
-    the load-timing log (`_log_dashboard_load`), and the empty / error
-    rendering branches (`_read_static_metadata`, `_render_no_data`,
-    `_render_empty_window`) to module-level helpers, so `_source_of`
-    fetches a named helper's source for the assertions that pin strings
-    living inside it.
+    rather than driving the page under Streamlit. The entrypoint loads
+    optional modules lazily and the page pipeline delegates controls,
+    read waves, empty states, and widget sections to named helpers, so
+    `_source_of` fetches the boundary each assertion protects.
     """
 
     def _main_source(self) -> str:
@@ -1592,8 +1587,8 @@ class ReliabilityTilesHtmlTest(unittest.TestCase):
 
 class BuildReadKeysTest(unittest.TestCase):
     """`_build_read_keys` composes the current + previous-window cache
-    keys the staged fan-out splats into the read wrappers (`*key` /
-    `*prev_key`), so the previous key must carry the same filters over
+    keys the staged fan-out binds to cached reader tasks, so the previous
+    key must carry the same filters over
     the immediately-preceding equal-length window.
     """
 
@@ -1672,13 +1667,15 @@ class DashboardDataPrepTest(unittest.TestCase):
         ]
 
         kpis, resolved, rejected = dashboard._build_kpi_strip_data(
-            theme=theme,
-            summary=summary,
-            prev_summary=prev_summary,
-            ts_points=ts_points,
-            throughput_rows=throughput_rows,
-            review_round_rows=review_round_rows,
-            days_in_window=2,
+            dashboard._KpiInputs(
+                theme=theme,
+                summary=summary,
+                prev_summary=prev_summary,
+                ts_points=ts_points,
+                throughput_rows=throughput_rows,
+                review_round_rows=review_round_rows,
+                days_in_window=2,
+            )
         )
 
         by_label = {kpi["label"]: kpi for kpi in kpis}
@@ -1781,23 +1778,24 @@ class CachedReadConnectionScopingTest(_MainSourceTest):
     connection-free -- a raw `psycopg.Connection` is not a hashable
     cache key and every reload would otherwise look like a cache miss.
 
-    The cached wrappers (in `_widget_readers` and `_read_static_metadata`)
-    and the per-issue drill-down all funnel their reads through the shared
-    `_scoped_read` primitive, which owns the `analytics_connection()`
-    checkout and the `conn=conn` forwarding, so these inspect
-    `_scoped_read`'s source plus the wrappers that route through it -- the
-    suite stays hermetic against the dashboard dependency group (Streamlit
-    + Plotly are opt-in).
+    Windowed wrappers route through `_read_filtered`; static metadata and
+    the per-issue drill-down call `_scoped_read` directly. That primitive
+    owns the `analytics_connection()` checkout and `conn=conn` forwarding,
+    so the suite inspects each link without importing the optional
+    Streamlit and Plotly dependency group.
     """
 
     def _readers_source(self) -> str:
-        return self._source_of("_widget_readers")
+        return self._combined_source(WIDGET_READER_WRAPPER_NAMES)
+
+    def _read_filtered_source(self) -> str:
+        return self._source_of("_read_filtered")
 
     def _metadata_source(self) -> str:
         return self._source_of("_read_static_metadata")
 
     def _drilldown_source(self) -> str:
-        return self._source_of("_render_drilldown")
+        return self._source_of("_render_drilldown_view")
 
     def _combined_source(self, names) -> str:
         return "\n\n".join(self._source_of(name) for name in names)
@@ -1812,8 +1810,9 @@ class CachedReadConnectionScopingTest(_MainSourceTest):
             "analytics_read.analytics_connection()",
             self._source_of("_scoped_read"),
         )
+        self.assertIn("_read_filtered(", self._readers_source())
         for label, src in (
-            ("widget readers", self._combined_source(WIDGET_READER_WRAPPER_NAMES)),
+            ("filtered widget read", self._read_filtered_source()),
             ("static metadata", self._combined_source(STATIC_METADATA_READER_NAMES)),
             ("drill-down", self._drilldown_source()),
         ):
@@ -1821,15 +1820,15 @@ class CachedReadConnectionScopingTest(_MainSourceTest):
                 self.assertIn(SCOPED_READ_CALL_FRAGMENT, src)
 
     def test_cached_wrappers_do_not_accept_conn_arg(self) -> None:
-        # Each `_read_*` wrapper's positional parameter list is the
+        # Each `_read_*` wrapper accepts the hashable filter tuple as its
         # cache key. `conn` must NOT appear there -- it would force
         # st.cache_data to hash a connection object, which crashes
         # on the unhashable psycopg.Connection and (with a stringy
         # fallback) treats every refreshed conn as a cache miss.
         for name in WIDGET_READER_WRAPPER_NAMES:
             with self.subTest(name=name):
-                # Each wrapper's signature is the cache key; `conn`
-                # belongs inside `_scoped_read`, not in the parameter list.
+                # `conn` belongs inside `_scoped_read`, not in the cached
+                # wrapper's parameter list.
                 src = self._source_of(name)
                 marker = f"def {name}("
                 self.assertIn(marker, src)
@@ -1843,15 +1842,13 @@ class CachedReadConnectionScopingTest(_MainSourceTest):
                 )
 
     def test_wrappers_forward_scoped_connection(self) -> None:
-        # Each cached reader delegates to `_scoped_read`, which opens the
-        # thread-local connection and forwards it to the read helper --
-        # otherwise a new socket would open per call (the very thing the
-        # scoping is supposed to eliminate). The wrappers stay
-        # connection-free so `conn` never lands in the cache key.
-        readers_src = self._combined_source(WIDGET_READER_WRAPPER_NAMES)
+        # Cached readers delegate through `_read_filtered` to the scoped
+        # connection adapter. The wrappers stay connection-free so `conn`
+        # never lands in the cache key.
+        readers_src = self._readers_source()
         self.assertGreaterEqual(
-            readers_src.count(SCOPED_READ_CALL_FRAGMENT), 15,
-            "every widget read should route through `_scoped_read`",
+            readers_src.count("_read_filtered("), 15,
+            "every widget read should route through `_read_filtered`",
         )
         # The two static-metadata reads route through it too.
         self.assertGreaterEqual(
@@ -1860,7 +1857,9 @@ class CachedReadConnectionScopingTest(_MainSourceTest):
             ),
             2,
         )
-        # And the per-issue drill-down runs its own scoped read.
+        # The shared filtered-read adapter and per-issue drill-down each
+        # run their own scoped read.
+        self.assertIn(SCOPED_READ_CALL_FRAGMENT, self._read_filtered_source())
         self.assertIn(SCOPED_READ_CALL_FRAGMENT, self._drilldown_source())
         # `_scoped_read` is the single place the scoped connection is
         # opened and forwarded to the read helper.
@@ -1883,9 +1882,9 @@ class CachedReadConnectionScopingTest(_MainSourceTest):
         # And the `prev_summary` entry in the reader fan-out must
         # dispatch through `_read_prev_kpi` so the lightweight path
         # is the one that actually fires when the dashboard renders.
-        src = self._readers_source()
+        src = self._source_of("_first_wave_readers")
         self.assertIn(
-            '("prev_summary", lambda: read_prev_kpi(*prev_key))',
+            '_widget_task(st, "prev_summary", _read_prev_kpi, prev_key)',
             src,
         )
 
@@ -1995,12 +1994,53 @@ class FacadeReExportCompatibilityTest(unittest.TestCase):
         self.assertIsInstance(dashboard._parse_parallel_reads_flag(), bool)
 
 
+class DashboardCompatibilityHelperTest(_MainSourceTest):
+    """Exported dashboard helpers retain their historical call shapes."""
+
+    def test_topbar_signature_is_stable(self) -> None:
+        import inspect
+
+        _, dashboard = _reload({ANALYTICS_DB_URL_ENV: CONFIGURED_DB_URL})
+        self.assertEqual(
+            tuple(inspect.signature(dashboard._topbar_html).parameters),
+            (
+                "extent",
+                "distinct_repos",
+                "total_events",
+                "spend_in_range",
+                "fmt_money_exact",
+                "fmt_num",
+            ),
+        )
+
+    def test_drilldown_signature_and_typed_delegate_are_stable(self) -> None:
+        import inspect
+
+        _, dashboard = _reload({ANALYTICS_DB_URL_ENV: CONFIGURED_DB_URL})
+        self.assertEqual(
+            tuple(inspect.signature(dashboard._render_drilldown).parameters),
+            (
+                "st",
+                "pd",
+                "window",
+                "repo_filter",
+                "issue_input_parsed",
+                "event_filter",
+                "stage_filter",
+            ),
+        )
+        self.assertIn(
+            "_render_drilldown_view(modules, filters)",
+            self._source_of("_render_drilldown"),
+        )
+
+
 class FanOutReadsSequentialTest(unittest.TestCase):
     """The sequential branch of `_fan_out_reads` runs each reader in
     submission order on the calling thread and returns results keyed
-    by reader name. The helper exists so the `main()` call site can
-    collapse 13 lines of `name = _read_name(*key)` into one dispatch
-    and so tests can inject fake readers without booting Streamlit.
+    by reader name. The helper lets each staged wave dispatch its bound
+    cached-reader tasks through one path and lets tests inject fake
+    readers without booting Streamlit.
     """
 
     def test_results_keep_name_and_submit_order(self) -> None:
@@ -2131,63 +2171,66 @@ class FanOutReadsParallelTest(unittest.TestCase):
 
 
 class MainRenderDispatchTest(_MainSourceTest):
-    """`main()` dispatches its body through focused `_render_*` helpers
-    -- the sidebar / date filter bar up top, then the widget cards in
-    top-to-bottom page order after the fan-out.
-    """
+    """The page pipeline preserves control and widget render order."""
 
     def test_render_helpers_called_in_page_order(self) -> None:
-        src = self._main_source()
-        order = [
-            "_render_sidebar_filters(",
-            "_render_date_filter_bar(",
+        controls_src = self._source_of("_render_dashboard_controls")
+        self.assertLess(
+            controls_src.index("_render_sidebar_filters("),
+            controls_src.index("_render_date_filter_bar("),
+        )
+
+        chart_src = self._source_of("_render_chart_widgets")
+        chart_order = [
             "_render_hero_usage(",
             "_render_stage_review_bars(",
             "_render_issues_and_backends(",
             "_render_repo_and_reliability(",
             "_render_activity_heatmap(",
+        ]
+        chart_indexes = [chart_src.index(marker) for marker in chart_order]
+        self.assertEqual(chart_indexes, sorted(chart_indexes))
+
+        remaining_src = self._source_of("_render_remaining_widgets")
+        remaining_order = [
             "_render_skill_triggers(",
             "_render_recent_runs(",
+            "_render_drilldown_view(",
+            "_render_dashboard_footer(",
         ]
-        idxs = [src.index(marker) for marker in order]
-        self.assertEqual(idxs, sorted(idxs))
-        # The final drill-down is the page's last section. The
-        # empty-window short-circuit also calls `_render_drilldown`
-        # earlier, so anchor on the last occurrence.
-        self.assertLess(idxs[-1], src.rindex("_render_drilldown("))
+        remaining_indexes = [
+            remaining_src.index(marker) for marker in remaining_order
+        ]
+        self.assertEqual(remaining_indexes, sorted(remaining_indexes))
 
-    def test_skill_card_between_heatmap_and_runs(
-        self,
-    ) -> None:
-        src = self._main_source()
-        heatmap = src.index("_render_activity_heatmap(")
-        skill = src.index("_render_skill_triggers(")
-        recent = src.index("_render_recent_runs(")
-        self.assertLess(heatmap, skill)
-        self.assertLess(skill, recent)
+        page_src = self._source_of("_render_dashboard_widgets")
+        self.assertLess(
+            page_src.index("_render_chart_widgets("),
+            page_src.index("_render_remaining_widgets("),
+        )
 
     def test_read_and_error_paths_use_helpers(self) -> None:
         # `main` dispatches the staged read fan-out and the empty /
         # error rendering branches through focused helpers rather than
         # inlining the cached wrappers, the fan-out, the load log, and
         # the metadata / no-data / empty-window banners.
-        src = self._main_source()
-        for marker in (
-            "_read_static_metadata(",
-            "_render_no_data(",
-            "_widget_readers(",
-            "_dispatch_reads(",
-            "_log_dashboard_load(",
-            "_render_empty_window(",
+        for helper, marker in (
+            ("_run_dashboard", "_read_static_metadata("),
+            ("_render_dashboard", "_render_no_data("),
+            ("_prepare_dashboard_page", "_widget_readers("),
+            ("_load_dashboard_data", "_dispatch_reads("),
+            ("_load_dashboard_data", "_log_dashboard_load("),
+            ("_render_first_wave", "_render_empty_window("),
         ):
-            with self.subTest(marker=marker):
-                self.assertIn(marker, src)
+            with self.subTest(helper=helper, marker=marker):
+                self.assertIn(marker, self._source_of(helper))
         # The read-error banners and the cached wrappers belong to the
         # helpers, so `main` never inlines `st.error(`, a
         # `_fan_out_reads` call, or a `_read_*` wrapper definition.
-        self.assertNotIn("st.error(", src)
-        self.assertNotIn("_fan_out_reads(", src)
-        self.assertNotIn("def _read_summary(", src)
+        main_src = self._main_source()
+        self.assertNotIn("st.error(", main_src)
+        self.assertNotIn("_fan_out_reads(", main_src)
+        self.assertNotIn("def _read_summary(", main_src)
 
 
 class MainParallelFanOutWiringTest(_MainSourceTest):
@@ -2203,13 +2246,15 @@ class MainParallelFanOutWiringTest(_MainSourceTest):
     def test_dispatch_wraps_fan_out_helper(self) -> None:
         # `_fan_out_reads` is the single dispatch surface; `main`
         # reaches it through the `_dispatch_reads` wave helper.
-        self.assertIn("_dispatch_reads(", self._main_source())
+        self.assertIn(
+            "_dispatch_reads(", self._source_of("_load_dashboard_data"),
+        )
         self.assertIn(
             "_fan_out_reads(", self._source_of("_dispatch_reads"),
         )
 
     def test_main_drives_parallel_off_env_helper(self) -> None:
-        src = self._main_source()
+        src = self._source_of("_prepare_dashboard_page")
         # The env-backed helper is the single source of truth for the
         # flag so a test or shutdown hook can flip it without
         # rewriting `main()`.
@@ -2220,9 +2265,10 @@ class MainParallelFanOutWiringTest(_MainSourceTest):
         # count, and the parallel flag so the operator can A/B with a
         # single grep; it is emitted by `_log_dashboard_load`, which
         # `main` calls (and clocks with `perf_counter`).
-        main_src = self._main_source()
-        self.assertIn("_log_dashboard_load(", main_src)
-        self.assertIn("perf_counter()", main_src)
+        load_src = self._source_of("_load_dashboard_data")
+        prepare_src = self._source_of("_prepare_dashboard_page")
+        self.assertIn("_log_dashboard_load(", load_src)
+        self.assertIn("perf_counter()", prepare_src)
         self.assertIn(
             "dashboard.load:", self._source_of("_log_dashboard_load"),
         )
@@ -2253,13 +2299,15 @@ class SkillMatrixWiringTest(_MainSourceTest):
         self.assertIn("analytics_read.get_skill_trigger_matrix", src)
 
     def test_matrix_read_forwards_scoped_connection(self) -> None:
-        # Reuse the cached-read pattern: the matrix wrapper delegates to
-        # `_scoped_read`, which checks out the scoped thread-local
+        # Reuse the cached-read pattern: the matrix wrapper delegates via
+        # `_read_filtered` to `_scoped_read`, which checks out the thread-local
         # connection and forwards it to the read helper, so the matrix
         # read shares the open socket rather than opening its own.
         src = self._source_of("_read_skill_trigger_matrix")
-        self.assertIn(SCOPED_READ_CALL_FRAGMENT, src)
+        self.assertIn("_read_filtered(", src)
         self.assertIn("analytics_read.get_skill_trigger_matrix", src)
+        filtered_src = self._source_of("_read_filtered")
+        self.assertIn(SCOPED_READ_CALL_FRAGMENT, filtered_src)
         scoped_src = self._source_of("_scoped_read")
         self.assertIn("analytics_read.analytics_connection()", scoped_src)
         self.assertIn("conn=conn", scoped_src)
@@ -2275,10 +2323,10 @@ class SkillMatrixWiringTest(_MainSourceTest):
         self.assertNotIn(" conn", src[head:tail])
 
     def test_matrix_dispatched_in_second_wave(self) -> None:
-        src = self._source_of("_widget_readers")
+        src = self._source_of("_second_wave_readers")
         self.assertIn(
-            '("skill_matrix_rows", '
-            "lambda: read_skill_trigger_matrix(*key))",
+            '_widget_task(st, "skill_matrix_rows", '
+            "_read_skill_trigger_matrix, key)",
             src,
         )
 
@@ -2387,10 +2435,10 @@ class StaticMetadataCacheTest(_MainSourceTest):
         # `get_data_extent` / `get_filter_options` calls live only
         # inside the helper's cached wrappers (routed through the
         # thread-local connection).
-        main_src = self._main_source()
-        self.assertIn("_read_static_metadata(", main_src)
-        self.assertNotIn("get_data_extent(", main_src)
-        self.assertNotIn("get_filter_options(", main_src)
+        run_src = self._source_of("_run_dashboard")
+        self.assertIn("_read_static_metadata(", run_src)
+        self.assertNotIn("get_data_extent(", run_src)
+        self.assertNotIn("get_filter_options(", run_src)
         # The helper itself dispatches through the cached wrappers.
         meta_src = self._metadata_source()
         self.assertIn("read_data_extent()", meta_src)
@@ -2398,191 +2446,109 @@ class StaticMetadataCacheTest(_MainSourceTest):
 
 
 class StagedRenderTest(_MainSourceTest):
-    """Issue #379 splits the read fan-out into two staged waves so
-    the topbar / filter meta / insight banners / KPI strip paint as
-    soon as their inputs are available, rather than blocking on every
-    widget. The first wave covers the six reads those above-the-fold
-    widgets consume; the second wave covers the eight remaining
-    widget reads. Worker threads only return data; every `st.*` /
-    placeholder write happens on the main render thread between the
-    two waves.
-    """
+    """The two read waves preserve their inputs and progressive render order."""
 
-    def _wave_block(self, src: str, name: str) -> str:
-        # The reader lists are short, indented at the function-body
-        # level (4 spaces), and bracketed by `[` ... `\n    ]`. The
-        # type annotation `list[tuple[str, Callable[[], Any]]]` sits
-        # on the assignment line, so we walk past the `= [` opening
-        # and stop at the first dedented `]` (preceded by the body
-        # indent) to extract just the list literal.
-        marker = f"{name}: list"
-        self.assertIn(marker, src, f"{name} declaration missing")
-        head = src.index("= [", src.index(marker)) + len("= [")
-        tail = src.index("\n    ]", head)
-        return src[head:tail]
+    def _first_wave_source(self) -> str:
+        return self._source_of("_first_wave_readers")
 
-    def _readers_source(self) -> str:
-        # The staged reader lists live in the `_widget_readers` helper.
-        return self._source_of("_widget_readers")
+    def _second_wave_source(self) -> str:
+        return self._source_of("_second_wave_readers")
+
+    def _load_source(self) -> str:
+        return self._source_of("_load_dashboard_data")
 
     def test_first_wave_has_only_topbar_inputs(self) -> None:
-        # The six reads in the first wave are exactly the inputs the
-        # topbar / filter meta / insight banners / KPI strip consume.
-        # Pin the set so a future refactor that adds (or drops) a
-        # reader has to update the staging explicitly.
-        src = self._readers_source()
-        wave = self._wave_block(src, "first_wave_readers")
+        wave = self._first_wave_source()
         for name in FIRST_WAVE_READER_NAMES:
             with self.subTest(name=name):
                 self.assertIn(f'"{name}"', wave)
-        # The remaining widget reads are NOT in the first wave -- they
-        # would force the spinner to wait for the slowest widget read
-        # before the KPI strip can paint.
         for name in SECOND_WAVE_READER_NAMES:
             with self.subTest(name=name):
                 self.assertNotIn(f'"{name}"', wave)
 
     def test_second_wave_has_remaining_reads(self) -> None:
-        src = self._readers_source()
-        wave = self._wave_block(src, "second_wave_readers")
+        wave = self._second_wave_source()
         for name in SECOND_WAVE_READER_NAMES:
             with self.subTest(name=name):
                 self.assertIn(f'"{name}"', wave)
-        # And the topbar / KPI-strip inputs are NOT in the second
-        # wave -- they belong to the first wave so the strip can
-        # paint before the slow widget reads finish.
         for name in FIRST_WAVE_READER_NAMES:
             with self.subTest(name=name):
                 self.assertNotIn(f'"{name}"', wave)
 
     def test_topbar_and_meta_render_between_waves(self) -> None:
-        # `topbar_slot.markdown` and `meta_slot.markdown` (which fill
-        # the above-the-fold content) must happen AFTER the first
-        # wave dispatch and BEFORE the second wave dispatch.
-        # Otherwise the staged-render gain evaporates.
-        src = self._main_source()
-        first = src.index("_dispatch_reads(\n            first_wave_readers")
-        second = src.index("_dispatch_reads(\n            second_wave_readers")
-        topbar_render = src.index("topbar_slot.markdown(")
-        meta_render = src.index("meta_slot.markdown(")
-        kpi_render = src.index("_kpi_strip_html(kpis)")
-        self.assertLess(first, topbar_render)
-        self.assertLess(topbar_render, second)
-        self.assertLess(first, meta_render)
-        self.assertLess(meta_render, second)
-        self.assertLess(first, kpi_render)
-        self.assertLess(kpi_render, second)
+        load_source = self._load_source()
+        first = load_source.index("page.reads.first_wave")
+        render = load_source.index("_render_first_wave(")
+        second = load_source.index("page.reads.second_wave")
+        self.assertLess(first, render)
+        self.assertLess(render, second)
+
+        first_render_source = self._source_of("_render_first_wave")
+        self.assertIn("_render_topbar_and_meta(", first_render_source)
+        self.assertIn("_kpi_strip_html(", first_render_source)
+        topbar_source = self._source_of("_render_topbar_and_meta")
+        self.assertIn("topbar_slot.markdown(", topbar_source)
+        self.assertIn("meta_slot.markdown(", topbar_source)
 
     def test_inline_loading_spinner_wraps_fan_out(self) -> None:
-        # A single in-line "Loading analytics…" spinner spans both
-        # waves so the user gets immediate feedback on a cold load
-        # instead of staring at a blank page. Pin the constant +
-        # `st.spinner` call so a future refactor cannot silently drop
-        # the feedback surface.
         _, dashboard = _reload({ANALYTICS_DB_URL_ENV: ""})
         self.assertEqual(
             dashboard.LOADING_INDICATOR_MESSAGE, "Loading analytics…"
         )
-        src = self._main_source()
-        self.assertIn(
-            "with st.spinner(LOADING_INDICATOR_MESSAGE):", src,
+        source = self._load_source()
+        spinner = source.index(
+            "with modules.st.spinner(LOADING_INDICATOR_MESSAGE):"
         )
-        # And the spinner brackets BOTH dispatch calls -- a spinner
-        # that only covered the first wave would clear before the
-        # second wave painted its widgets.
-        spinner_head = src.index(
-            "with st.spinner(LOADING_INDICATOR_MESSAGE):"
-        )
-        first = src.index(
-            "_dispatch_reads(\n            first_wave_readers"
-        )
-        second = src.index(
-            "_dispatch_reads(\n            second_wave_readers"
-        )
-        self.assertLess(spinner_head, first)
-        self.assertLess(spinner_head, second)
+        first = source.index("page.reads.first_wave")
+        second = source.index("page.reads.second_wave")
+        self.assertLess(spinner, first)
+        self.assertLess(spinner, second)
 
     def test_widgets_render_on_main_thread(self) -> None:
-        # Worker threads in `_fan_out_reads` only return data -- the
-        # `st.*` / `topbar_slot.markdown(...)` calls all live in
-        # `main()` itself, on the main render thread. We assert this
-        # by checking the reader entries in `_widget_readers` are pure
-        # data callables (`lambda: _read_*(...)`) with no Streamlit
-        # writes inside.
-        src = self._readers_source()
-        # The first/second wave list literals are pure data closures --
-        # `st.` (i.e. Streamlit attribute access) only appears outside
-        # those list entries (the wrapper decorators sit above them).
-        for marker, end in (
-            ("first_wave_readers: list", "second_wave_readers"),
-            ("second_wave_readers: list", "return first_wave_readers"),
-        ):
-            with self.subTest(marker=marker):
-                head = src.index(marker)
-                tail = src.index(end, head)
-                wave_block = src[head:tail]
-                self.assertNotIn(" st.", wave_block)
-                self.assertNotIn("slot.markdown", wave_block)
+        for helper in ("_first_wave_readers", "_second_wave_readers"):
+            with self.subTest(helper=helper):
+                wave_source = self._source_of(helper)
+                self.assertIn("_widget_task(", wave_source)
+                self.assertNotIn(".markdown(", wave_source)
+                self.assertNotIn(".info(", wave_source)
+                self.assertNotIn(".plotly_chart(", wave_source)
+        task_source = self._source_of("_widget_task")
+        self.assertIn("partial(cached_reader, *args)", task_source)
+        self.assertNotIn(".markdown(", task_source)
 
     def test_empty_window_short_circuits_second_wave(self) -> None:
-        # When the first wave's summary returns no events, the
-        # second wave never fires -- the eight remaining widget
-        # reads would just paint empty cards. Pin the short-circuit
-        # so a future refactor cannot silently re-introduce the
-        # wasted reads on an empty window.
-        src = self._main_source()
-        # The `summary.total_events == 0` check sits between the
-        # first-wave dispatch and the second-wave dispatch.
-        first = src.index(
-            "_dispatch_reads(\n            first_wave_readers"
-        )
-        second = src.index(
-            "_dispatch_reads(\n            second_wave_readers"
-        )
-        empty_check = src.index("summary.total_events == 0")
-        self.assertLess(first, empty_check)
-        self.assertLess(empty_check, second)
-        # And the empty branch returns early (via `_render_empty_window`)
-        # so the second wave never executes on an empty window.
-        empty_block = src[empty_check:second]
-        self.assertIn("return", empty_block)
-        self.assertIn("_render_empty_window(", empty_block)
+        load_source = self._load_source()
+        first_render = load_source.index("_render_first_wave(")
+        second = load_source.index("page.reads.second_wave")
+        short_circuit = load_source[first_render:second]
+        self.assertIn("if kpis is None:", short_circuit)
+        self.assertIn("return None", short_circuit)
+
+        first_wave_source = self._source_of("_render_first_wave")
+        empty_check = first_wave_source.index("summary.total_events == 0")
+        empty_render = first_wave_source.index("_render_empty_window(")
+        self.assertLess(empty_check, empty_render)
+        self.assertIn("return None", first_wave_source[empty_check:])
 
 
 class StagedRenderErrorTest(_MainSourceTest):
-    """A read error in EITHER wave surfaces as one `st.error` +
-    `st.stop`: both waves route through the single `_dispatch_reads`
-    helper (whose handler is pinned by `MainParallelFanOutWiringTest`),
-    and the second-wave dispatch runs only AFTER the topbar / KPI strip
-    have painted -- so a second-wave error stops a half-rendered
-    dashboard cleanly instead of continuing into broken widget code.
-    """
+    """Both read waves share error handling and retain their render order."""
 
     def test_both_waves_route_through_dispatch_helper(self) -> None:
-        # Each wave is dispatched via `_dispatch_reads`, so both inherit
-        # the same `try/except AnalyticsReadError` -> `st.error` + stop
-        # handling rather than each open-coding it.
-        src = self._main_source()
-        self.assertIn(
-            "_dispatch_reads(\n            first_wave_readers", src
-        )
-        self.assertIn(
-            "_dispatch_reads(\n            second_wave_readers", src
-        )
+        source = self._source_of("_load_dashboard_data")
+        self.assertIn("page.reads.first_wave", source)
+        self.assertIn("page.reads.second_wave", source)
+        self.assertEqual(source.count("_dispatch_reads("), 2)
 
     def test_second_wave_error_after_topbar_paints(self) -> None:
-        # The second-wave dispatch runs AFTER the topbar / KPI strip
-        # have already painted -- so the user sees real content (the
-        # topbar + KPI strip) and then, on a read error, a single
-        # `st.error` instead of a half-rendered dashboard.
-        src = self._main_source()
-        topbar_render = src.index("topbar_slot.markdown(")
-        second_dispatch = src.index(
-            "_dispatch_reads(\n            second_wave_readers"
+        source = self._source_of("_load_dashboard_data")
+        first_wave_render = source.index("_render_first_wave(")
+        second_dispatch = source.index("page.reads.second_wave")
+        self.assertLess(first_wave_render, second_dispatch)
+        self.assertIn(
+            "_render_topbar_and_meta(",
+            self._source_of("_render_first_wave"),
         )
-        self.assertLess(topbar_render, second_dispatch)
-
-
 class FanOutReadsErrorPropagationTest(unittest.TestCase):
     """The first-wave error path must NOT swallow the worker's
     `AnalyticsReadError` -- the existing fan-out helper already


### PR DESCRIPTION
## Summary

Complete linter-remediation Packages 3.1–3.5 and the decomposition-stage cleanup.

- Simplify analytics readers, retention, trajectory processing, and PostgreSQL synchronization.
- Streamline dashboard orchestration, chart and HTML builders, KPIs, and trajectory rendering.
- Reduce complexity in agent execution, usage parsing, configuration loading, and main-loop orchestration.
- Simplify base synchronization, branch publication, authenticated Git operations, verification, and worktree lifecycle handling.
- Refactor workflow support code across GitHub integration, scheduling, skill catalog, state management, drift detection, messages, and usage helpers.
- Extract decomposition post-run routing to eliminate its remaining targeted complexity finding.
- Update `plans/linter-remediation.md` with completed tasks and reviewed compatibility exceptions.

## Compatibility

Preserve existing public signatures and behavior, including:

- Provider payload formats and subprocess shutdown behavior.
- Lazy optional dashboard dependencies.
- Git authentication, locking, command ordering, and recovery behavior.
- Worktree re-export contracts.
- Late-bound workflow calls and decomposition cleanup.
- `IssueScheduler.submit()` compatibility.

Remaining WPS211 findings are limited to documented, reviewed public-signature compatibility cases.

## Validation

- Ruff passed.
- Targeted complexity scans passed.
- Diff and whitespace checks passed.
- Full suite: 2,100 passed, 3 skipped.
- Focused package and stage test suites passed.