### PR TITLE
Fix orchestrator module entrypoint after runtime split

### DIFF
--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -61,4 +61,7 @@ _SIGNAL_EXIT_BASE = 128
 
 
 if __name__ == "__main__":
+    # `python -m` registers this module only as `__main__`; runtime leaves
+    # resolve their process-wide patch surface through its canonical name.
+    sys.modules["orchestrator.main"] = sys.modules[__name__]
     sys.exit(main())

--- a/tests/test_runtime_core_compat.py
+++ b/tests/test_runtime_core_compat.py
@@ -52,6 +52,18 @@ class PackageExportTest(unittest.TestCase):
         self.assertEqual(_ORCHESTRATOR_PACKAGE.__all__, ("__version__",))
 
 
+class MainModuleEntrypointTest(unittest.TestCase):
+    def test_module_launch_resolves_runtime_facade(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, "-m", "orchestrator.main", "--help"],
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("Agent orchestrator polling loop.", completed.stdout)
+
+
 class PinnedStateCompatibilityTest(unittest.TestCase):
     def test_keywords_share_data_attribute(self) -> None:
         state_data = {"branch": "orchestrator/issue-7"}


### PR DESCRIPTION
## Summary

- Register the `__main__` module as `orchestrator.main` when launched with `python -m`.
- Restore runtime helper access to the main façade.
- Add a subprocess regression test for module execution.

## Testing

- Ruff passed.
- 2,217 tests passed; 3 expected skips.
- `python -m orchestrator.main --help` passed.