### PR TITLE
fix: use a supported cooldown policy for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 30
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 14
     labels:
       - "workflow:dependencies"
       - "workflow:github_actions"

--- a/docs/configuration/operations.md
+++ b/docs/configuration/operations.md
@@ -95,19 +95,20 @@ shape for every workflow, but nothing checks the comment against the SHA it labe
 together; Dependabot's `github-actions` updates rewrite the pair.
 
 [`../../.github/dependabot.yml`](../../.github/dependabot.yml) opens weekly update PRs for the `github-actions` and `uv`
-(Python `pyproject.toml` + `uv.lock`) ecosystems. Both declare the same cooldown policy, holding a release for a
-stabilization window before an update PR offers it: 30 days for a major and for anything SemVer does not classify
-(`cooldown.default-days`), 14 days for a minor or a patch. The `uv` entry additionally declares `allow:` rules, which
-replace Dependabot's default rule rather than extend it — `dependency-type: direct` restates that default, and
-`dependency-name: gitpython` names the single transitive dependency it is widened for, because GitPython reaches the
-lockfile only through Streamlit and its advisories would otherwise leave a grouped security job with no allowed
-dependency to update. Each entry also declares the service labels GitHub stamps on the PRs it opens:
+(Python `pyproject.toml` + `uv.lock`) ecosystems. For routine version updates, `github-actions` uses the ecosystem-wide
+cooldown GitHub supports and holds every release for 30 days. The `uv` entry holds a major release, and anything SemVer
+does not classify, for 30 days; it holds a minor or a patch for 14 days. Cooldowns do not delay security updates. The
+`uv` entry additionally declares `allow:` rules, which replace Dependabot's default rule rather than extend it —
+`dependency-type: direct` restates that default, and `dependency-name: gitpython` names the single transitive dependency
+it is widened for, because GitPython reaches the lockfile only through Streamlit and its advisories would otherwise
+leave a grouped security job with no allowed dependency to update. Each entry also declares the service labels GitHub
+stamps on the PRs it opens:
 `workflow:dependencies` on every update PR, so the whole dependency queue is one label filter, plus
 `workflow:github_actions` or `workflow:python:uv` naming which ecosystem moved. Those three share the `workflow:`
 prefix with the labels the orchestrator writes but are not workflow states — nothing in the tree reads them, so a PR
 carrying one is not an issue in a stage. `github-actions` and `uv` above name the ecosystems Dependabot updates, not
 labels. [`../../tests/repository/test_dependabot_config.py`](../../tests/repository/test_dependabot_config.py) holds
-the cooldown policy, the allow rules, and the labels against what the config declares.
+the cooldown policies, the allow rules, and the labels against what the config declares.
 [`../../.github/workflows/dependency-review.yml`](../../.github/workflows/dependency-review.yml) runs
 `actions/dependency-review-action` on every PR and fails the check when a PR introduces a vulnerable or non-compliant
 dependency.

--- a/docs/security.md
+++ b/docs/security.md
@@ -48,8 +48,9 @@ trust boundary — see [`architecture.md`](architecture.md#design-constraints).
   ([`configuration.md#continuous-integration`](configuration.md#continuous-integration)). Dependabot covers the `uv`
   and `github-actions` ecosystems in [`../.github/dependabot.yml`](../.github/dependabot.yml), stamping every update PR
   it opens with `workflow:dependencies` plus `workflow:github_actions` or `workflow:python:uv`, so the queue a
-  maintainer has to triage is one label filter. Both entries hold a release for a stabilization window before an
-  update PR offers it — 30 days for a major, 14 days for a minor or a patch. Dependabot allows only direct
+  maintainer has to triage is one label filter. For routine version updates, `github-actions` uses its supported
+  ecosystem-wide window to hold every release for 30 days; `uv` holds a major or unclassified release for 30 days and
+  a minor or patch for 14 days. These cooldowns do not delay security updates. Dependabot allows only direct
   dependencies by default, so a transitive package is in scope only once the `uv` entry's `allow:` rules name it:
   `gitpython` is named there because GitPython reaches the lockfile through Streamlit, and its advisories would
   otherwise leave the grouped security job with nothing it is allowed to update. An advisory against any other
@@ -113,8 +114,8 @@ mechanism from the weekly version-update PRs [`../.github/dependabot.yml`](../.g
 alerts fire when a published advisory matches a version pinned in [`../uv.lock`](../uv.lock), and security updates
 open the PR that bumps that one dependency to the fixed version.
 
-- **They are not subject to the cooldown windows** the config declares — 30 days for a major, 14 for a minor or a
-  patch. Those windows are there to let a routine version update age before a maintainer has to look at it; a
+- **They are not subject to the cooldown windows** the `uv` entry declares — 30 days for a major, 14 for a minor or
+  a patch. Those windows are there to let a routine version update age before a maintainer has to look at it; a
   security patch is the case where waiting is the cost, and the cooldown applies to version updates only.
 - They are the acting half of the standing scan:
   [`../.github/workflows/vulnerability-scan.yml`](../.github/workflows/vulnerability-scan.yml) reports a vulnerable

--- a/tests/repository/test_dependabot_config.py
+++ b/tests/repository/test_dependabot_config.py
@@ -6,13 +6,14 @@ Three blocks carry behavior. The service labels stamped on every update PR let
 a reviewer select the dependency queue by label rather than by reading titles:
 the shared one the whole queue is filtered by, plus the one naming which
 ecosystem moved. The cooldown windows hold a release for a stabilization
-period before an update PR opens, and both ecosystems run the same policy, so
-a window rewritten on one of them and not the other is a divergence rather
-than a decision. The `uv` allow rules name GitPython, which reaches the
-lockfile only through Streamlit: an `allow:` block replaces Dependabot's
-default rule instead of adding to it, so losing either rule either stops
-direct updates outright or sends the grouped security job back to skipping the
-whole group with no allowed dependency matched.
+period before an update PR opens. GitHub Actions accepts only an
+ecosystem-wide default window, while `uv` accepts SemVer-specific windows, so
+each entry is held against the policy shape its ecosystem supports. The `uv`
+allow rules name GitPython, which reaches the lockfile only through Streamlit:
+an `allow:` block replaces Dependabot's default rule instead of adding to it,
+so losing either rule either stops direct updates outright or sends the
+grouped security job back to skipping the whole group with no allowed
+dependency matched.
 
 Nothing in the tree reads this config -- GitHub does -- so a dropped label, a
 window quietly rewritten on one ecosystem, or a deleted allow rule would
@@ -46,17 +47,22 @@ _EXPECTED_LABELS = (
     ("github-actions", ("workflow:dependencies", "workflow:github_actions")),
     ("uv", ("workflow:dependencies", "workflow:python:uv")),
 )
-_ECOSYSTEMS = tuple(ecosystem for ecosystem, _ in _EXPECTED_LABELS)
 _SERVICE_LABELS = frozenset(
     label for _, labels in _EXPECTED_LABELS for label in labels
 )
-# The one cooldown policy both ecosystems run: a major, and anything SemVer
-# does not classify, waits a month; a minor or a patch waits a fortnight.
-_EXPECTED_COOLDOWN = (
-    ("default-days", 30),
-    ("semver-major-days", 30),
-    ("semver-minor-days", 14),
-    ("semver-patch-days", 14),
+# GitHub Actions accepts only its ecosystem-wide window; `uv` can tier its
+# stabilization windows by SemVer change.
+_EXPECTED_COOLDOWNS = (
+    ("github-actions", (("default-days", 30),)),
+    (
+        "uv",
+        (
+            ("default-days", 30),
+            ("semver-major-days", 30),
+            ("semver-minor-days", 14),
+            ("semver-patch-days", 14),
+        ),
+    ),
 )
 # The `uv` allow rules, in file order: the default rule the block would
 # otherwise replace, then the transitive dependency the grouped security job
@@ -88,6 +94,18 @@ def _entry_declarations(ecosystem: str) -> str:
     )
 
 
+def _entry_block(ecosystem: str, key: str) -> str:
+    """One complete declaration block from an ecosystem entry."""
+    marker = f"    {key}:"
+    below_key = _entry_declarations(ecosystem).partition(f"{marker}\n")[2]
+    declarations = []
+    for line in below_key.splitlines():
+        if not line.startswith("      "):
+            break
+        declarations.append(line)
+    return "\n".join((marker, *declarations))
+
+
 class DependabotServiceLabelsTest(unittest.TestCase):
     def test_ecosystems_declare_their_labels(self) -> None:
         for ecosystem, labels in _EXPECTED_LABELS:
@@ -99,14 +117,17 @@ class DependabotServiceLabelsTest(unittest.TestCase):
 
 
 class DependabotCooldownPolicyTest(unittest.TestCase):
-    def test_ecosystems_share_one_cooldown_policy(self) -> None:
-        declared = _block(
-            "cooldown",
-            (f"{window}: {days}" for window, days in _EXPECTED_COOLDOWN),
-        )
-        for ecosystem in _ECOSYSTEMS:
+    def test_ecosystems_use_supported_cooldowns(self) -> None:
+        for ecosystem, cooldown in _EXPECTED_COOLDOWNS:
+            declared = _block(
+                "cooldown",
+                (f"{window}: {days}" for window, days in cooldown),
+            )
             with self.subTest(ecosystem=ecosystem):
-                self.assertIn(declared, _entry_declarations(ecosystem))
+                self.assertEqual(
+                    declared,
+                    _entry_block(ecosystem, "cooldown"),
+                )
 
 
 class DependabotAllowRulesTest(unittest.TestCase):


### PR DESCRIPTION
Remove unsupported parameters in cooldown policy for GitHub Actions.