### PR TITLE
docs: bypass the stale Scorecard badge cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,8 @@ Licensed under the Apache License, Version 2.0. See [`LICENSE`](LICENSE) for the
 
 [ci-badge]: https://github.com/geserdugarov/agent-orchestrator/actions/workflows/ci.yml/badge.svg
 [ci-link]: https://github.com/geserdugarov/agent-orchestrator/actions/workflows/ci.yml
-[scorecard-badge]: https://api.scorecard.dev/projects/github.com/geserdugarov/agent-orchestrator/badge
+<!-- Use the canonical JSON feed while https://github.com/ossf/scorecard/issues/5197 leaves the badge path stale. -->
+[scorecard-badge]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.scorecard.dev%2Fprojects%2Fgithub.com%2Fgeserdugarov%2Fagent-orchestrator&query=%24.score&label=openssf%20scorecard&color=green&cacheSeconds=600
 [scorecard-link]: https://scorecard.dev/viewer/?uri=github.com/geserdugarov/agent-orchestrator
 [best-practices-badge]: https://www.bestpractices.dev/projects/14235/badge
 [best-practices-link]: https://www.bestpractices.dev/projects/14235


### PR DESCRIPTION
The standard OpenSSF Scorecard badge is serving a stale score of 6.9 while the canonical API and viewer report 8.0.

This temporarily replaces the standard badge endpoint with a Shields dynamic JSON badge that reads the score directly from the canonical OpenSSF API. The viewer link remains unchanged.

Upstream issue: https://github.com/ossf/scorecard-infra/issues/101

Once the upstream caching issue is resolved, the standard badge endpoint can be restored.

## Validation

- Confirmed the replacement badge renders the current score from the canonical API.