### PR TITLE
chore: update canonical repository references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@
 # manage this orchestrator's own repo (self-bootstrap); set to any other
 # `owner/name` (e.g. `lance-open-source/lance`) plus TARGET_REPO_ROOT
 # below to drive a different repo without touching the rest of this file.
-REPO=geserdugarov/agent-orchestrator
+REPO=chippingway/orchestrator
 
 # Path to the local clone of REPO. Worktrees are `git worktree add`-ed
 # from here. Defaults to the orchestrator's own checkout (self-bootstrap);

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ is in [`docs/state-machine/lifecycle.md`](docs/state-machine/lifecycle.md).
 1. **Clone and enter the repo**
 
    ```sh
-   git clone https://github.com/geserdugarov/agent-orchestrator.git
-   cd agent-orchestrator
+   git clone https://github.com/chippingway/orchestrator.git
+   cd orchestrator
    ```
 
 2. **Install from the lockfile**
@@ -118,8 +118,8 @@ is in [`docs/state-machine/lifecycle.md`](docs/state-machine/lifecycle.md).
    path. The default token path is derived from `REPO` (`~/.config/<owner>/<repo>/token`):
 
    ```sh
-   OWNER=geserdugarov
-   REPO=agent-orchestrator
+   OWNER=chippingway
+   REPO=orchestrator
    install -d -m 700 "$HOME/.config/$OWNER/$REPO"
    printf %s "$YOUR_PERSONAL_ACCESS_TOKEN" > "$HOME/.config/$OWNER/$REPO/token"
    chmod 600 "$HOME/.config/$OWNER/$REPO/token"
@@ -304,11 +304,11 @@ agent-workflow input — the versions that are supported, and what a report earn
 
 Licensed under the Apache License, Version 2.0. See [`LICENSE`](LICENSE) for the full text.
 
-[ci-badge]: https://github.com/geserdugarov/agent-orchestrator/actions/workflows/ci.yml/badge.svg
-[ci-link]: https://github.com/geserdugarov/agent-orchestrator/actions/workflows/ci.yml
+[ci-badge]: https://github.com/chippingway/orchestrator/actions/workflows/ci.yml/badge.svg
+[ci-link]: https://github.com/chippingway/orchestrator/actions/workflows/ci.yml
 <!-- Use the canonical JSON feed while https://github.com/ossf/scorecard/issues/5197 leaves the badge path stale. -->
-[scorecard-badge]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.scorecard.dev%2Fprojects%2Fgithub.com%2Fgeserdugarov%2Fagent-orchestrator&query=%24.score&label=openssf%20scorecard&color=green&cacheSeconds=600
-[scorecard-link]: https://scorecard.dev/viewer/?uri=github.com/geserdugarov/agent-orchestrator
+[scorecard-badge]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.scorecard.dev%2Fprojects%2Fgithub.com%2Fchippingway%2Forchestrator&query=%24.score&label=openssf%20scorecard&color=green&cacheSeconds=600
+[scorecard-link]: https://scorecard.dev/viewer/?uri=github.com/chippingway/orchestrator
 [best-practices-badge]: https://www.bestpractices.dev/projects/14235/badge
 [best-practices-link]: https://www.bestpractices.dev/projects/14235
 [cfg-systemd]: docs/configuration.md#running-under-systemd-user-service

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Reporting a vulnerability
 
 Report a suspected vulnerability **privately**, through GitHub Private Vulnerability Reporting on this repository:
-open the [Security tab](https://github.com/geserdugarov/agent-orchestrator/security) and choose **"Report a
+open the [Security tab](https://github.com/chippingway/orchestrator/security) and choose **"Report a
 vulnerability"**. That opens an advisory draft only the maintainer and the people invited to it can read.
 
 Please do **not** open a public issue, pull request, or discussion for one. Issues on this repository drive an

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,7 @@ Token resolution order:
 Use `REPO` for a single repo (the default), or `REPOS` to drive several from one process. When `REPOS` is set, the
 legacy single-repo quartet (`REPO` / `TARGET_REPO_ROOT` / `BASE_BRANCH` / `REMOTE_NAME`) is ignored.
 
-- `REPO` — default `geserdugarov/agent-orchestrator`. `owner/name` of the single repo to manage (ignored when `REPOS`
+- `REPO` — default `chippingway/orchestrator`. `owner/name` of the single repo to manage (ignored when `REPOS`
   is set)
 - `TARGET_REPO_ROOT` — default `REPO_ROOT` (self-bootstrap). path to the local clone of `REPO` — worktrees are
   `git worktree add`-ed from here

--- a/docs/configuration/operations.md
+++ b/docs/configuration/operations.md
@@ -127,7 +127,7 @@ and adds only `security-events: write`, which the CodeQL action needs to upload 
 supply-chain grader behind the README badge — on a weekly `schedule`, on every push to `main`, and on
 `workflow_dispatch`, which is how a maintainer can prove a change to it works without waiting a week. It sets
 `publish_results: true`, so a run on `main` publishes the score the badge and the public
-[viewer](https://scorecard.dev/viewer/?uri=github.com/geserdugarov/agent-orchestrator) read, and hands the SARIF it
+[viewer](https://scorecard.dev/viewer/?uri=github.com/chippingway/orchestrator) read, and hands the SARIF it
 produces to `github/codeql-action/upload-sarif`, which files each finding as a code-scanning alert on this repo. It
 declares the same top-level `contents: read` and reads no secrets; the job adds exactly the two grants those two
 publications need — `id-token: write` for the OIDC token the publication is authenticated by, and

--- a/orchestrator/config/environment.py
+++ b/orchestrator/config/environment.py
@@ -31,7 +31,7 @@ ConfigWarning = Callable[[str], None]
 _DEFAULT_ENABLED = "on"
 _CLAUDE = "claude"
 _CODEX = "codex"
-_DEFAULT_REPO = "geserdugarov/agent-orchestrator"
+_DEFAULT_REPO = "chippingway/orchestrator"
 _DEFAULT_HITL = "geserdugarov"
 
 # Added lines a candidate may carry and still publish as one change. Spelled


### PR DESCRIPTION
Update references after project migration to a separate GitHub organization.