### PR TITLE
docs: refresh roadmap against current implementation

### DIFF
--- a/plans/roadmap.md
+++ b/plans/roadmap.md
@@ -1,7 +1,8 @@
-# Agent Orchestrator — Roadmap
+# chipping-orchestrator — Roadmap
 
-## Status as of 2026-08-19
+## Status as of 2026-09-11
 
+Checked against `main` at `68f8fa73`, which declares version 0.11.1.
 The fixed delivery lifecycle is wired end-to-end: pickup →
 `workflow:decomposing` → `workflow:ready` / `workflow:blocked` /
 `workflow:umbrella` → `workflow:implementing` → `workflow:validating` →
@@ -12,16 +13,30 @@ The fixed delivery lifecycle is wired end-to-end: pickup →
 labels provide read-only Q&A and design-conversation side branches; a
 confirmed discussion publishes a plan PR. The `backlog` and `paused`
 control labels hold fresh or in-flight work without changing the workflow
-state.
+state. With the default `DECOMPOSE=on`, every new committed candidate is
+measured against `MAX_ADDED_LINES` before its first publication and again,
+cumulatively, before every later push onto its PR. Oversized work returns
+to `workflow:decomposing` for a resumable single-or-split adjudication that
+preserves and reuses the committed candidate. A late `single` verdict parks
+for a human decision; a trusted `/orchestrator authorize-oversized <commit>`
+authorizes that exact candidate, while guidance resumes the developer for a
+revision. Every proposed split child declares its own addition budget below
+the frozen ceiling, including tests and documentation. Turning decomposition
+off does not bypass a candidate already recorded in a live generation or
+still owed publication.
 
-The orchestrator runs as a single long-lived Python process
-(`python -m orchestrator`, wrapped by `run.sh` for self-restart),
-polls one or more configured repos, and delegates coding to `codex` /
+The orchestrator runs as a single long-lived Python process through
+`chipping-orchestrator` or `python -m orchestrator`, with `run.sh` wrapping
+it for self-restart. It polls one or more configured repos and delegates
+coding to `codex` /
 `claude` CLI subprocesses in per-issue git worktrees. State lives in
 GitHub Issues themselves (one workflow label plus one pinned JSON
 comment), so the loop stays stateless and progress is observable on
 github.com. Per-repo ticks fan out concurrently; per-issue handlers
-within each repo run in parallel up to configurable caps.
+within each repo run in parallel up to configurable caps. A durable
+per-issue circuit limits lifetime agent-process starts, and a host-wide
+maintenance pass reclaims proven-safe terminal worktrees and branches on a
+daily interval or on demand.
 
 The observability stack is also in place: audit events, analytics JSONL
 with Postgres rollups, repo skill catalogs, session-aware skill adoption
@@ -29,7 +44,10 @@ with confirmed / inferred / incidental evidence, the Streamlit analytics
 dashboard, and an opt-in file-backed trajectory sink and viewer for
 redacted agent run timelines. Agent token / cost usage is captured both
 as run-level analytics and as per-issue pinned counters that produce a
-terminal receipt comment.
+terminal receipt comment. Both event streams also carry size-gate transitions,
+completed exemption transfers, and agent-run-budget transitions; terminal
+artifact cleanup contributes one bounded analytics record per candidate it
+decides about.
 
 For the authoritative behavior, see:
 
@@ -52,18 +70,28 @@ This file tracks what shipped and what is still open.
 ## Shipped
 
 The orchestrator is feature-complete against its original scope. Each
-shipped area below is a one-line pointer; behavior details live in the
-linked docs.
+shipped area below summarizes the implementation; behavior details live in
+the linked docs, and unfinished follow-ups are listed under Future work.
 
-- **Bootstrap and process model.** Canonical `agent-orchestrator` and
+- **Bootstrap and process model.** Canonical `chipping-orchestrator` and
   `python -m orchestrator` launch forms, polling loop with `--once` and
-  signal-clean shutdown, ancestry-aware self-update detection, and the
-  `run.sh` self-restart wrapper. See
+  `--cleanup-terminal-artifacts`, signal-clean shutdown,
+  ancestry-aware self-update detection, and the `run.sh` self-restart
+  wrapper. See
   [`docs/architecture.md#process-model`](../docs/architecture.md#process-model).
 - **Agent invocation.** `agents.run_agent` dispatches to `codex` /
-  `claude`; `DEV_AGENT` / `REVIEW_AGENT` / `DECOMPOSE_AGENT` specs are
-  pinned per issue and re-parsed on every resume. See
+  `claude`. Developer sessions pin `DEV_AGENT`; decomposition, question,
+  and discussion sessions pin `DECOMPOSE_AGENT`. They re-parse the full
+  pinned spec on resume. The reviewer starts fresh under the current
+  `REVIEW_AGENT` spec every round. See
   [`docs/workflow.md`](../docs/workflow.md).
+- **Lifetime agent-run circuit.** Every agent-process start is charged
+  durably before invocation against `MAX_AGENT_RUNS_PER_ISSUE`; the
+  dispatcher holds an exhausted issue on `agent_run_limit`, and a trusted
+  `/orchestrator add-agent-runs N` can extend that issue's allowance.
+  Reservation, start, exhaustion, and extension transitions reach both
+  observability sinks. See
+  [`docs/security.md#bounded-agent-spend-per-issue-max_agent_runs_per_issue`][agent-run-circuit].
 - **Security hardening.** Agent and verify-command env strip GitHub
   tokens and secret-shaped vars; provider keys are exact-name
   allowlisted for agent subprocesses only; authenticated git operations
@@ -81,6 +109,40 @@ linked docs.
   parked developer paths, and the read-only `question` side branch all
   live under `orchestrator/workflow/stages/`. See
   [`docs/state-machine.md#stage-handlers`](../docs/state-machine.md#stage-handlers).
+- **Candidate size gate and automatic late splitting.** With the default
+  `DECOMPOSE=on`, `MAX_ADDED_LINES` measures the exact committed candidate
+  before first publication and the cumulative PR before every later push;
+  switching decomposition off retains unmeasured publication only for new
+  work. Oversized work is frozen and adjudicated under
+  `workflow:decomposing`. A `split` verdict preserves it on immutable refs
+  and creates dependency-ordered children that reuse the contribution and
+  own their implementation, tests, and documentation. Each fresh child
+  proposal must declare a positive `estimated_added_lines` strictly below
+  the frozen ceiling; that budget survives verdict recovery and appears on
+  the child issue. The child's actual cumulative diff still passes its own
+  gate. See
+  [`docs/workflow/roles.md#the-size-gate-a-committed-candidate-passes`][size-gate].
+- **Human authorization of oversized single candidates.** A late `single`
+  verdict records its `split_blocker` explanation and parks as
+  `late_single_decision`. A trusted whole-comment
+  `/orchestrator authorize-oversized <commit>` binds publication to the
+  frozen commit, base, measured size, contribution fingerprint, and command
+  comment. Guidance resumes the developer for a revision; a bare
+  `/orchestrator continue` cannot authorize publication. Recorded results,
+  authorizations, and notices survive interrupted ticks. See
+  [`docs/workflow/roles.md#authorizing-one-oversized-candidate-to-publish`][oversized-authorization].
+- **Publication and rewrite recovery.** Size-gate parks reconcile the
+  recorded candidate through the publication seam before any agent spawn;
+  head and clean-tree checks protect both the push and the review handoff.
+  Publication approvals record their basis and the outstanding push.
+  Equivalent squashes, clean base rebases, and recorded conflict-stage
+  rebases can carry an accepted contribution's exemption after fingerprint
+  checks. Interrupted squashes recover from a durable record, including
+  when `SQUASH_ON_APPROVE` is turned off after the rewrite. A settled
+  transfer emits `late_transfer` only after its publication receipt is
+  persisted. Generation records also retain cleanup obligations when the
+  owner closes. See [the size gate][size-gate] and
+  [the size gate on an open PR][pr-gate].
 - **Control labels.** `backlog` keeps not-yet work out of dispatch;
   `paused` freezes in-flight work across dispatch, base sync, and fresh
   post-agent checks without discarding durable state; and, when
@@ -118,6 +180,14 @@ linked docs.
   cap-exempt on a dedicated pool. See
   [`docs/architecture.md#per-tick-flow-workflowtick`](../docs/architecture.md#per-tick-flow-workflowtick)
   and [`orchestrator/scheduler/service.py`](../orchestrator/scheduler/service.py).
+- **Terminal artifact reclamation.** A daily or on-demand maintenance
+  pass discovers current, legacy, local, and remote-only per-issue
+  worktrees and branches, then removes only artifacts whose terminal
+  ownership, commit survival, clean checkout, quiet period, and lack of
+  active PRs are all proved. Scheduler admission barriers, a host lock,
+  tip rechecks, and leased ref deletion make ambiguous evidence retain the
+  candidate. See
+  [`docs/configuration/operations.md#reclaiming-a-finished-issues-artifacts`][artifact-reclamation].
 - **Responsibility-owned package layout.** The former flat production and
   test trees are split into domain packages with narrow explicit APIs,
   responsibility-named owners, mirrored tests, and repository checks for
@@ -130,15 +200,18 @@ linked docs.
   stays in the in-memory fakes under `tests/support/github/`, reached
   through `tests/support/fakes.py`. See
   [`CLAUDE.md`](../CLAUDE.md).
-- **Project CI.** GitHub Actions runs Ruff, WPS-focused Flake8, and
-  pytest on PRs under read-only token scope; the 120-column repository
-  line-length limit is enforced by Ruff E501 for Python and
-  `tests/repository/test_line_length.py` for tracked Markdown / text;
-  Dependabot opens weekly updates with a 30-day cooldown;
-  `dependency-review` blocks vulnerable PRs.
+- **Project CI and supply-chain checks.** Read-only CI runs Ruff,
+  WPS-focused Flake8, pytest with coverage, an sdist / wheel build, and an
+  isolated installed-console smoke test on Python 3.12 and 3.13. Workflow
+  actions are SHA-pinned; dependency review, CodeQL, OpenSSF Scorecard,
+  and a weekly whole-lockfile vulnerability scan complement Dependabot's
+  cooled update PRs. See
+  [`docs/configuration/operations.md#continuous-integration`][continuous-integration]
+  and [`SECURITY.md`](../SECURITY.md).
 - **Audit event log.** Optional opt-in JSONL sink at `EVENT_LOG_PATH`,
-  one record per workflow event, including opt-in `skill_triggered`
-  events when `TRACK_SKILL_TRIGGERS` is enabled. See
+  one record per workflow event, including the late-size and agent-run
+  budget families plus opt-in `skill_triggered` events when
+  `TRACK_SKILL_TRIGGERS` is enabled. See
   [`docs/observability.md#audit-event-log-event_log_path`](../docs/observability.md#audit-event-log-event_log_path).
 - **Analytics sink, database, and dashboard.** JSONL sink at
   `ANALYTICS_LOG_PATH` plus an operator-deployed Postgres aggregation
@@ -147,8 +220,9 @@ linked docs.
   model under `orchestrator/observability/analytics/query/`, and the
   `orchestrator/apps/analytics_dashboard.py` Streamlit app. Records
   include stage evaluations, agent exits, repo skill catalogs, opt-in
-  skill-observation fields, logical-session adoption, and invocation-level
-  trigger diagnostics. See
+  skill-observation fields, logical-session adoption, invocation-level
+  trigger diagnostics, late-size and agent-run budget transitions, and
+  terminal-artifact cleanup outcomes. See
   [`docs/observability.md`](../docs/observability.md).
 - **Trajectory sink and viewer.** Opt-in `TRAJECTORY_LOG_PATH` records
   redacted, head/tail-truncated `agent_trajectory` JSONL records for
@@ -175,10 +249,25 @@ linked docs.
 
 ## Future work
 
-Open as of 2026-08-19. None of these entries has an implementation or a
-public configuration surface yet. Expand one into a design document only
-when it is picked up.
+Open as of 2026-09-11. The first two entries are follow-ups to existing
+code. The remaining entries are feature proposals with no implementation
+or public configuration surface; expand one into a design document when
+it is picked up.
 
+- **Complete authorization enforcement for existing publication records.**
+  The size gate can recover an existing `late_unauthorized_exemption` park,
+  but ordinary ticks do not create that park. Legacy exemption, approval,
+  and publication records can still admit oversized work without human
+  authorization. Apply that policy to oversized work entering through those
+  records while preserving valid measured approvals and recovery for work
+  already published. See
+  [`orchestrator/workflow/stages/implementing/late_gate.py`](../orchestrator/workflow/stages/implementing/late_gate.py)
+  and [the authorization contract][oversized-authorization].
+- **Retire the pre-PR rebase compatibility alias.** Confirm that no
+  out-of-repo patch still imports `_merge_base_into_worktree`, then remove
+  that forwarding function and its compatibility test. The source TODO in
+  [`orchestrator/git/base_sync/pre_pr.py`](../orchestrator/git/base_sync/pre_pr.py)
+  named 2026-08-24 as the removal point.
 - **Spec-first split.** Insert a `specifying` stage between `ready` and
   `implementing` so a separate spec agent writes failing tests first
   (scoped to test paths) and the orchestrator verifies they fail
@@ -212,7 +301,7 @@ when it is picked up.
   provider-specific leaves under `orchestrator/agents/backends/` and
   `orchestrator/observability/usage/`; failures surface as
   `session_id=None` (logged) or empty `last_message` (park with stderr
-  quoted via `workflow.engine.messages._format_stderr_diagnostics`).
+  quoted via `workflow.engine.agent_diagnostics._format_stderr_diagnostics`).
 - **R2 — Self-mutation while running.** Per-issue worktrees +
   ancestry-aware self-update detection in
   `runtime.self_update.self_modifying_merge_happened` + the `run.sh`
@@ -220,7 +309,9 @@ when it is picked up.
 - **R3 — Runaway agent loops / token cost.** Wall-clock timeouts
   (`AGENT_TIMEOUT`, `REVIEW_TIMEOUT`), per-issue retry budget
   (`MAX_RETRIES_PER_DAY`), review / fix cap (`MAX_REVIEW_ROUNDS`),
-  conflict-resolution cap (`MAX_CONFLICT_ROUNDS`).
+  conflict-resolution cap (`MAX_CONFLICT_ROUNDS`), and the durable lifetime
+  circuit (`MAX_AGENT_RUNS_PER_ISSUE`) bound the separate ways an issue can
+  keep spawning agents.
 - **R4 — GitHub rate limits.** Idle per-repo polls and closed-issue
   sweeps can exhaust a PAT's 5000 requests/hour at the default cadence
   once enough repos are tracked. Label caching and
@@ -229,7 +320,22 @@ when it is picked up.
 - **R5 — Race between human controls and orchestrator action.** Trusted
   comment filters, per-surface watermarks, content hashes, and fresh
   post-agent label reads keep late comments from being silently consumed
-  and keep agent output from being published after a mid-run pause.
+  and keep agent output from being published after a mid-run pause. An
+  oversized candidate's authorization names the exact commit and is retired
+  when its adjudication or generation is replaced; checkout checks bracket
+  publication and the handoff to review.
+- **R6 — Destructive terminal cleanup.** Artifact reclamation is bounded
+  to derived orchestrator names and fails closed on every ambiguous read;
+  it also drains scheduler work, takes the host maintenance lock, rechecks
+  tips, and uses non-forced / leased deletes. Those are application guards,
+  not an OS isolation boundary: arbitrary processes running as the same
+  user remain outside the lock's protection.
 
 [typed-states]: ../docs/state-machine.md#typed-states-and-the-transition-guard
 [trajectory-sink]: ../docs/observability.md#trajectory-sink-trajectory_log_path
+[agent-run-circuit]: ../docs/security.md#bounded-agent-spend-per-issue-max_agent_runs_per_issue
+[size-gate]: ../docs/workflow/roles.md#the-size-gate-a-committed-candidate-passes
+[oversized-authorization]: ../docs/workflow/roles.md#authorizing-one-oversized-candidate-to-publish
+[pr-gate]: ../docs/state-machine/delivery-stages.md#the-size-gate-on-a-published-pull-request-every-push-onto-an-open-pr
+[artifact-reclamation]: ../docs/configuration/operations.md#reclaiming-a-finished-issues-artifacts
+[continuous-integration]: ../docs/configuration/operations.md#continuous-integration


### PR DESCRIPTION
Refresh the roadmap against current `main`, covering size gates, human authorization, split budgets, publication recovery, agent-run limits, cleanup, and CI improvements. Update remaining work, risks, and stale implementation references.